### PR TITLE
Add developer overrides for community backend (API base, TLS trust)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,46 @@
+# Developer overrides for the community backend.
+#
+# Copy to ".env" (next to main.py, or in data/config/) and edit. The file is
+# gitignored. Real environment variables take precedence over anything here,
+# so a shell export still wins.
+#
+# None of this is needed to run the app normally — the defaults point at the
+# production backend with normal TLS verification.
+
+# ---------------------------------------------------------------------------
+# Community API base URL
+# ---------------------------------------------------------------------------
+# Default: https://www.reloadingrecipes.com/api
+# Point this at a local copy of the backend while developing. Include the
+# /api suffix; a trailing slash is fine.
+#CASESORTER_API_BASE=https://localhost:7043/api
+
+# ---------------------------------------------------------------------------
+# TLS trust for community calls
+# ---------------------------------------------------------------------------
+# Preferred way to talk to a local HTTPS dev server: trust its certificate.
+# Export the dev cert to a PEM file and point here. This replaces the system
+# trust store for community calls (including the Azure blob URLs the API
+# returns), so use a bundle if you need both.
+#
+#   ASP.NET Core dev cert (Windows/macOS/Linux):
+#     dotnet dev-certs https --export-path devcert.pem --format PEM --no-password
+#
+#CASESORTER_API_CA_BUNDLE=./devcert.pem
+
+# Blunt escape hatch: skip TLS verification altogether.
+# Honoured ONLY when CASESORTER_API_BASE points at localhost / 127.0.0.1 —
+# against any other host it is ignored and verification stays on. Prefer the
+# CA bundle above; this exists for when the cert isn't worth exporting.
+#CASESORTER_API_INSECURE=1
+
+# ---------------------------------------------------------------------------
+# Other
+# ---------------------------------------------------------------------------
+# Where the app keeps its data (db, models, images). Must be a real environment
+# variable or set in the app-root .env — a .env inside data/config/ can't
+# relocate the folder it lives in.
+#CASESORTER_DATA_DIR=/path/to/casesorter-data
+
+# Trace the community feedback loop (capture -> queue -> upload) to stderr.
+#CASESORTER_FEEDBACK_DEBUG=1

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,7 @@
 .venv/
 .installed
+.env
+data/config/.env
 __pycache__/
 *.pyc
 data/config.json

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,6 +136,14 @@ sanctioned way for worker threads to update the UI.
   (`normalize_upload_mode`, `SUPPORTED_MODEL_MODES`).
 - **`paths.py`** — single source of truth for the on-disk layout (see §6).
   `CASESORTER_DATA_DIR` overrides the data root.
+- **`appenv.py`** — developer overrides for the community backend, read from the
+  environment with an optional `.env` (real env vars always win; see
+  `.env.example`). `api_base()` applies `CASESORTER_API_BASE` over the
+  production default; `tls_verify()` returns what to pass `requests` as
+  `verify=` — a `CASESORTER_API_CA_BUNDLE` path, or `False` when
+  `CASESORTER_API_INSECURE=1` **and** the base URL is loopback (it is ignored,
+  with a warning, for any other host). `main.py` calls `load_dotenv()` at
+  startup; `CommunityApi` resolves both at construction, not import.
 
 ### Active-model concept
 "Active model" = `settings.default_model_id`. When **absent**, the app is in
@@ -233,7 +241,10 @@ used, headstamps in the `headstamps` table). Activating a model posts
   `reloadingrecipes.com/api` (cartridges, model search, download via Azure-blob
   SAS URL, feedback-image upload, wish-list fetch, model share). Bearer token
   pulled fresh from `AuthManager` per call. Downloads/uploads stream with atomic
-  writes.
+  writes. Base URL and TLS trust come from `appenv` (see above); `verify` is
+  passed **per request**, never set on the session — `REQUESTS_CA_BUNDLE` /
+  `CURL_CA_BUNDLE` in the environment outrank `session.verify`, so a
+  session-level setting is silently ignored on machines that set them.
 - **`feedback.py`** — `FeedbackService`: the community **feedback loop**. When a
   community model with the loop enabled produces a below-floor prediction (floor
   clamped to ≥ 50), the cropped image is staged to
@@ -341,9 +352,11 @@ where `ticks` is the .NET `DateTime.Ticks` value.
 - **Headstamps are read fresh, not cached** — don't reintroduce a cached
   snapshot (it previously caused silent data loss).
 - **Cloud features depend on the hosted `reloadingrecipes.com` backend** and a
-  specific Azure B2C tenant, both hardcoded. The backend is a separate service
-  (not in this repo); a fork cannot run community features against its own infra
-  without editing `auth.py` / `community_api.py`.
+  specific Azure B2C tenant. The API base URL and its TLS trust are
+  environment-overridable (`appenv`, `.env.example`) so you can run against a
+  local copy of the backend; the **Azure B2C tenant/client/scopes in `auth.py`
+  are still hardcoded**, so a fork pointing at its own identity provider has to
+  edit that file. The backend itself is a separate service, not in this repo.
 - **No CI yet.** Run `pytest` before pushing; UI is not covered by tests.
 - See **`OPEN_SOURCE_READINESS.md`** for the open-source readiness assessment and
   **`CONTRIBUTING.md`** for how to set up and contribute.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -231,8 +231,9 @@ used, headstamps in the `headstamps` table). Activating a model posts
   optional; the only gated surface is the Community tab.
 - **`community_api.py`** — `CommunityApi`: HTTPS client for
   `reloadingrecipes.com/api` (cartridges, model search, download via Azure-blob
-  SAS URL, feedback-image upload, model share). Bearer token pulled fresh from
-  `AuthManager` per call. Downloads/uploads stream with atomic writes.
+  SAS URL, feedback-image upload, wish-list fetch, model share). Bearer token
+  pulled fresh from `AuthManager` per call. Downloads/uploads stream with atomic
+  writes.
 - **`feedback.py`** — `FeedbackService`: the community **feedback loop**. When a
   community model with the loop enabled produces a below-floor prediction (floor
   clamped to ≥ 50), the cropped image is staged to
@@ -240,6 +241,15 @@ used, headstamps in the `headstamps` table). Activating a model posts
   `upload_pending` drains it via `CommunityApi`, deleting on success or drop on
   failure. Debug tracing to stderr is **off by default** — enable with
   `CASESORTER_FEEDBACK_DEBUG=1`.
+  Also owns the **wish list** (model balancing): `GET /Models/FetchWishList`
+  returns the classifications a model is short of images for. The Run tab fetches
+  it on a worker thread at Start (gated on `is_feedback_model`, so an opted-out
+  user's auth path is untouched) and clears it at Stop; `should_capture` then
+  captures on *below floor **or** wanted label*. Wish-list capture applies to
+  continuous runs only (not Manual Feed), is capped at
+  `MAX_WISH_LIST_CAPTURES_PER_LABEL` (40) per classification per run, and **fails
+  open** — any error or non-200 installs an empty list, i.e. confidence-only
+  behavior. No UI surface.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -162,6 +162,24 @@ Please run `pytest` before opening a PR. The UI itself is not covered by
 automated tests. See [`CONTRIBUTING.md`](CONTRIBUTING.md) for setup and
 guidelines, and [`SECURITY.md`](SECURITY.md) to report a vulnerability.
 
+### Pointing at a local community backend
+
+The community client talks to `https://www.reloadingrecipes.com/api` and
+verifies TLS normally. To develop against a local copy of that backend, copy
+[`.env.example`](.env.example) to `.env` (next to `main.py`, or in
+`data/config/`) and set:
+
+| Variable | Purpose |
+|----------|---------|
+| `CASESORTER_API_BASE` | Base URL of the community API, e.g. `https://localhost:7043/api`. |
+| `CASESORTER_API_CA_BUNDLE` | PEM cert/bundle to trust — the right way to make a local HTTPS dev server verify. |
+| `CASESORTER_API_INSECURE` | `1` skips TLS verification. **Honoured only when the API base is localhost**, so it can't weaken production traffic. |
+
+Real environment variables take precedence over the `.env` file, and `.env` is
+gitignored. For an ASP.NET Core dev server, export its certificate with
+`dotnet dev-certs https --export-path devcert.pem --format PEM --no-password`
+and point `CASESORTER_API_CA_BUNDLE` at it.
+
 - [`CONTRIBUTING.md`](CONTRIBUTING.md) — how to set up, run the tests, and submit
   changes.
 - [`CLAUDE.md`](CLAUDE.md) — architecture map for contributors and AI coding

--- a/main.py
+++ b/main.py
@@ -15,12 +15,10 @@ def main() -> int:
     from sorter.db import Database
     from sorter.ui.app import MainWindow
 
-    # Developer overrides (community API base URL / TLS trust). A no-op unless
-    # a .env exists — see sorter/appenv.py and .env.example.
-    for env_file in appenv.load_dotenv():
-        print(f"[casesorter] loaded {env_file}")
-    if appenv.api_base() != appenv.DEFAULT_API_BASE:
-        print(f"[casesorter] {appenv.describe()}")
+    # Developer overrides (community API base URL / TLS trust). Silent unless
+    # something is actually configured — see sorter/appenv.py and .env.example.
+    for line in appenv.startup_report(appenv.load_dotenv()):
+        print(f"[casesorter] {line}")
 
     paths.ensure_directories()
     legacy_json = here / "data" / "config.json"

--- a/main.py
+++ b/main.py
@@ -10,10 +10,17 @@ def main() -> int:
     if str(here) not in sys.path:
         sys.path.insert(0, str(here))
 
-    from sorter import paths
+    from sorter import appenv, paths
     from sorter.config import Config
     from sorter.db import Database
     from sorter.ui.app import MainWindow
+
+    # Developer overrides (community API base URL / TLS trust). A no-op unless
+    # a .env exists — see sorter/appenv.py and .env.example.
+    for env_file in appenv.load_dotenv():
+        print(f"[casesorter] loaded {env_file}")
+    if appenv.api_base() != appenv.DEFAULT_API_BASE:
+        print(f"[casesorter] {appenv.describe()}")
 
     paths.ensure_directories()
     legacy_json = here / "data" / "config.json"

--- a/sorter/appenv.py
+++ b/sorter/appenv.py
@@ -1,0 +1,223 @@
+"""Environment overrides for the community backend (developer settings).
+
+Production needs no configuration: the community client points at
+``https://www.reloadingrecipes.com/api`` and verifies TLS the normal way. This
+module exists so a developer can point the app at a locally-running copy of
+that backend — and trust its certificate — without editing source.
+
+Settings come from environment variables. A ``.env`` file is a convenience for
+setting them; **real environment variables always win**, so a shell export
+overrides a checked-out ``.env``. Files are looked for in this order, and every
+one that exists is applied (first value wins):
+
+  1. ``$CASESORTER_ENV_FILE`` — explicit path,
+  2. ``<data dir>/config/.env`` — per-installation,
+  3. ``<app>/.env`` — next to ``main.py``, the usual developer spot.
+
+Recognised keys (see ``.env.example``):
+
+``CASESORTER_API_BASE``
+    Base URL of the community API. Default
+    ``https://www.reloadingrecipes.com/api``.
+``CASESORTER_API_CA_BUNDLE``
+    Path to a PEM certificate/bundle to trust *in addition to* nothing else —
+    it replaces the system trust store for community calls. This is the right
+    way to talk to a local HTTPS dev server: export its cert and point here.
+``CASESORTER_API_INSECURE``
+    ``1`` skips TLS verification entirely. **Loopback only** — it is ignored
+    unless ``CASESORTER_API_BASE`` points at localhost, so it can never
+    silently weaken production traffic.
+
+``CASESORTER_DATA_DIR`` (see ``paths``) is deliberately NOT read from a ``.env``
+in the data directory — that file lives inside the directory it would be
+relocating. Set it as a real environment variable, or in the app-root ``.env``.
+"""
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from urllib.parse import urlsplit
+
+from . import paths
+
+
+DEFAULT_API_BASE = "https://www.reloadingrecipes.com/api"
+
+ENV_API_BASE = "CASESORTER_API_BASE"
+ENV_CA_BUNDLE = "CASESORTER_API_CA_BUNDLE"
+ENV_INSECURE = "CASESORTER_API_INSECURE"
+
+_TRUTHY = {"1", "true", "yes", "on"}
+
+# One-shot warnings: these are evaluated per request, and nobody needs the same
+# line a thousand times in a run.
+_warned: set[str] = set()
+
+
+def _warn_once(key: str, msg: str) -> None:
+    if key in _warned:
+        return
+    _warned.add(key)
+    print(f"[casesorter] {msg}", file=sys.stderr, flush=True)
+
+
+def _flag(name: str) -> bool:
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+# ----- .env loading -----------------------------------------------------------
+
+
+def parse_env_text(text: str) -> dict[str, str]:
+    """Parse ``KEY=VALUE`` lines. Blank lines and ``#`` comments are skipped.
+
+    Tolerates a leading ``export ``, surrounding whitespace, and single or
+    double quotes around the value. Deliberately minimal — no interpolation,
+    no multi-line values — so there is no dependency on python-dotenv.
+    """
+    values: dict[str, str] = {}
+    for raw in text.splitlines():
+        line = raw.strip()
+        if not line or line.startswith("#") or "=" not in line:
+            continue
+        if line.startswith("export "):
+            line = line[len("export "):].lstrip()
+        key, _, value = line.partition("=")
+        key = key.strip()
+        if not key:
+            continue
+        value = value.strip()
+        if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
+            value = value[1:-1]
+        values[key] = value
+    return values
+
+
+def env_file_candidates() -> list[Path]:
+    """Where a ``.env`` may live, most specific first."""
+    candidates: list[Path] = []
+    explicit = os.environ.get("CASESORTER_ENV_FILE", "").strip()
+    if explicit:
+        candidates.append(Path(explicit).expanduser())
+    candidates.append(paths.config_dir() / ".env")
+    candidates.append(Path(__file__).resolve().parent.parent / ".env")
+    return candidates
+
+
+def load_dotenv() -> list[Path]:
+    """Apply every ``.env`` that exists into ``os.environ``; return those files.
+
+    Never overwrites a variable that is already set, so the real environment
+    (and, between files, the more specific one) wins. Safe to call more than
+    once. An unreadable file is reported and skipped rather than fatal — a
+    developer convenience must not stop the app from starting.
+    """
+    applied: list[Path] = []
+    seen: set[Path] = set()
+    for path in env_file_candidates():
+        try:
+            resolved = path.resolve()
+        except OSError:
+            continue
+        if resolved in seen:
+            continue
+        seen.add(resolved)
+        if not path.is_file():
+            continue
+        try:
+            values = parse_env_text(path.read_text(encoding="utf-8"))
+        except OSError as exc:
+            _warn_once(f"envfile:{path}", f"could not read {path}: {exc}")
+            continue
+        for key, value in values.items():
+            os.environ.setdefault(key, value)
+        applied.append(path)
+    return applied
+
+
+# ----- resolved settings ------------------------------------------------------
+
+
+def api_base() -> str:
+    """Effective community API base URL, without a trailing slash."""
+    return (os.environ.get(ENV_API_BASE, "").strip() or DEFAULT_API_BASE).rstrip("/")
+
+
+def is_loopback(url: str) -> bool:
+    """True when ``url``'s host is this machine.
+
+    Guards the insecure-TLS switch: a developer pointing at their own box gets
+    the escape hatch, and nobody can turn verification off against a remote
+    host by leaving a stray variable set.
+    """
+    host = (urlsplit(url).hostname or "").strip().lower()
+    if not host:
+        return False
+    return (
+        host in ("localhost", "127.0.0.1", "::1", "0.0.0.0")
+        or host.endswith(".localhost")
+        or host.startswith("127.")
+    )
+
+
+def tls_verify() -> bool | str:
+    """What to hand ``requests`` as ``verify=`` for community calls.
+
+    A CA bundle (preferred) wins over the insecure switch, which is honored
+    only for a loopback API base. Anything unusable falls back to normal
+    system-trust verification — the safe direction.
+    """
+    bundle = os.environ.get(ENV_CA_BUNDLE, "").strip()
+    if bundle:
+        path = Path(bundle).expanduser()
+        if path.is_file() or path.is_dir():
+            return str(path)
+        _warn_once(
+            "ca-missing",
+            f"{ENV_CA_BUNDLE}={bundle!r} does not exist — using system trust instead.",
+        )
+    if _flag(ENV_INSECURE):
+        base = api_base()
+        if not is_loopback(base):
+            _warn_once(
+                "insecure-remote",
+                f"{ENV_INSECURE} is set but {ENV_API_BASE}={base} is not a loopback "
+                "address — ignoring it and verifying TLS normally.",
+            )
+            return True
+        _warn_once(
+            "insecure-loopback",
+            f"TLS verification is DISABLED for community calls to {base} "
+            f"({ENV_INSECURE}=1). Development only.",
+        )
+        _silence_insecure_warnings()
+        return False
+    return True
+
+
+def _silence_insecure_warnings() -> None:
+    """Mute urllib3's per-request unverified-HTTPS warning.
+
+    We print one explicit warning of our own instead; the alternative is the
+    same paragraph repeated for every request of the session.
+    """
+    try:
+        import urllib3
+
+        urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
+    except Exception:
+        pass
+
+
+def describe() -> str:
+    """One-line summary of the effective settings, for startup logging."""
+    base = api_base()
+    verify = tls_verify()
+    if verify is False:
+        tls = "TLS verification DISABLED"
+    elif isinstance(verify, str):
+        tls = f"CA bundle {verify}"
+    else:
+        tls = "system trust"
+    return f"community API: {base} ({tls})"

--- a/sorter/appenv.py
+++ b/sorter/appenv.py
@@ -35,6 +35,7 @@ relocating. Set it as a real environment variable, or in the app-root ``.env``.
 from __future__ import annotations
 
 import os
+import re
 import sys
 from pathlib import Path
 from urllib.parse import urlsplit
@@ -49,6 +50,9 @@ ENV_CA_BUNDLE = "CASESORTER_API_CA_BUNDLE"
 ENV_INSECURE = "CASESORTER_API_INSECURE"
 
 _TRUTHY = {"1", "true", "yes", "on"}
+
+# A plain environment-variable name; anything else in a .env is discarded.
+_VALID_KEY = re.compile(r"[A-Za-z_][A-Za-z0-9_]*")
 
 # One-shot warnings: these are evaluated per request, and nobody needs the same
 # line a thousand times in a run.
@@ -69,23 +73,51 @@ def _flag(name: str) -> bool:
 # ----- .env loading -----------------------------------------------------------
 
 
+def read_env_text(path: Path) -> str:
+    """Decode a ``.env`` whatever the editor saved it as.
+
+    Notepad writes UTF-8 **with a BOM** by default and PowerShell's ``>``
+    redirection writes UTF-16 — both are what a Windows user is most likely to
+    end up with, and both broke naive UTF-8 decoding (a BOM silently corrupts
+    the first key's name; UTF-16 raises). ``utf-8-sig`` strips a BOM if present
+    and is otherwise plain UTF-8; ``utf-16`` picks LE/BE off its own BOM;
+    latin-1 cannot fail, so decoding always succeeds.
+    """
+    raw = path.read_bytes()
+    for encoding in ("utf-8-sig", "utf-16", "utf-16-le", "utf-16-be", "latin-1"):
+        try:
+            text = raw.decode(encoding)
+        except (UnicodeDecodeError, UnicodeError):
+            continue
+        # NUL characters mean we guessed the codec wrong (UTF-8 happily decodes
+        # the zero bytes of UTF-16 text). Keep looking.
+        if "\x00" in text:
+            continue
+        return text
+    return ""
+
+
 def parse_env_text(text: str) -> dict[str, str]:
     """Parse ``KEY=VALUE`` lines. Blank lines and ``#`` comments are skipped.
 
-    Tolerates a leading ``export ``, surrounding whitespace, and single or
-    double quotes around the value. Deliberately minimal — no interpolation,
-    no multi-line values — so there is no dependency on python-dotenv.
+    Tolerates a leading ``export ``, surrounding whitespace, single or double
+    quotes around the value, CRLF line endings, and a stray byte-order mark.
+    Deliberately minimal — no interpolation, no multi-line values — so there is
+    no dependency on python-dotenv.
     """
     values: dict[str, str] = {}
     for raw in text.splitlines():
-        line = raw.strip()
+        line = raw.strip().lstrip("\ufeff").strip()
         if not line or line.startswith("#") or "=" not in line:
             continue
         if line.startswith("export "):
             line = line[len("export "):].lstrip()
         key, _, value = line.partition("=")
         key = key.strip()
-        if not key:
+        # Anything that isn't a plain environment-variable name is garbage from
+        # a mis-decoded file. Dropping it beats handing os.environ a key it
+        # rejects (an embedded NUL raises ValueError) at app startup.
+        if not _VALID_KEY.fullmatch(key):
             continue
         value = value.strip()
         if len(value) >= 2 and value[0] == value[-1] and value[0] in ("'", '"'):
@@ -105,13 +137,30 @@ def env_file_candidates() -> list[Path]:
     return candidates
 
 
+# Names a ``.env`` commonly ends up with by accident. Windows Explorer hides
+# known extensions, so "Save as .env" in Notepad quietly produces ".env.txt"
+# and the file looks correct in the folder listing.
+_NEAR_MISS_NAMES = (".env.txt", "env.txt", "env", ".env.env")
+
+
+def near_miss_env_files() -> list[Path]:
+    """Files that look like a misnamed ``.env`` next to a candidate location."""
+    found: list[Path] = []
+    for candidate in env_file_candidates():
+        for name in _NEAR_MISS_NAMES:
+            sibling = candidate.parent / name
+            if sibling.is_file() and sibling not in found:
+                found.append(sibling)
+    return found
+
+
 def load_dotenv() -> list[Path]:
     """Apply every ``.env`` that exists into ``os.environ``; return those files.
 
     Never overwrites a variable that is already set, so the real environment
     (and, between files, the more specific one) wins. Safe to call more than
-    once. An unreadable file is reported and skipped rather than fatal — a
-    developer convenience must not stop the app from starting.
+    once. A file that can't be read or parsed is reported and skipped rather
+    than fatal — a developer convenience must never stop the app from starting.
     """
     applied: list[Path] = []
     seen: set[Path] = set()
@@ -126,9 +175,12 @@ def load_dotenv() -> list[Path]:
         if not path.is_file():
             continue
         try:
-            values = parse_env_text(path.read_text(encoding="utf-8"))
-        except OSError as exc:
-            _warn_once(f"envfile:{path}", f"could not read {path}: {exc}")
+            values = parse_env_text(read_env_text(path))
+        except Exception as exc:
+            _warn_once(
+                f"envfile:{path}",
+                f"could not read {path} ({exc.__class__.__name__}: {exc}) — ignoring it.",
+            )
             continue
         for key, value in values.items():
             os.environ.setdefault(key, value)
@@ -208,6 +260,40 @@ def _silence_insecure_warnings() -> None:
         urllib3.disable_warnings(urllib3.exceptions.InsecureRequestWarning)
     except Exception:
         pass
+
+
+def startup_report(applied: list[Path] | None = None) -> list[str]:
+    """Lines describing where the community settings came from.
+
+    Silent in the default case — a normal user with no ``.env`` and no
+    overrides sees nothing. When anything IS configured it says which file was
+    read, which keys it held, and the settings that actually took effect, so a
+    file that was found but didn't apply (a misspelled key, a value overridden
+    by a real environment variable) is visible instead of mysterious.
+    """
+    lines: list[str] = []
+    applied = list(applied or [])
+    for path in applied:
+        try:
+            keys = ", ".join(parse_env_text(read_env_text(path))) or "no settings found"
+        except Exception:
+            keys = "unreadable"
+        lines.append(f"loaded {path} ({keys})")
+
+    configured = bool(
+        os.environ.get(ENV_API_BASE, "").strip()
+        or os.environ.get(ENV_CA_BUNDLE, "").strip()
+        or _flag(ENV_INSECURE)
+    )
+    if applied or configured:
+        lines.append(describe())
+    else:
+        for miss in near_miss_env_files():
+            lines.append(
+                f"note: {miss} looks like a misnamed .env and is being ignored "
+                "(Windows Explorer hides the .txt extension)."
+            )
+    return lines
 
 
 def describe() -> str:

--- a/sorter/community_api.py
+++ b/sorter/community_api.py
@@ -6,6 +6,12 @@ the `AuthManager` on each call so we always send the freshest token.
 
 Model downloads use an Azure-blob SAS URL returned by the API. We just stream
 the URL with `requests`; no `azure-storage-blob` dependency needed.
+
+The base URL and TLS trust are developer-overridable (`CASESORTER_API_BASE`,
+`CASESORTER_API_CA_BUNDLE`, `CASESORTER_API_INSECURE` — see `appenv`) so the
+app can be pointed at a local copy of the backend. Both are resolved when a
+`CommunityApi` is constructed, not at import, so a `.env` loaded during startup
+still applies.
 """
 from __future__ import annotations
 
@@ -19,11 +25,15 @@ from urllib.parse import quote_plus
 
 import requests
 
+from . import appenv
 from .auth import API_SCOPES, AuthError, AuthManager
 from .feedback import debug_log
 
 
-API_BASE = "https://www.reloadingrecipes.com/api"
+# The production default. The URL actually used is `appenv.api_base()`, which
+# applies a CASESORTER_API_BASE override; this constant is what that falls back
+# to.
+API_BASE = appenv.DEFAULT_API_BASE
 _session = requests.Session()
 
 
@@ -221,14 +231,25 @@ class CommunityApi:
         self,
         auth: AuthManager,
         *,
-        base_url: str = API_BASE,
+        base_url: str | None = None,
         session: requests.Session | None = None,
         timeout: float = 30.0,
+        verify: bool | str | None = None,
     ) -> None:
         self.auth = auth
-        self.base_url = base_url.rstrip("/")
+        self.base_url = (base_url or appenv.api_base()).rstrip("/")
         self.session = session or _session
         self.timeout = timeout
+        # Passed to every call — including the Azure-blob URLs the API hands
+        # back, since a local backend pairs with a local blob emulator whose
+        # cert needs the same trust.
+        #
+        # It has to be per request, NOT `session.verify`: requests lets
+        # REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE in the environment outrank the
+        # session attribute, so behind a corporate proxy (or any box that sets
+        # those) a session-level setting is silently ignored. A per-request
+        # value wins. Leaving it True keeps the env bundle working as before.
+        self.verify = appenv.tls_verify() if verify is None else verify
 
     # ----- helpers ------------------------------------------------------------
 
@@ -243,6 +264,7 @@ class CommunityApi:
             f"{self.base_url}{path}",
             headers=self._headers(),
             timeout=self.timeout,
+            verify=self.verify,
             **kwargs,
         )
 
@@ -252,6 +274,7 @@ class CommunityApi:
             headers={**self._headers(), "Content-Type": "application/json"},
             json=json,
             timeout=self.timeout,
+            verify=self.verify,
         )
 
     # ----- user metadata ------------------------------------------------------
@@ -323,7 +346,9 @@ class CommunityApi:
         dest_path.parent.mkdir(parents=True, exist_ok=True)
         tmp = dest_path.with_suffix(dest_path.suffix + ".tmp")
 
-        with self.session.get(url, stream=True, timeout=self.timeout) as resp:
+        with self.session.get(
+            url, stream=True, timeout=self.timeout, verify=self.verify,
+        ) as resp:
             resp.raise_for_status()
             total = expected_total
             if total is None:
@@ -447,7 +472,9 @@ class CommunityApi:
             "Content-Type": "image/jpeg",
         }
         with open(file_path, "rb") as f:
-            resp = self.session.put(url, data=f, headers=headers, timeout=self.timeout)
+            resp = self.session.put(
+                url, data=f, headers=headers, timeout=self.timeout, verify=self.verify,
+            )
         debug_log(f"PUT blob -> HTTP {resp.status_code}")
         resp.raise_for_status()
 
@@ -521,7 +548,9 @@ class CommunityApi:
         for attempt in range(max(1, retries)):
             reader = _ProgressReader(file_path, total, progress)
             try:
-                resp = self.session.put(url, data=reader, headers=headers, timeout=None)
+                resp = self.session.put(
+                    url, data=reader, headers=headers, timeout=None, verify=self.verify,
+                )
                 debug_log(f"PUT blob ({total} bytes) -> HTTP {resp.status_code}")
                 resp.raise_for_status()
                 return

--- a/sorter/community_api.py
+++ b/sorter/community_api.py
@@ -390,6 +390,44 @@ class CommunityApi:
         debug_log(f"  ticket: accepted={ticket.feedback_accepted} container={ticket.container_uri!r} blob={ticket.blob_path!r}")
         return ticket
 
+    def fetch_wish_list(self, community_model_uid: str) -> list[str]:
+        """Classifications this community model wants more training images for.
+
+        ``GET /Models/FetchWishList?communityModelId={uid}`` answers with a JSON
+        array of classification names (the same strings the classifier returns).
+
+        The server has no error path — an unknown or malformed UID, a disabled
+        feedback loop, no configured threshold, or an unpopulated image folder
+        all answer ``200 []``, meaning "don't collect anything extra". We extend
+        that to our side too: not signed in, a non-200, or an unparseable body
+        all return ``[]`` so the feature fails open to confidence-only feedback
+        and a run is never blocked on this call.
+        """
+        if not community_model_uid:
+            return []
+        try:
+            resp = self._get(
+                f"/Models/FetchWishList?communityModelId={quote_plus(community_model_uid)}"
+            )
+        except Exception as exc:
+            debug_log(f"GET /Models/FetchWishList failed ({exc.__class__.__name__}: {exc})")
+            return []
+        debug_log(f"GET /Models/FetchWishList -> HTTP {resp.status_code}")
+        if resp.status_code != 200:
+            debug_log(f"  non-200 body: {(resp.text or '')[:200]!r}")
+            return []
+        try:
+            data = resp.json()
+        except ValueError:
+            debug_log(f"  non-JSON body: {(resp.text or '')[:200]!r}")
+            return []
+        if not isinstance(data, list):
+            debug_log(f"  unexpected JSON shape: {type(data).__name__}")
+            return []
+        names = [item.strip() for item in data if isinstance(item, str) and item.strip()]
+        debug_log(f"  wish list ({len(names)}): {names}")
+        return names
+
     def upload_feedback_blob(
         self,
         file_path: Path | str,

--- a/sorter/feedback.py
+++ b/sorter/feedback.py
@@ -19,14 +19,20 @@ deleted rather than retained. There is no durable cross-session retry queue.
 
 The effective floor is ``max(50, publisher_floor)`` and upload is a SAS
 round-trip (request ticket -> PUT blob -> complete).
+
+A prediction is captured for one of two independent reasons: its confidence
+fell below the publisher's floor (the original rule), or its label is on the
+model's **wish list** — the classifications the publisher's model is short of
+training images for, fetched once at run start. See ``set_wish_list``.
 """
 from __future__ import annotations
 
 import os
 import sys
+import threading
 import traceback
 from pathlib import Path
-from typing import Any
+from typing import Any, Iterable
 
 import numpy as np
 
@@ -39,6 +45,13 @@ from .training.dataset import parse_feedback_filename, save_feedback_image
 # Floor on the publisher's floor: even if a publisher set a very low
 # threshold, anything under 50% confidence is worth moderating.
 MIN_EFFECTIVE_FLOOR = 50
+
+# Wish-list capture ignores confidence, so a wished headstamp that happens to
+# dominate a batch would otherwise upload every single case. Cap how many
+# images one run collects per classification via the wish list. The
+# below-confidence rule is unaffected — it keeps its original unbounded
+# behavior.
+MAX_WISH_LIST_CAPTURES_PER_LABEL = 40
 
 
 def _debug_enabled() -> bool:
@@ -68,17 +81,121 @@ def is_feedback_model(model: Model | None) -> bool:
 class FeedbackService:
     def __init__(self, db: Any) -> None:
         self.db = db
+        # Wish list for the run in progress: the model it belongs to, the
+        # wanted classifications (lowercased for case-insensitive matching,
+        # as the server compares them), and how many images each has already
+        # contributed this run. Written from the UI thread at run start and
+        # read/updated from the run thread, so all access is under the lock.
+        self._wish_lock = threading.Lock()
+        self._wish_model_id: int | None = None
+        self._wish_list: set[str] = set()
+        self._wish_counts: dict[str, int] = {}
+
+    # ----- wish list ----------------------------------------------------------
+
+    def set_wish_list(self, model_id: int | None, names: Iterable[str]) -> None:
+        """Install the classifications this model wants more images of.
+
+        Bound to ``model_id`` so a mid-session model switch can never apply one
+        model's list to another. Resets the per-classification counters, so
+        every run starts with a fresh quota.
+        """
+        cleaned = {n.strip().lower() for n in (names or ()) if n and n.strip()}
+        with self._wish_lock:
+            self._wish_model_id = model_id if cleaned else None
+            self._wish_list = cleaned
+            self._wish_counts = {}
+        debug_log(f"wish list for model {model_id}: {sorted(cleaned) or '(empty)'}")
+
+    def clear_wish_list(self) -> None:
+        self.set_wish_list(None, ())
+
+    def wish_list(self) -> list[str]:
+        """The wanted classifications currently installed (sorted, lowercased)."""
+        with self._wish_lock:
+            return sorted(self._wish_list)
+
+    def refresh_wish_list(self, model: Model | None, *, auth: Any) -> list[str]:
+        """Fetch ``model``'s wish list from the community API and install it.
+
+        Blocking (one HTTPS round-trip) — call it from a worker thread, never
+        from the run loop. Fails open and never raises: a model that isn't a
+        feedback-enabled community model, a signed-out user, or any network /
+        API failure installs an empty list, i.e. plain confidence-only feedback.
+
+        The ``is_feedback_model`` gate matters beyond saving a call: it keeps
+        the auth path untouched for users who have a community model but left
+        the feedback loop off.
+        """
+        names: list[str] = []
+        if not is_feedback_model(model) or auth is None:
+            debug_log(
+                "wish list: not fetching "
+                f"(feedback_model={is_feedback_model(model)}, auth={auth is not None})"
+            )
+        else:
+            try:
+                # Lazy import: the capture path carries no requests/msal dependency.
+                from .community_api import CommunityApi
+
+                names = CommunityApi(auth=auth).fetch_wish_list(model.community_model_uid)
+            except Exception:
+                debug_log("wish list fetch FAILED:\n" + traceback.format_exc())
+                names = []
+        self.set_wish_list(model.id if model is not None else None, names)
+        return names
+
+    def _claim_wish_capture(self, model: Model | None, label: str) -> bool:
+        """Consume one wish-list slot for ``label``.
+
+        True when the label is on the current model's wish list and hasn't yet
+        hit ``MAX_WISH_LIST_CAPTURES_PER_LABEL`` for this run — and in that case
+        the quota is spent, so this must only be called when the image really
+        is about to be staged.
+        """
+        key = (label or "").strip().lower()
+        if model is None or not key:
+            return False
+        with self._wish_lock:
+            if model.id != self._wish_model_id or key not in self._wish_list:
+                return False
+            used = self._wish_counts.get(key, 0)
+            if used >= MAX_WISH_LIST_CAPTURES_PER_LABEL:
+                debug_log(
+                    f"wish list: {label!r} already at the per-run cap "
+                    f"({MAX_WISH_LIST_CAPTURES_PER_LABEL}) — not capturing"
+                )
+                return False
+            self._wish_counts[key] = used + 1
+        return True
 
     # ----- policy -------------------------------------------------------------
 
     def effective_floor(self, model: Model) -> int:
         return max(MIN_EFFECTIVE_FLOOR, int(model.feedback_loop_confidence_floor))
 
-    def should_capture(self, model: Model | None, confidence: float) -> bool:
-        """Capture below-floor predictions on feedback-enabled community models.
+    def should_capture(
+        self,
+        model: Model | None,
+        confidence: float,
+        label: str = "",
+        *,
+        wish_list: bool = False,
+    ) -> bool:
+        """Capture this prediction for the feedback loop?
 
-        Confidence is a 0-100 percentage; ``-1`` (unknown — e.g. an HTTP
-        backend returned no confidence) is never captured.
+        Two independent reasons, checked in that order:
+
+        1. **Confidence** — below the publisher's effective floor. Confidence
+           is a 0-100 percentage; ``-1`` (unknown — e.g. an HTTP backend
+           returned no confidence) never satisfies this rule.
+        2. **Wish list** — ``label`` is a classification the model is short of
+           images for, regardless of confidence. Only offered during a
+           continuous run (``wish_list=True``; a Manual Feed keeps
+           confidence-only behavior) and capped per classification per run.
+
+        Checking confidence first means a below-floor prediction of a wished
+        headstamp is captured as it always was, without spending wish quota.
         """
         if not is_feedback_model(model):
             debug_log(
@@ -87,16 +204,24 @@ class FeedbackService:
                 f"community_uid={getattr(model, 'community_model_uid', None)!r})"
             )
             return False
-        if confidence is None or confidence < 0:
-            debug_log(f"should_capture=False: unknown confidence ({confidence!r})")
-            return False
         floor = self.effective_floor(model)
-        decision = float(confidence) < floor
+        if confidence is None or confidence < 0:
+            debug_log(f"unknown confidence ({confidence!r}) — confidence rule skipped")
+        elif float(confidence) < floor:
+            debug_log(
+                f"should_capture=True: confidence={confidence} < effective_floor={floor} "
+                f"(publisher_floor={model.feedback_loop_confidence_floor}, "
+                f"mode={model.feedback_loop_upload_mode})"
+            )
+            return True
+        if wish_list and self._claim_wish_capture(model, label):
+            debug_log(f"should_capture=True: {label!r} is on the model's wish list")
+            return True
         debug_log(
-            f"should_capture={decision}: confidence={confidence} vs effective_floor={floor} "
-            f"(publisher_floor={model.feedback_loop_confidence_floor}, mode={model.feedback_loop_upload_mode})"
+            f"should_capture=False: confidence={confidence} vs effective_floor={floor}, "
+            f"label={label!r} not wanted (wish_list_checked={wish_list})"
         )
-        return decision
+        return False
 
     # ----- staging folder (the queue) ----------------------------------------
 

--- a/sorter/run_controller.py
+++ b/sorter/run_controller.py
@@ -224,13 +224,37 @@ class RunController:
         except Exception:
             traceback.print_exc()
 
-    def _maybe_capture_feedback(self, image_bgr, label: str, confidence: float) -> None:
-        """Stage a below-threshold prediction for the community feedback loop.
+    # ----- community feedback loop -------------------------------------------
 
-        Independent of the run confidence floor — feedback uses the publisher's
-        own threshold (``model.feedback_loop_confidence_floor``). Best-effort;
-        a failure here never interrupts a run. Posts ``feedback/queued`` so the
-        Run tab (which holds the auth token) can drive the upload.
+    def refresh_wish_list(self, *, auth: Any) -> list[str]:
+        """Fetch the active model's wish list for the run about to start.
+
+        Blocking (one HTTPS round-trip) — the UI calls this from a worker
+        thread, never from the run loop, so a slow or unreachable server can't
+        delay a run. Fails open to an empty list.
+        """
+        if self._feedback is None:
+            return []
+        model_id = self.config.settings.get_active_model_id()
+        model = ModelRepo(self.db).get(model_id) if model_id is not None else None
+        return self._feedback.refresh_wish_list(model, auth=auth)
+
+    def clear_wish_list(self) -> None:
+        """Forget the current wish list (and its per-run capture quotas)."""
+        if self._feedback is not None:
+            self._feedback.clear_wish_list()
+
+    def _maybe_capture_feedback(
+        self, image_bgr, label: str, confidence: float, *, wish_list: bool = False,
+    ) -> None:
+        """Stage a prediction for the community feedback loop.
+
+        Captured when confidence falls below the publisher's own threshold
+        (``model.feedback_loop_confidence_floor``, independent of the run
+        confidence floor) or — during a continuous run only — when the label is
+        on the model's wish list. Best-effort; a failure here never interrupts
+        a run. Posts ``feedback/queued`` so the Run tab (which holds the auth
+        token) can drive the upload.
         """
         if self._feedback is None or image_bgr is None:
             debug_log(
@@ -244,7 +268,9 @@ class RunController:
         debug_log(f"run-hook: model_id={model_id} label={label!r} confidence={confidence}")
         try:
             model = ModelRepo(self.db).get(model_id)
-            if not self._feedback.should_capture(model, confidence):
+            if not self._feedback.should_capture(
+                model, confidence, label, wish_list=wish_list,
+            ):
                 return
             if self._feedback.capture(model, image_bgr, label, confidence):
                 debug_log(
@@ -382,7 +408,8 @@ class RunController:
             result["slot"] = slot
             result["halt"] = halt
             self._maybe_store_run_image(cropped, label, above_floor)
-            self._maybe_capture_feedback(cropped, label, confidence)
+            # Continuous run: wish-list capture is in play (see _loop).
+            self._maybe_capture_feedback(cropped, label, confidence, wish_list=True)
             # Track the latest classification so a follow-up Manual feed or
             # the next continuous-run prime can route the case still queued
             # at position 5 instead of defaulting back to 0.
@@ -473,6 +500,7 @@ class RunController:
             result["slot"] = slot
             result["ok"] = True
             self._maybe_store_run_image(cropped, label, above_floor)
+            # Manual feed isn't a run: confidence-only feedback, no wish list.
             self._maybe_capture_feedback(cropped, label, confidence)
             self.bus.post(
                 "run/classified",

--- a/sorter/ui/tab_run.py
+++ b/sorter/ui/tab_run.py
@@ -1269,8 +1269,39 @@ class RunTab(ttk.Frame):
             debug_log("tab_run: not auto-draining (mode!=Instant or declined) — manual/OnRunComplete path")
             self._update_feedback_button()
 
+    def _begin_wish_list_fetch(self, controller) -> None:
+        """Fetch the active community model's wish list for the run starting now.
+
+        Fire-and-forget on a worker thread — the run starts immediately and
+        picks the list up when it lands, so at most the first case or two are
+        judged on confidence alone. Gated on a feedback-enabled community model
+        so a user who left the feedback loop off never touches the auth path.
+        Any failure leaves the list empty: normal confidence-only feedback.
+        """
+        if not hasattr(controller, "refresh_wish_list"):
+            return
+        # Drop the previous run's list (and its per-headstamp quotas) up front,
+        # so a failed or skipped fetch can't leave a stale one in play.
+        controller.clear_wish_list()
+        model = self._active_feedback_model()
+        auth = getattr(self.app, "auth", None)
+        if model is None or auth is None:
+            debug_log(
+                f"tab_run: wish list not fetched (model={model.id if model else None}, "
+                f"auth={auth is not None})"
+            )
+            return
+        self.app.run_worker(
+            lambda: controller.refresh_wish_list(auth=auth),
+            on_done=lambda names: debug_log(f"tab_run: wish list for this run: {names}"),
+            on_error=lambda _exc: None,
+        )
+
     def _on_run_stopped(self) -> None:
         self._set_running(False)
+        controller = self.app.run_controller
+        if controller is not None and hasattr(controller, "clear_wish_list"):
+            controller.clear_wish_list()
         model = self._active_feedback_model()
         if model is not None:
             debug_log(
@@ -1356,6 +1387,7 @@ class RunTab(ttk.Frame):
         if self._is_running:
             controller.stop()
         else:
+            self._begin_wish_list_fetch(controller)
             controller.start()
 
     def _manual_feed(self) -> None:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -4,6 +4,25 @@ from __future__ import annotations
 import sys
 from pathlib import Path
 
+import pytest
+
 ROOT = Path(__file__).resolve().parent.parent
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+
+
+# Developer overrides (see sorter/appenv.py) must not leak into the suite: a
+# contributor pointing their app at a local backend should still get the same
+# test results as CI. Tests that want an override set it themselves.
+_DEV_ENV_VARS = (
+    "CASESORTER_ENV_FILE",
+    "CASESORTER_API_BASE",
+    "CASESORTER_API_CA_BUNDLE",
+    "CASESORTER_API_INSECURE",
+)
+
+
+@pytest.fixture(autouse=True)
+def _clear_dev_env(monkeypatch):
+    for name in _DEV_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)

--- a/tests/test_appenv.py
+++ b/tests/test_appenv.py
@@ -255,3 +255,98 @@ def test_default_verify_stays_true_so_env_ca_bundles_still_work(tmp_path) -> Non
     s.next_responses[url] = _FakeResp(json_data=[])
     api.fetch_wish_list("uid-1")
     assert s.verify_args == [True]
+
+
+# ----- .env encodings (Windows) ----------------------------------------------
+
+
+BODY = (
+    "CASESORTER_API_BASE=https://localhost:5001/api\n"
+    "#CASESORTER_API_CA_BUNDLE=./devcert.pem\n"
+    "CASESORTER_API_INSECURE=1\n"
+)
+
+ENCODINGS = {
+    "plain_lf": BODY.encode(),
+    "crlf": BODY.replace("\n", "\r\n").encode(),
+    # Notepad's default. The BOM used to corrupt the first key's NAME, so the
+    # base URL was silently dropped and the app kept talking to production.
+    "utf8_bom": b"\xef\xbb\xbf" + BODY.encode(),
+    "utf8_bom_crlf": b"\xef\xbb\xbf" + BODY.replace("\n", "\r\n").encode(),
+    # PowerShell's `>` redirection.
+    "utf16_le_bom": BODY.encode("utf-16"),
+    "trailing_space": BODY.replace("\n", "   \n").encode(),
+}
+
+
+@pytest.mark.parametrize("name", sorted(ENCODINGS))
+def test_env_file_applies_whatever_the_editor_saved(name, tmp_path, monkeypatch) -> None:
+    env_file = tmp_path / "dev.env"
+    env_file.write_bytes(ENCODINGS[name])
+    monkeypatch.setenv("CASESORTER_ENV_FILE", str(env_file))
+
+    assert appenv.load_dotenv() == [env_file]
+    assert appenv.api_base() == "https://localhost:5001/api"
+    assert appenv.tls_verify() is False        # loopback + insecure
+    # The commented-out line stays commented out.
+    assert not os.environ.get("CASESORTER_API_CA_BUNDLE")
+
+
+@pytest.mark.parametrize("raw", [b"", b"\x00\x01\x02", bytes(range(256))])
+def test_unparseable_env_file_never_crashes_startup(raw, tmp_path, monkeypatch) -> None:
+    """os.environ rejects keys with NULs — garbage must not reach it."""
+    env_file = tmp_path / "dev.env"
+    env_file.write_bytes(raw)
+    monkeypatch.setenv("CASESORTER_ENV_FILE", str(env_file))
+    appenv.load_dotenv()                        # must not raise
+    assert appenv.api_base() == appenv.DEFAULT_API_BASE
+
+
+def test_parse_drops_keys_that_are_not_env_var_names() -> None:
+    parsed = appenv.parse_env_text(
+        "GOOD=1\nbad key=2\n\x00NUL=3\n9LEADING=4\ndot.ted=5\n"
+    )
+    assert parsed == {"GOOD": "1"}
+
+
+# ----- startup diagnostics ----------------------------------------------------
+
+
+def test_startup_report_is_silent_by_default() -> None:
+    assert appenv.startup_report([]) == []
+
+
+def test_startup_report_names_the_file_its_keys_and_the_effect(tmp_path, monkeypatch) -> None:
+    env_file = tmp_path / "dev.env"
+    env_file.write_bytes(ENCODINGS["utf8_bom"])
+    monkeypatch.setenv("CASESORTER_ENV_FILE", str(env_file))
+    lines = appenv.startup_report(appenv.load_dotenv())
+    assert str(env_file) in lines[0]
+    assert "CASESORTER_API_BASE" in lines[0]
+    assert "localhost:5001" in lines[1] and "DISABLED" in lines[1]
+
+
+def test_startup_report_flags_a_file_that_held_nothing(tmp_path, monkeypatch) -> None:
+    """A found-but-useless file reads as such instead of looking applied."""
+    env_file = tmp_path / "dev.env"
+    env_file.write_text("# just a comment\n")
+    monkeypatch.setenv("CASESORTER_ENV_FILE", str(env_file))
+    lines = appenv.startup_report(appenv.load_dotenv())
+    assert "no settings found" in lines[0]
+    assert appenv.DEFAULT_API_BASE in lines[1]
+
+
+def test_startup_report_hints_at_a_misnamed_env_file(tmp_path, monkeypatch) -> None:
+    """Explorer hides .txt, so 'Save as .env' in Notepad yields '.env.txt'."""
+    monkeypatch.setenv("CASESORTER_ENV_FILE", str(tmp_path / ".env"))
+    (tmp_path / ".env.txt").write_text("CASESORTER_API_BASE=https://localhost:5001/api\n")
+    lines = appenv.startup_report(appenv.load_dotenv())
+    assert lines and "misnamed" in lines[0] and ".env.txt" in lines[0]
+
+
+def test_no_misnaming_hint_once_settings_are_in_effect(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_ENV_FILE", str(tmp_path / ".env"))
+    monkeypatch.setenv("CASESORTER_API_BASE", "https://localhost:5001/api")
+    (tmp_path / ".env.txt").write_text("x")
+    lines = appenv.startup_report(appenv.load_dotenv())
+    assert not any("misnamed" in line for line in lines)

--- a/tests/test_appenv.py
+++ b/tests/test_appenv.py
@@ -1,0 +1,257 @@
+"""Developer environment overrides: .env loading, API base, TLS trust.
+
+The insecure-TLS switch is the interesting part — it must apply for a loopback
+backend and must NOT apply to anything else, however it is spelled.
+"""
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+from sorter import appenv
+
+
+@pytest.fixture(autouse=True)
+def _reset_warnings():
+    """Warnings are one-shot per process; clear them between tests."""
+    appenv._warned.clear()
+
+
+# ----- .env parsing ----------------------------------------------------------
+
+
+def test_parse_env_text_handles_comments_quotes_and_export() -> None:
+    parsed = appenv.parse_env_text(
+        "\n"
+        "# a comment\n"
+        "CASESORTER_API_BASE=https://localhost:7043/api\n"
+        "  export QUOTED = 'value with spaces' \n"
+        'DOUBLE="dq"\n'
+        "novalue\n"
+        "EMPTY=\n"
+    )
+    assert parsed == {
+        "CASESORTER_API_BASE": "https://localhost:7043/api",
+        "QUOTED": "value with spaces",
+        "DOUBLE": "dq",
+        "EMPTY": "",
+    }
+
+
+def test_load_dotenv_applies_file_without_clobbering_real_env(tmp_path, monkeypatch) -> None:
+    env_file = tmp_path / "dev.env"
+    env_file.write_text("CASESORTER_API_BASE=https://localhost:7043/api\nOTHER=x\n")
+    monkeypatch.setenv("CASESORTER_ENV_FILE", str(env_file))
+    monkeypatch.setenv("OTHER", "already-set")
+
+    applied = appenv.load_dotenv()
+
+    assert env_file in applied
+    assert appenv.api_base() == "https://localhost:7043/api"
+    # A real environment variable outranks the file.
+    assert os.environ["OTHER"] == "already-set"
+
+
+def test_load_dotenv_is_a_noop_without_files(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_ENV_FILE", str(tmp_path / "nope.env"))
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    assert appenv.load_dotenv() == []
+    assert appenv.api_base() == appenv.DEFAULT_API_BASE
+
+
+def test_load_dotenv_survives_an_unreadable_file(tmp_path, monkeypatch) -> None:
+    """A developer convenience must never stop the app from starting."""
+    bad = tmp_path / "dir.env"
+    bad.mkdir()                      # is_file() is False → skipped, not raised
+    monkeypatch.setenv("CASESORTER_ENV_FILE", str(bad))
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    assert appenv.load_dotenv() == []
+
+
+# ----- api base --------------------------------------------------------------
+
+
+def test_api_base_default_and_override(monkeypatch) -> None:
+    assert appenv.api_base() == "https://www.reloadingrecipes.com/api"
+    monkeypatch.setenv("CASESORTER_API_BASE", "https://localhost:7043/api/")
+    assert appenv.api_base() == "https://localhost:7043/api"   # trailing / trimmed
+    monkeypatch.setenv("CASESORTER_API_BASE", "   ")
+    assert appenv.api_base() == appenv.DEFAULT_API_BASE        # blank → default
+
+
+# ----- tls trust -------------------------------------------------------------
+
+
+def test_tls_verify_defaults_to_system_trust() -> None:
+    assert appenv.tls_verify() is True
+
+
+def test_ca_bundle_is_used_when_it_exists(tmp_path, monkeypatch) -> None:
+    pem = tmp_path / "devcert.pem"
+    pem.write_text("-----BEGIN CERTIFICATE-----\n")
+    monkeypatch.setenv("CASESORTER_API_CA_BUNDLE", str(pem))
+    assert appenv.tls_verify() == str(pem)
+
+
+def test_missing_ca_bundle_falls_back_to_system_trust(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_API_CA_BUNDLE", str(tmp_path / "gone.pem"))
+    assert appenv.tls_verify() is True
+
+
+def test_ca_bundle_wins_over_insecure(tmp_path, monkeypatch) -> None:
+    pem = tmp_path / "devcert.pem"
+    pem.write_text("x")
+    monkeypatch.setenv("CASESORTER_API_CA_BUNDLE", str(pem))
+    monkeypatch.setenv("CASESORTER_API_INSECURE", "1")
+    monkeypatch.setenv("CASESORTER_API_BASE", "https://localhost:7043/api")
+    assert appenv.tls_verify() == str(pem)
+
+
+def test_insecure_honoured_for_loopback(monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_API_INSECURE", "1")
+    for base in (
+        "https://localhost:7043/api",
+        "https://127.0.0.1:7043/api",
+        "https://127.0.1.5/api",
+        "https://app.localhost/api",
+        "https://[::1]:7043/api",
+    ):
+        monkeypatch.setenv("CASESORTER_API_BASE", base)
+        appenv._warned.clear()
+        assert appenv.tls_verify() is False, base
+
+
+def test_insecure_ignored_for_remote_hosts(monkeypatch) -> None:
+    """A stray CASESORTER_API_INSECURE can never weaken production traffic."""
+    monkeypatch.setenv("CASESORTER_API_INSECURE", "1")
+    for base in (
+        appenv.DEFAULT_API_BASE,
+        "https://evil.example.com/api",
+        "https://localhost.evil.example.com/api",   # not a loopback host
+    ):
+        monkeypatch.setenv("CASESORTER_API_BASE", base)
+        appenv._warned.clear()
+        assert appenv.tls_verify() is True, base
+
+
+def test_insecure_ignored_with_the_default_base(monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_API_INSECURE", "1")   # no base override at all
+    assert appenv.tls_verify() is True
+
+
+def test_insecure_flag_spellings(monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_API_BASE", "https://localhost/api")
+    for value, expected in (
+        ("1", False), ("true", False), ("TRUE", False), ("yes", False), ("on", False),
+        ("0", True), ("false", True), ("", True), ("maybe", True),
+    ):
+        monkeypatch.setenv("CASESORTER_API_INSECURE", value)
+        appenv._warned.clear()
+        assert appenv.tls_verify() is expected, value
+
+
+def test_describe_reports_the_effective_settings(tmp_path, monkeypatch) -> None:
+    assert "system trust" in appenv.describe()
+    monkeypatch.setenv("CASESORTER_API_BASE", "https://localhost:7043/api")
+    monkeypatch.setenv("CASESORTER_API_INSECURE", "1")
+    text = appenv.describe()
+    assert "localhost:7043" in text and "DISABLED" in text
+
+
+def test_warnings_are_emitted_once(capsys, monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_API_BASE", "https://localhost/api")
+    monkeypatch.setenv("CASESORTER_API_INSECURE", "1")
+    for _ in range(3):
+        appenv.tls_verify()
+    assert capsys.readouterr().err.count("TLS verification is DISABLED") == 1
+
+
+# ----- wiring into the API client --------------------------------------------
+
+
+def test_community_api_picks_up_the_override(monkeypatch) -> None:
+    from sorter.community_api import API_BASE, CommunityApi
+
+    class _Auth:
+        def acquire_token_silent(self, scopes=None): return None
+
+    class _Session:
+        verify = True
+
+    assert CommunityApi(auth=_Auth(), session=_Session()).base_url == API_BASE
+    monkeypatch.setenv("CASESORTER_API_BASE", "https://localhost:7043/api/")
+    assert CommunityApi(auth=_Auth(), session=_Session()).base_url == "https://localhost:7043/api"
+
+
+def test_community_api_resolves_tls_trust(tmp_path, monkeypatch) -> None:
+    from sorter.community_api import CommunityApi
+
+    class _Auth:
+        def acquire_token_silent(self, scopes=None): return None
+
+    class _Session:
+        verify = True
+
+    pem = tmp_path / "devcert.pem"
+    pem.write_text("x")
+    monkeypatch.setenv("CASESORTER_API_CA_BUNDLE", str(pem))
+    assert CommunityApi(auth=_Auth(), session=_Session()).verify == str(pem)
+
+
+def test_explicit_verify_argument_wins(monkeypatch) -> None:
+    from sorter.community_api import CommunityApi
+
+    class _Auth:
+        def acquire_token_silent(self, scopes=None): return None
+
+    class _Session:
+        verify = True
+
+    monkeypatch.setenv("CASESORTER_API_INSECURE", "1")
+    monkeypatch.setenv("CASESORTER_API_BASE", "https://localhost/api")
+    assert CommunityApi(auth=_Auth(), session=_Session(), verify=True).verify is True
+
+
+def test_env_file_candidate_order(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_ENV_FILE", str(tmp_path / "explicit.env"))
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    candidates = appenv.env_file_candidates()
+    assert candidates[0] == tmp_path / "explicit.env"
+    assert candidates[1] == tmp_path / "data" / "config" / ".env"
+    assert candidates[2] == Path(appenv.__file__).resolve().parent.parent / ".env"
+
+
+def test_verify_is_passed_per_request_not_on_the_session(tmp_path, monkeypatch) -> None:
+    """Regression guard: session.verify is not enough.
+
+    requests lets REQUESTS_CA_BUNDLE / CURL_CA_BUNDLE in the environment
+    outrank ``session.verify``, so a session-level setting is silently ignored
+    on any machine that sets one (corporate proxies do). Only a per-request
+    ``verify=`` wins.
+    """
+    from tests.test_community_api import _FakeResp, _FakeSession, _api
+
+    pem = tmp_path / "devcert.pem"
+    pem.write_text("x")
+    monkeypatch.setenv("CASESORTER_API_CA_BUNDLE", str(pem))
+
+    s = _FakeSession()
+    api = _api(s)
+    url = f"{api.base_url}/Models/FetchWishList?communityModelId=uid-1"
+    s.next_responses[url] = _FakeResp(json_data=["FC"])
+    api.fetch_wish_list("uid-1")
+    assert s.verify_args == [str(pem)]
+
+
+def test_default_verify_stays_true_so_env_ca_bundles_still_work(tmp_path) -> None:
+    """Passing True (not None) keeps requests' own env-bundle handling intact."""
+    from tests.test_community_api import _FakeResp, _FakeSession, _api
+
+    s = _FakeSession()
+    api = _api(s)
+    url = f"{api.base_url}/Models/FetchWishList?communityModelId=uid-1"
+    s.next_responses[url] = _FakeResp(json_data=[])
+    api.fetch_wish_list("uid-1")
+    assert s.verify_args == [True]

--- a/tests/test_community_api.py
+++ b/tests/test_community_api.py
@@ -53,18 +53,24 @@ class _FakeSession:
         self.get_calls: list[tuple[str, dict[str, str]]] = []
         self.post_calls: list[tuple[str, Any]] = []
         self.put_calls: list[tuple[str, dict[str, str]]] = []
+        # `verify` as passed per request — see the note in CommunityApi.__init__
+        # on why it must not live on the session.
+        self.verify_args: list = []
         self.next_responses: dict[str, _FakeResp] = {}
 
     def get(self, url: str, headers=None, timeout=None, **kw) -> _FakeResp:
         self.get_calls.append((url, headers or {}))
+        self.verify_args.append(kw.get("verify"))
         return self.next_responses.get(url, _FakeResp(404))
 
-    def post(self, url: str, headers=None, json=None, timeout=None) -> _FakeResp:
+    def post(self, url: str, headers=None, json=None, timeout=None, **kw) -> _FakeResp:
         self.post_calls.append((url, json))
+        self.verify_args.append(kw.get("verify"))
         return self.next_responses.get(url, _FakeResp(404))
 
     def put(self, url: str, data=None, headers=None, timeout=None, **kw) -> _FakeResp:
         self.put_calls.append((url, headers or {}))
+        self.verify_args.append(kw.get("verify"))
         # Drain the body the way requests would: read() a file-like (drives the
         # progress callback) or iterate a generator.
         if hasattr(data, "read"):
@@ -95,7 +101,9 @@ class _FakeAuth(AuthManager):
 
 
 def _api(session: _FakeSession) -> CommunityApi:
-    return CommunityApi(auth=_FakeAuth(), session=session)
+    # base_url pinned so these URL assertions don't depend on the developer's
+    # CASESORTER_API_BASE; the override itself is covered below.
+    return CommunityApi(auth=_FakeAuth(), session=session, base_url=API_BASE)
 
 
 def test_authorization_header_added(tmp_path: Path) -> None:

--- a/tests/test_community_api.py
+++ b/tests/test_community_api.py
@@ -450,3 +450,68 @@ def test_share_model_raises_when_file_request_refused(tmp_path: Path) -> None:
             zip_path=zip_path, manifest_path=tmp_path / "m.json",
             model_info={},
         )
+
+
+# ----- wish list (model-balancing feedback) ----------------------------------
+
+
+def _wish_url(uid: str = "uid-1") -> str:
+    return f"{API_BASE}/Models/FetchWishList?communityModelId={uid}"
+
+
+def test_fetch_wish_list_returns_names() -> None:
+    s = _FakeSession()
+    s.next_responses[_wish_url()] = _FakeResp(json_data=["FC", "R-P", "WIN 9MM"])
+    assert _api(s).fetch_wish_list("uid-1") == ["FC", "R-P", "WIN 9MM"]
+    assert s.get_calls[0][1].get("Authorization") == "Bearer TOKEN"
+
+
+def test_fetch_wish_list_url_encodes_uid() -> None:
+    s = _FakeSession()
+    url = f"{API_BASE}/Models/FetchWishList?communityModelId=a+b"
+    s.next_responses[url] = _FakeResp(json_data=[])
+    _api(s).fetch_wish_list("a b")
+    assert s.get_calls[0][0] == url
+
+
+def test_fetch_wish_list_drops_blank_and_non_string_entries() -> None:
+    s = _FakeSession()
+    s.next_responses[_wish_url()] = _FakeResp(json_data=["  FC  ", "", None, 7, "R-P"])
+    assert _api(s).fetch_wish_list("uid-1") == ["FC", "R-P"]
+
+
+def test_fetch_wish_list_fails_open() -> None:
+    """Every failure mode answers [] — a run is never blocked on this call."""
+    class _RaisingResp(_FakeResp):
+        def json(self) -> Any:
+            raise ValueError("not json")
+
+    class _BoomSession(_FakeSession):
+        def get(self, url, headers=None, timeout=None, **kw):
+            raise requests.exceptions.ConnectionError("offline")
+
+    assert _api(_FakeSession()).fetch_wish_list("") == []           # no UID
+    assert _api(_BoomSession()).fetch_wish_list("uid-1") == []      # network error
+
+    s = _FakeSession()
+    s.next_responses[_wish_url()] = _FakeResp(status_code=500, text="boom")
+    assert _api(s).fetch_wish_list("uid-1") == []                   # non-200
+
+    s = _FakeSession()
+    s.next_responses[_wish_url()] = _RaisingResp(text="<html>")
+    assert _api(s).fetch_wish_list("uid-1") == []                   # non-JSON body
+
+    s = _FakeSession()
+    s.next_responses[_wish_url()] = _FakeResp(json_data={"nope": 1})
+    assert _api(s).fetch_wish_list("uid-1") == []                   # wrong shape
+
+
+def test_fetch_wish_list_signed_out_returns_empty() -> None:
+    class _NoAuth(_FakeAuth):
+        def acquire_token_silent(self, scopes=None):
+            return None
+
+    s = _FakeSession()
+    api = CommunityApi(auth=_NoAuth(), session=s)
+    assert api.fetch_wish_list("uid-1") == []
+    assert s.get_calls == []

--- a/tests/test_feedback.py
+++ b/tests/test_feedback.py
@@ -209,3 +209,127 @@ def test_upload_pending_empty_queue_is_noop(db) -> None:
     m = _model(db)
     result = svc.upload_pending(m.id, auth=_OkAuth())
     assert result == {"uploaded": 0, "dropped": 0, "declined": False, "skipped": False}
+
+
+# ----- wish list (model-balancing feedback) ----------------------------------
+
+
+class _WishApi:
+    """Fake CommunityApi that records the UID it was asked about."""
+    names: list[str] = []
+    boom = False
+    calls: list[str] = []
+
+    def __init__(self, auth=None, **kw) -> None:
+        pass
+
+    def fetch_wish_list(self, uid: str) -> list[str]:
+        _WishApi.calls.append(uid)
+        if _WishApi.boom:
+            raise RuntimeError("offline")
+        return list(_WishApi.names)
+
+
+@pytest.fixture
+def wish_api(monkeypatch):
+    import sorter.community_api as ca
+    _WishApi.names, _WishApi.boom, _WishApi.calls = [], False, []
+    monkeypatch.setattr(ca, "CommunityApi", _WishApi)
+    return _WishApi
+
+
+def test_set_wish_list_normalises_and_clears(db) -> None:
+    svc = FeedbackService(db)
+    svc.set_wish_list(1, ["  FC ", "R-P", "", None, "fc"])
+    assert svc.wish_list() == ["fc", "r-p"]
+    svc.clear_wish_list()
+    assert svc.wish_list() == []
+
+
+def test_wish_list_captures_regardless_of_confidence(db) -> None:
+    svc = FeedbackService(db)
+    m = _model(db, floor=95)
+    svc.set_wish_list(m.id, ["WIN 9MM"])
+    # Well above the floor, but wanted → captured (case-insensitively).
+    assert svc.should_capture(m, 100.0, "win 9mm", wish_list=True) is True
+    # Not wanted, above floor → still not captured.
+    assert svc.should_capture(m, 100.0, "FC", wish_list=True) is False
+
+
+def test_wish_list_ignored_outside_a_continuous_run(db) -> None:
+    """Manual Feed passes wish_list=False and keeps confidence-only behavior."""
+    svc = FeedbackService(db)
+    m = _model(db, floor=95)
+    svc.set_wish_list(m.id, ["WIN"])
+    assert svc.should_capture(m, 100.0, "WIN") is False
+    assert svc.should_capture(m, 90.0, "WIN") is True    # confidence rule still applies
+
+
+def test_wish_list_is_bound_to_its_model(db) -> None:
+    svc = FeedbackService(db)
+    m = _model(db, floor=95)
+    other = _model(db, floor=95, community="uid-2")
+    svc.set_wish_list(other.id, ["WIN"])
+    assert svc.should_capture(m, 100.0, "WIN", wish_list=True) is False
+
+
+def test_wish_list_requires_a_feedback_model(db) -> None:
+    svc = FeedbackService(db)
+    m = _model(db, enabled=False)
+    svc.set_wish_list(m.id, ["WIN"])
+    assert svc.should_capture(m, 100.0, "WIN", wish_list=True) is False
+
+
+def test_wish_list_capped_per_label_per_run(db) -> None:
+    from sorter.feedback import MAX_WISH_LIST_CAPTURES_PER_LABEL as CAP
+    svc = FeedbackService(db)
+    m = _model(db, floor=95)
+    svc.set_wish_list(m.id, ["WIN", "FC"])
+    assert all(svc.should_capture(m, 100.0, "WIN", wish_list=True) for _ in range(CAP))
+    assert svc.should_capture(m, 100.0, "WIN", wish_list=True) is False
+    # The cap is per classification…
+    assert svc.should_capture(m, 100.0, "FC", wish_list=True) is True
+    # …and the confidence rule stays unbounded.
+    assert svc.should_capture(m, 10.0, "WIN", wish_list=True) is True
+    # A new run reinstalls the list and refills the quota.
+    svc.set_wish_list(m.id, ["WIN"])
+    assert svc.should_capture(m, 100.0, "WIN", wish_list=True) is True
+
+
+def test_below_floor_capture_does_not_spend_wish_quota(db) -> None:
+    from sorter.feedback import MAX_WISH_LIST_CAPTURES_PER_LABEL as CAP
+    svc = FeedbackService(db)
+    m = _model(db, floor=95)
+    svc.set_wish_list(m.id, ["WIN"])
+    for _ in range(CAP):
+        assert svc.should_capture(m, 10.0, "WIN", wish_list=True) is True
+    assert svc.should_capture(m, 100.0, "WIN", wish_list=True) is True
+
+
+def test_refresh_wish_list_installs_server_names(db, wish_api) -> None:
+    svc = FeedbackService(db)
+    m = _model(db)
+    wish_api.names = ["FC", "R-P"]
+    assert svc.refresh_wish_list(m, auth=_OkAuth()) == ["FC", "R-P"]
+    assert svc.wish_list() == ["fc", "r-p"]
+    assert wish_api.calls == ["uid-1"]
+
+
+def test_refresh_wish_list_skips_non_feedback_models_and_signed_out(db, wish_api) -> None:
+    """The auth path is never touched when the loop is off or nobody's signed in."""
+    svc = FeedbackService(db)
+    wish_api.names = ["FC"]
+    assert svc.refresh_wish_list(_model(db, enabled=False), auth=_OkAuth()) == []
+    assert svc.refresh_wish_list(_model(db, community=None), auth=_OkAuth()) == []
+    assert svc.refresh_wish_list(None, auth=_OkAuth()) == []
+    assert svc.refresh_wish_list(_model(db, community="uid-9"), auth=None) == []
+    assert wish_api.calls == []
+
+
+def test_refresh_wish_list_fails_open_on_error(db, wish_api) -> None:
+    svc = FeedbackService(db)
+    m = _model(db)
+    svc.set_wish_list(m.id, ["stale"])
+    wish_api.boom = True
+    assert svc.refresh_wish_list(m, auth=_OkAuth()) == []
+    assert svc.wish_list() == []          # the stale list is dropped too

--- a/tests/test_feedback_ui.py
+++ b/tests/test_feedback_ui.py
@@ -234,3 +234,81 @@ def test_trigger_drain_coalesces_while_inflight(root, db) -> None:
         assert tab._feedback_upload_inflight is True
     finally:
         tab.destroy()
+
+
+# ----- run-tab wish-list fetch ------------------------------------------------
+
+
+class _FakeController:
+    """Stands in for RunController's wish-list surface."""
+
+    def __init__(self) -> None:
+        self.cleared = 0
+        self.refreshed: list = []
+
+    def refresh_wish_list(self, *, auth):
+        self.refreshed.append(auth)
+        return ["FC"]
+
+    def clear_wish_list(self) -> None:
+        self.cleared += 1
+
+
+def test_wish_list_fetched_on_worker_at_run_start(root, db) -> None:
+    m = _community_model(db, mode="Instant")
+    SettingsRepo(db).set_active_model_id(m.id)
+    tab, app, _cfg = _make_run_tab(root, db)
+    try:
+        app.auth = object()
+        ctrl = _FakeController()
+        tab._begin_wish_list_fetch(ctrl)
+        # Stale list dropped up front, fetch deferred to a worker thread so the
+        # run isn't blocked on the round-trip.
+        assert ctrl.cleared == 1
+        assert len(app.worker_calls) == 1
+        assert app.worker_calls[0][0]() == ["FC"]
+        assert ctrl.refreshed == [app.auth]
+    finally:
+        tab.destroy()
+
+
+def test_wish_list_not_fetched_when_signed_out(root, db) -> None:
+    m = _community_model(db, mode="Instant")
+    SettingsRepo(db).set_active_model_id(m.id)
+    tab, app, _cfg = _make_run_tab(root, db)
+    try:
+        app.auth = None
+        ctrl = _FakeController()
+        tab._begin_wish_list_fetch(ctrl)
+        assert app.worker_calls == []
+        assert ctrl.cleared == 1
+    finally:
+        tab.destroy()
+
+
+def test_wish_list_not_fetched_when_feedback_loop_off(root, db) -> None:
+    """No community-model round-trip (and no auth touch) for an opted-out model."""
+    m = _community_model(db, enabled=False)
+    SettingsRepo(db).set_active_model_id(m.id)
+    tab, app, _cfg = _make_run_tab(root, db)
+    try:
+        app.auth = object()
+        ctrl = _FakeController()
+        tab._begin_wish_list_fetch(ctrl)
+        assert app.worker_calls == []
+        assert ctrl.refreshed == []
+    finally:
+        tab.destroy()
+
+
+def test_wish_list_cleared_when_the_run_stops(root, db) -> None:
+    m = _community_model(db, mode="Manual")
+    SettingsRepo(db).set_active_model_id(m.id)
+    tab, app, _cfg = _make_run_tab(root, db)
+    try:
+        ctrl = _FakeController()
+        app.run_controller = ctrl
+        tab._on_run_stopped()
+        assert ctrl.cleared == 1
+    finally:
+        tab.destroy()

--- a/tests/test_run_controller.py
+++ b/tests/test_run_controller.py
@@ -257,3 +257,63 @@ def test_test_once_returns_parent_label_in_parent_mode(tmp_path) -> None:
     assert result["label"] == "WIN"
     assert result["parent"] == "Brass"
     assert events and events[0]["parent"] == "Brass"
+
+
+# ----- wish list (model-balancing feedback) ----------------------------------
+
+
+def test_wish_list_capture_during_a_run(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    ctrl, _, db = _make_controller(tmp_path)
+    mid = _enable_feedback(db, floor=95, mode="Instant")
+    from sorter.feedback import FeedbackService
+    ctrl._feedback.set_wish_list(mid, ["WIN"])
+    events: list[dict] = []
+    ctrl.bus.subscribe("feedback/queued", events.append)
+    # 99 is well above the 95 floor, but WIN is wanted → captured anyway.
+    with patch("sorter.classifier.classify_active", return_value=("WIN", 99)):
+        ctrl.run_once()
+    ctrl.bus.drain()
+    assert FeedbackService(db).count_pending(mid) == 1
+    assert events and events[0]["model_id"] == mid
+
+
+def test_wish_list_not_applied_to_manual_feed(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    ctrl, _, db = _make_controller(tmp_path)
+    mid = _enable_feedback(db, floor=95)
+    from sorter.feedback import FeedbackService
+    ctrl._feedback.set_wish_list(mid, ["WIN"])
+    with patch("sorter.classifier.classify_active", return_value=("WIN", 99)):
+        ctrl.cycle_once()
+    assert FeedbackService(db).count_pending(mid) == 0
+
+
+def test_wish_list_off_leaves_confidence_only_behaviour(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    ctrl, _, db = _make_controller(tmp_path)
+    mid = _enable_feedback(db, floor=95)
+    from sorter.feedback import FeedbackService
+    with patch("sorter.classifier.classify_active", return_value=("WIN", 99)):
+        ctrl.run_once()
+    assert FeedbackService(db).count_pending(mid) == 0
+
+
+def test_refresh_and_clear_wish_list(tmp_path, monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    ctrl, _, db = _make_controller(tmp_path)
+    _enable_feedback(db)
+
+    class _Api:
+        def __init__(self, auth=None, **kw) -> None: pass
+        def fetch_wish_list(self, uid): return ["FC"]
+
+    class _Auth:
+        def acquire_token_silent(self, scopes=None): return object()
+
+    import sorter.community_api as ca
+    monkeypatch.setattr(ca, "CommunityApi", _Api)
+    assert ctrl.refresh_wish_list(auth=_Auth()) == ["FC"]
+    assert ctrl._feedback.wish_list() == ["fc"]
+    ctrl.clear_wish_list()
+    assert ctrl._feedback.wish_list() == []


### PR DESCRIPTION
## Summary

Adds a new `appenv` module that lets developers point the app at a local copy of the community backend and configure TLS trust, without editing source code. Settings come from environment variables with an optional `.env` file for convenience (real env vars always win). This is essential for developing against a locally-running backend.

## Key Changes

- **New `sorter/appenv.py`** — Developer environment overrides module:
  - `load_dotenv()` reads `.env` files from three locations (explicit path, data dir, app root) with robust encoding handling (UTF-8 BOM, UTF-16, CRLF, trailing spaces)
  - `parse_env_text()` parses `KEY=VALUE` lines with support for comments, quotes, and `export` prefix
  - `api_base()` applies `CASESORTER_API_BASE` override (defaults to production URL)
  - `tls_verify()` returns what to pass `requests` as `verify=`: a CA bundle path, `False` for insecure loopback, or `True` for system trust
  - **Insecure-TLS guard**: `CASESORTER_API_INSECURE=1` is honored **only** when the API base is loopback (localhost, 127.x, ::1, *.localhost); ignored with a warning for any remote host, preventing accidental production weakening
  - One-shot warnings to stderr so repeated calls don't spam the same message
  - `startup_report()` logs which `.env` files were applied and their effective settings

- **New `.env.example`** — Template showing all available settings with documentation

- **Updated `sorter/community_api.py`**:
  - `CommunityApi.__init__` now resolves `base_url` and `verify` from `appenv` at construction time (not import), so `.env` loaded at startup applies
  - `verify` is passed per-request (not on session) because `requests` lets `REQUESTS_CA_BUNDLE`/`CURL_CA_BUNDLE` environment variables outrank session-level settings; per-request wins behind corporate proxies
  - Updated docstring explaining the override mechanism

- **Updated `sorter/feedback.py`**:
  - Added wish-list support for model-balancing feedback (classifications the publisher wants more training images for)
  - `FeedbackService.set_wish_list()`, `clear_wish_list()`, `wish_list()` manage the current list
  - `refresh_wish_list()` fetches from the community API (blocking, call from worker thread)
  - `_claim_wish_capture()` consumes quota slots (capped at 40 per label per run)
  - `should_capture()` now accepts `wish_list=True` to capture wanted classifications regardless of confidence

- **Updated `sorter/run_controller.py`**:
  - `refresh_wish_list()` and `clear_wish_list()` methods to manage wish list for the run
  - `_maybe_capture_feedback()` now checks wish list in addition to confidence floor

- **Updated `sorter/ui/tab_run.py`**:
  - `_begin_wish_list_fetch()` fetches wish list on a worker thread at run start (non-blocking)
  - `_on_run_stopped()` clears the wish list when run ends

- **Updated `main.py`** — Calls `appenv.load_dotenv()` at startup to apply `.env` files before any community API calls

- **Updated `tests/conftest.py`** — Auto-fixture clears dev environment variables between tests so overrides don't leak into the suite

- **Comprehensive test suite** (`tests/test_appenv.py`):
  - `.env` parsing (comments, quotes, export, CRLF, BOM, UTF-16, trailing spaces, invalid keys)
  - File loading and precedence (explicit > data dir > app root)
  - API base override and trimming
  - TLS trust resolution (CA bundle, insecure flag, loopback guard)
  - Insecure-flag spellings and one-shot warnings
  - Integration with

https://claude.ai/code/session_01ENhWC6Q5AyiymkdKH2wE84