### PR TITLE
Add sorting templates: named slot layouts per model + run mode

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,23 +117,25 @@ sanctioned way for worker threads to update the UI.
 - **`db.py`** — `Database`: owns one `sqlite3.Connection` (WAL, foreign keys on,
   `check_same_thread=False` with an `RLock` serializing multi-statement
   transactions / SAVEPOINTs). Schema is `PRAGMA user_version`-versioned
-  (`SCHEMA_VERSION = 3`) with idempotent DDL + `_apply_column_migrations`.
+  (`SCHEMA_VERSION = 4`) with idempotent DDL + `_apply_column_migrations`.
   `ensure_initialized()` creates the DB, runs a one-shot import from legacy
   `data/config.json` (renaming it `.bak`), or seeds a default cartridge+model.
-  Tables: `cartridges`, `models`, `headstamp_parents`, `headstamps`, `settings`.
+  Tables: `cartridges`, `models`, `headstamp_parents`, `headstamps`,
+  `slot_templates`, `settings`.
 - **`repository.py`** — `CartridgeRepo`, `ModelRepo`, `HeadstampRepo`,
-  `HeadstampParentRepo`, `SettingsRepo`. All SQL is **parameterized**. `SettingsRepo`
-  is a typed key/value store (JSON-encoded values) and holds `default_model_id`
-  (the "active model").
+  `HeadstampParentRepo`, `SlotTemplateRepo`, `SettingsRepo`. All SQL is
+  **parameterized**. `SettingsRepo` is a typed key/value store (JSON-encoded
+  values) and holds `default_model_id` (the "active model").
 - **`config.py`** — `Config`: in-memory mirror of the `settings` sections (`api`,
   `serial`, `image_proc`, `camera`) plus the canonical `DEFAULTS`. Headstamps are
   **not cached** — they're read fresh from the DB on every access (scoped to the
   active model; AI Config mode stashes them in a settings key). Also the home of
   routing logic: `slot_for_headstamp`, package-mode slot maps, parent
-  classifications, auto-select, run options (confidence floor, store-images mode).
-- **`models.py`** — dataclasses: `Model`, `Headstamp`, `Cartridge`,
+  classifications, auto-select, run options (confidence floor, store-images mode),
+  and the sorting-template API (see below).
+- **`models.py`** — dataclasses: `Model`, `Headstamp`, `Cartridge`, `SlotTemplate`,
   `TrainingConfig`, `AIModelConfig`, `ImageProcessingConfig`, plus normalizers
-  (`normalize_upload_mode`, `SUPPORTED_MODEL_MODES`).
+  (`normalize_upload_mode`, `SUPPORTED_MODEL_MODES`, `SLOT_TEMPLATE_MODES`).
 - **`paths.py`** — single source of truth for the on-disk layout (see §6).
   `CASESORTER_DATA_DIR` overrides the data root.
 
@@ -143,6 +145,31 @@ sanctioned way for worker threads to update the UI.
 When **set**, that local model is active (Train tab visible, local inference
 used, headstamps in the `headstamps` table). Activating a model posts
 `mode/changed`, which toggles tab visibility.
+
+### Sorting templates
+A **sorting template** is a named snapshot of the Run tab's slot assignments, so
+one model can carry several bin layouts ("Range brass", "Match prep") and switch
+between them from the Run tab's template dropdown.
+
+- **Scope:** per model (`model_id NULL` = AI Config mode) **and** per run mode.
+  Standard and package mode keep separate lists — package assignments are
+  many-to-many (one headstamp in several slots), so a layout from one mode is
+  meaningless in the other. `config.slot_template_mode()` picks the list.
+- **Storage:** rows in `slot_templates`; `assignments_json` is name-keyed
+  (`{"headstamps": {name: slot}, "parents": {name: slot}}`, or
+  `{"slots": {slot: [names]}}` for package mode) so a template survives a
+  headstamp being deleted and re-added. Unknown names are ignored on apply.
+- **The live assignments stay authoritative.** A run still reads
+  `headstamps.slot` / `headstamp_parents.slot` / the package slot map — templates
+  never sit in the hot path. The *active* template (settings key
+  `active_slot_template:<model id|ai>:<mode>`) is kept in lock-step with them by
+  `Config.sync_active_slot_template()`, called from every slot mutation, so
+  there is no explicit "save template" step. Switching is therefore a straight
+  save-current / load-next swap (`activate_slot_template`), and applying a
+  template **clears** any slot it doesn't mention.
+- **Seeding/upgrade:** the first read of a scope with no rows creates "Default"
+  holding whatever is currently assigned, so existing installs keep their layout.
+  The last template in a scope can't be deleted.
 
 ### Hardware control
 - **`serial_broker.py`** — `SerialBroker`: ASCII command protocol over UART
@@ -260,7 +287,7 @@ Config shows in AI Config mode; Community is mounted only while signed in. The
 ### Tabs (`tab_*.py`)
 | Tab | File | Purpose |
 |-----|------|---------|
-| **Run** | `tab_run.py` | Production sorting. Flow-grid of slot cards + per-slot headstamp checkboxes with live counts; Start/Stop/Manual-feed; package-mode counters. The largest UI module. |
+| **Run** | `tab_run.py` | Production sorting. Sorting-template bar; flow-grid of slot cards + per-slot headstamp checkboxes with live counts; Start/Stop/Manual-feed; package-mode counters. The largest UI module. |
 | **Models** | `tab_models.py` | Model library: browse/filter, create, edit, **activate**, import/export, delete. Synthetic "Use AI Config" row. |
 | **Train** | `tab_train.py` | Feed→capture→classify→label→save loop; "Sort While Training"; launches training (Install-PyTorch dialog if needed → progress dialog). |
 | **AI Config** | `tab_ai.py` | HTTP server config (endpoint/key/model/prompt/encoding), headstamp manager, single-shot test. Visible only in AI Config mode. |
@@ -275,7 +302,8 @@ Config shows in AI Config mode; Community is mounted only while signed in. The
 opt-in), `dialog_install_torch` (pip-installs torch/torchvision into the venv),
 `dialog_login` (MSAL interactive sign-in), `dialog_model_evaluator` (run eval +
 HTML report + history), `dialog_model_images` + `dialog_image_preview` (training
-image browser/reclassify/delete), `dialog_share_model` (publish to community).
+image browser/reclassify/delete), `dialog_share_model` (publish to community),
+`dialog_slot_template` (new / rename / delete a sorting template).
 
 ### Shared UI infrastructure
 - **`theme.py`** — `PALETTE` (dark slate theme), `apply_theme(root)` (fonts +

--- a/sorter/config.py
+++ b/sorter/config.py
@@ -15,7 +15,13 @@ import copy
 from typing import Any
 
 from .db import Database
-from .repository import HeadstampParentRepo, HeadstampRepo, SettingsRepo
+from .models import SLOT_TEMPLATE_MODES, SlotTemplate
+from .repository import (
+    HeadstampParentRepo,
+    HeadstampRepo,
+    SettingsRepo,
+    SlotTemplateRepo,
+)
 
 
 DEFAULT_INIT_SETTINGS: dict[str, int | str] = {
@@ -120,6 +126,17 @@ DEFAULT_PACKAGE_SIZE = 50
 # any slot is auto-routed to the first empty slot.
 _RUN_AUTO_SELECT_KEY = "run_auto_select_trays"
 
+# Sorting templates: named layouts of the Run tab's slot assignments, so one
+# model can carry several bin arrangements. The live assignments (the
+# `headstamps`/`headstamp_parents` slot columns and the package slot map) stay
+# the single source of truth a run reads; the *active* template is kept in
+# lock-step with them (see `sync_active_slot_template`) so switching templates
+# is a straight save-current / load-next swap. Templates are per model AND per
+# run mode — package mode's many-to-many assignments are a different shape.
+# Key: `active_slot_template:<model id|ai>:<mode>` -> template row id.
+_ACTIVE_TEMPLATE_KEY = "active_slot_template"
+DEFAULT_SLOT_TEMPLATE_NAME = "Default"
+
 # Sort While Training: send xf:<slot> for a labelled case instead of xf:0
 # during training.
 _SORT_WHILE_TRAINING_KEY = "sort_while_training"
@@ -154,6 +171,7 @@ class Config:
         self.settings = SettingsRepo(db)
         self.headstamps_repo = HeadstampRepo(db)
         self.parents_repo = HeadstampParentRepo(db)
+        self.templates_repo = SlotTemplateRepo(db)
         self.data: dict[str, Any] = copy.deepcopy(DEFAULTS)
 
     def load(self) -> "Config":
@@ -231,6 +249,8 @@ class Config:
                 return False
             current.append({"name": name, "slot": int(slot)})
             self._write_ai_headstamps(current)
+            if int(slot) > 0:
+                self.sync_active_slot_template("standard")
             return True
         existing = {h.name for h in self.headstamps_repo.list_for_model(active_id)}
         if name in existing:
@@ -239,6 +259,8 @@ class Config:
             self.headstamps_repo.add(active_id, name, slot)
         except Exception:
             return False
+        if int(slot) > 0:
+            self.sync_active_slot_template("standard")
         return True
 
     def remove_headstamp(self, name: str) -> bool:
@@ -289,11 +311,13 @@ class Config:
                 if entry["name"] == name:
                     entry["slot"] = int(slot)
                     self._write_ai_headstamps(current)
+                    self.sync_active_slot_template("standard")
                     return True
             return False
         for h in self.headstamps_repo.list_for_model(active_id):
             if h.name == name:
                 self.headstamps_repo.update_slot(h.id, int(slot))
+                self.sync_active_slot_template("standard")
                 return True
         return False
 
@@ -393,6 +417,7 @@ class Config:
         if mid is None:
             return False
         self.parents_repo.update_slot(int(parent_id), int(slot))
+        self.sync_active_slot_template("standard")
         return True
 
     def parent_for_headstamp(self, name: str) -> str | None:
@@ -516,6 +541,263 @@ class Config:
             names = [n for n in names if n != name]
         raw[key] = names
         self.settings.set(self._package_slots_key(), raw)
+        self.sync_active_slot_template("package")
+
+    # ----- sorting templates --------------------------------------------------
+
+    def slot_template_mode(self) -> str:
+        """Which template list applies right now: 'package' or 'standard'."""
+        return "package" if self.run_package_mode else "standard"
+
+    @staticmethod
+    def _template_key_for(model_id: int | None, mode: str) -> str:
+        return f"{_ACTIVE_TEMPLATE_KEY}:{model_id if model_id is not None else 'ai'}:{mode}"
+
+    def _active_template_key(self, mode: str) -> str:
+        return self._template_key_for(self.settings.get_active_model_id(), mode)
+
+    def _resolve_template_mode(self, mode: str | None) -> str:
+        if mode is None:
+            return self.slot_template_mode()
+        if mode not in SLOT_TEMPLATE_MODES:
+            raise ValueError(f"Unsupported slot-template mode: {mode!r}")
+        return mode
+
+    def capture_slot_assignments(self, mode: str | None = None) -> dict[str, Any]:
+        """Snapshot the live slot assignments for `mode` into a template payload.
+
+        Only non-catch-all assignments are stored; anything not mentioned is
+        restored to slot 0 (unassigned) when the payload is applied.
+        """
+        mode = self._resolve_template_mode(mode)
+        if mode == "package":
+            return {
+                "slots": {
+                    str(int(slot)): list(names)
+                    for slot, names in sorted(self.package_slot_map().items())
+                    if int(slot) > 0 and names
+                }
+            }
+        return {
+            "headstamps": {
+                str(e["name"]): int(e.get("slot", 0))
+                for e in self.headstamps
+                if int(e.get("slot", 0)) > 0
+            },
+            "parents": {
+                str(p["name"]): int(p["slot"])
+                for p in self.parents_with_slots()
+                if int(p["slot"]) > 0
+            },
+        }
+
+    def apply_slot_assignments(
+        self, assignments: dict[str, Any] | None, mode: str | None = None,
+    ) -> None:
+        """Write a template payload back onto the live assignments.
+
+        Names the payload doesn't mention are cleared to slot 0, so applying a
+        template fully replaces the layout rather than merging into it. Unknown
+        names (a headstamp deleted since the template was saved) are ignored.
+        """
+        mode = self._resolve_template_mode(mode)
+        data = assignments if isinstance(assignments, dict) else {}
+
+        if mode == "package":
+            raw = data.get("slots")
+            cleaned: dict[str, list[str]] = {}
+            if isinstance(raw, dict):
+                for key, names in raw.items():
+                    try:
+                        slot = int(key)
+                    except (TypeError, ValueError):
+                        continue
+                    if slot <= 0:
+                        continue
+                    cleaned[str(slot)] = [str(n) for n in (names or []) if n]
+            self.settings.set(self._package_slots_key(), cleaned)
+            return
+
+        hs_slots = data.get("headstamps") if isinstance(data.get("headstamps"), dict) else {}
+        parent_slots = data.get("parents") if isinstance(data.get("parents"), dict) else {}
+
+        def _slot_of(table: dict[str, Any], name: str) -> int:
+            try:
+                return max(0, int(table.get(name, 0)))
+            except (TypeError, ValueError):
+                return 0
+
+        mid = self.settings.get_active_model_id()
+        with self.db.transaction() as _:
+            if mid is None:
+                entries = self._read_ai_headstamps()
+                for entry in entries:
+                    entry["slot"] = _slot_of(hs_slots, entry["name"])
+                self._write_ai_headstamps(entries)
+                return
+            for h in self.headstamps_repo.list_for_model(mid):
+                desired = _slot_of(hs_slots, h.name)
+                if int(h.slot) != desired:
+                    self.headstamps_repo.update_slot(h.id, desired)
+            for p in self.parents_repo.list_for_model(mid):
+                desired = _slot_of(parent_slots, p.name)
+                if int(p.slot) != desired:
+                    self.parents_repo.update_slot(p.id, desired)
+
+    def list_slot_templates(self, mode: str | None = None) -> list[SlotTemplate]:
+        """Templates for the active model + `mode`, newest scope seeded lazily.
+
+        The first read of a scope with no templates creates "Default" holding
+        whatever is currently assigned, so upgrading users keep their layout
+        and land on a named template without doing anything.
+        """
+        mode = self._resolve_template_mode(mode)
+        mid = self.settings.get_active_model_id()
+        rows = self.templates_repo.list_for_scope(mid, mode)
+        if rows:
+            return rows
+        with self.db.transaction() as _:
+            template = self.templates_repo.create(
+                mid, mode, DEFAULT_SLOT_TEMPLATE_NAME,
+                self.capture_slot_assignments(mode),
+            )
+            self.settings.set(self._active_template_key(mode), template.id)
+        return [template]
+
+    def active_slot_template(self, mode: str | None = None) -> SlotTemplate:
+        """The template currently driving the live assignments for `mode`."""
+        mode = self._resolve_template_mode(mode)
+        rows = self.list_slot_templates(mode)
+        stored = self.settings.get(self._active_template_key(mode))
+        for row in rows:
+            if row.id == stored:
+                return row
+        # Pointer missing or stale (template deleted elsewhere): adopt the first
+        # one without applying it — the live assignments are what the user last
+        # worked on and the next sync writes them into it.
+        self.settings.set(self._active_template_key(mode), rows[0].id)
+        return rows[0]
+
+    def sync_active_slot_template(self, mode: str | None = None) -> None:
+        """Persist the live assignments into the active template.
+
+        Called after every slot-assignment mutation so the active template
+        never drifts from what the Run tab shows — there is no explicit "save
+        template" step.
+        """
+        mode = self._resolve_template_mode(mode)
+        template = self.active_slot_template(mode)
+        self.templates_repo.update_assignments(
+            template.id, self.capture_slot_assignments(mode),
+        )
+
+    def activate_slot_template(
+        self, template_id: int, mode: str | None = None,
+    ) -> SlotTemplate | None:
+        """Switch to another template: save the outgoing one, load the incoming.
+
+        Returns the newly active template, or None when `template_id` doesn't
+        belong to the active model + mode.
+        """
+        mode = self._resolve_template_mode(mode)
+        mid = self.settings.get_active_model_id()
+        target = self.templates_repo.get(int(template_id))
+        if target is None or target.mode != mode or target.model_id != mid:
+            return None
+        current = self.active_slot_template(mode)
+        if current.id == target.id:
+            return current
+        with self.db.transaction() as _:
+            self.templates_repo.update_assignments(
+                current.id, self.capture_slot_assignments(mode),
+            )
+            self.apply_slot_assignments(target.assignments, mode)
+            self.settings.set(self._active_template_key(mode), target.id)
+        return target
+
+    def create_slot_template(
+        self,
+        name: str,
+        *,
+        copy_current: bool = True,
+        mode: str | None = None,
+    ) -> SlotTemplate:
+        """Create a template and make it active.
+
+        With `copy_current` the new template starts as a copy of the live
+        assignments (the outgoing template keeps its own copy); without it the
+        slots are cleared so the user starts from a blank layout.
+
+        Raises ValueError on an empty or duplicate name.
+        """
+        mode = self._resolve_template_mode(mode)
+        name = (name or "").strip()
+        if not name:
+            raise ValueError("Enter a name for the template.")
+        mid = self.settings.get_active_model_id()
+        if self.templates_repo.find_by_name(mid, mode, name) is not None:
+            raise ValueError(f"A template named “{name}” already exists.")
+        current = self.active_slot_template(mode)
+        payload = (
+            self.capture_slot_assignments(mode) if copy_current
+            else ({"slots": {}} if mode == "package" else {"headstamps": {}, "parents": {}})
+        )
+        with self.db.transaction() as _:
+            # Flush the outgoing template first so nothing unsaved is lost.
+            self.templates_repo.update_assignments(
+                current.id, self.capture_slot_assignments(mode),
+            )
+            template = self.templates_repo.create(mid, mode, name, payload)
+            self.apply_slot_assignments(payload, mode)
+            self.settings.set(self._active_template_key(mode), template.id)
+        return template
+
+    def rename_slot_template(self, template_id: int, name: str) -> SlotTemplate | None:
+        """Rename a template. Raises ValueError on an empty or duplicate name."""
+        template = self.templates_repo.get(int(template_id))
+        if template is None:
+            return None
+        name = (name or "").strip()
+        if not name:
+            raise ValueError("Enter a name for the template.")
+        if name == template.name:
+            return template
+        clash = self.templates_repo.find_by_name(template.model_id, template.mode, name)
+        if clash is not None and clash.id != template.id:
+            raise ValueError(f"A template named “{name}” already exists.")
+        self.templates_repo.rename(template.id, name)
+        template.name = name
+        return template
+
+    def delete_slot_template(self, template_id: int) -> SlotTemplate | None:
+        """Delete a template and return whichever one is active afterwards.
+
+        Deleting the active template loads the next remaining one. The last
+        template in a scope can't be deleted — there is always somewhere for
+        the current assignments to live.
+        """
+        template = self.templates_repo.get(int(template_id))
+        if template is None:
+            return None
+        mode = template.mode
+        remaining = [
+            t for t in self.templates_repo.list_for_scope(template.model_id, mode)
+            if t.id != template.id
+        ]
+        if not remaining:
+            raise ValueError("A model needs at least one sorting template.")
+        key = self._template_key_for(template.model_id, mode)
+        was_active = self.settings.get(key) == template.id
+        # Only touch the live assignments when the template being deleted is
+        # the one currently loaded for the active model.
+        loaded = was_active and template.model_id == self.settings.get_active_model_id()
+        with self.db.transaction() as _:
+            self.templates_repo.delete(template.id)
+            if was_active:
+                if loaded:
+                    self.apply_slot_assignments(remaining[0].assignments, mode)
+                self.settings.set(key, remaining[0].id)
+        return remaining[0] if was_active else self.active_slot_template(mode)
 
     # ----- auto-select / sort-while-training toggles -------------------------
 

--- a/sorter/db.py
+++ b/sorter/db.py
@@ -19,7 +19,7 @@ from typing import Any, Iterator
 from . import paths
 
 
-SCHEMA_VERSION = 3
+SCHEMA_VERSION = 4
 
 SCHEMA_DDL = """
 PRAGMA foreign_keys = ON;
@@ -80,6 +80,24 @@ CREATE TABLE IF NOT EXISTS headstamps (
   UNIQUE(model_id, name)
 );
 CREATE INDEX IF NOT EXISTS idx_headstamps_model ON headstamps(model_id);
+
+-- Named slot-assignment layouts for the Run tab. Scoped to a model
+-- (model_id NULL = AI Config mode) and to a run mode ('standard'/'package'),
+-- which keep separate lists because their assignment rules differ.
+CREATE TABLE IF NOT EXISTS slot_templates (
+  id INTEGER PRIMARY KEY AUTOINCREMENT,
+  model_id INTEGER REFERENCES models(id) ON DELETE CASCADE,
+  mode TEXT NOT NULL CHECK(mode IN ('standard','package')),
+  name TEXT NOT NULL,
+  assignments_json TEXT NOT NULL DEFAULT '{}',
+  created_at TEXT NOT NULL DEFAULT (datetime('now')),
+  updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+);
+-- IFNULL() because UNIQUE treats every NULL model_id (AI Config mode) as
+-- distinct, which would let duplicate AI-mode template names through.
+CREATE UNIQUE INDEX IF NOT EXISTS idx_slot_templates_name
+  ON slot_templates(IFNULL(model_id, -1), mode, name COLLATE NOCASE);
+CREATE INDEX IF NOT EXISTS idx_slot_templates_scope ON slot_templates(model_id, mode);
 
 CREATE TABLE IF NOT EXISTS settings (
   key TEXT PRIMARY KEY,

--- a/sorter/models.py
+++ b/sorter/models.py
@@ -23,6 +23,10 @@ SUPPORTED_MODEL_MODES = (
 MODEL_TYPES = ("Standard", "ReadOnly", "CommunityManaged")
 FEEDBACK_UPLOAD_MODES = ("Instant", "OnRunComplete", "Manual")
 
+# Slot templates are stored per run mode: package mode has its own set because
+# it allows a headstamp in several slots (see SlotTemplate).
+SLOT_TEMPLATE_MODES = ("standard", "package")
+
 
 def normalize_upload_mode(raw: Any, *, feedback_enabled: bool) -> str:
     """Coerce a feedback upload-mode value to a canonical name string.
@@ -105,6 +109,50 @@ class HeadstampParent:
             name=row["name"],
             model_id=row["model_id"],
             slot=row["slot"] if "slot" in keys else 0,
+        )
+
+
+@dataclass
+class SlotTemplate:
+    """A named snapshot of the Run tab's slot assignments.
+
+    Templates let one model carry several bin layouts (e.g. "Range brass" vs
+    "Match prep") and switch between them without re-ticking every headstamp.
+
+    Scoping: templates belong to a model (``model_id is None`` = AI Config
+    mode) *and* to a ``mode``. Standard and package mode keep separate template
+    lists because their assignment rules differ — standard mode routes a
+    headstamp to exactly one slot, package mode allows the same headstamp in
+    several slots at once, so a layout from one is meaningless in the other.
+
+    ``assignments`` is the persisted payload, shaped per mode:
+      standard: ``{"headstamps": {name: slot}, "parents": {name: slot}}``
+      package:  ``{"slots": {"<slot>": [name, ...]}}``
+    Names, not row ids, so a template survives a headstamp being deleted and
+    re-added (e.g. a re-import). Unknown names are ignored when applied.
+    """
+    id: int | None = None
+    model_id: int | None = None
+    mode: str = "standard"
+    name: str = ""
+    assignments: dict[str, Any] = field(default_factory=dict)
+
+    @classmethod
+    def from_row(cls, row: Any) -> "SlotTemplate":
+        import json
+
+        try:
+            assignments = json.loads(row["assignments_json"] or "{}")
+        except (TypeError, ValueError):
+            assignments = {}
+        if not isinstance(assignments, dict):
+            assignments = {}
+        return cls(
+            id=row["id"],
+            model_id=row["model_id"],
+            mode=row["mode"],
+            name=row["name"],
+            assignments=assignments,
         )
 
 

--- a/sorter/repository.py
+++ b/sorter/repository.py
@@ -17,7 +17,9 @@ from .models import (
     HeadstampParent,
     ImageProcessingConfig,
     Model,
+    SLOT_TEMPLATE_MODES,
     SUPPORTED_MODEL_MODES,
+    SlotTemplate,
     TrainingConfig,
 )
 
@@ -348,6 +350,84 @@ class HeadstampParentRepo:
         self.db.conn.execute(
             "DELETE FROM headstamp_parents WHERE id = ?", (parent_id,)
         )
+
+
+class SlotTemplateRepo:
+    """CRUD for named slot-assignment layouts (see ``models.SlotTemplate``).
+
+    Every method is scoped by ``(model_id, mode)`` — ``model_id=None`` is AI
+    Config mode, and 'standard'/'package' never share a list.
+    """
+
+    def __init__(self, db: Database) -> None:
+        self.db = db
+
+    def list_for_scope(self, model_id: int | None, mode: str) -> list[SlotTemplate]:
+        rows = self.db.conn.execute(
+            "SELECT * FROM slot_templates "
+            "WHERE model_id IS ? AND mode = ? ORDER BY name COLLATE NOCASE",
+            (model_id, mode),
+        ).fetchall()
+        return [SlotTemplate.from_row(r) for r in rows]
+
+    def get(self, template_id: int) -> SlotTemplate | None:
+        row = self.db.conn.execute(
+            "SELECT * FROM slot_templates WHERE id = ?", (template_id,)
+        ).fetchone()
+        return SlotTemplate.from_row(row) if row else None
+
+    def find_by_name(
+        self, model_id: int | None, mode: str, name: str
+    ) -> SlotTemplate | None:
+        row = self.db.conn.execute(
+            "SELECT * FROM slot_templates "
+            "WHERE model_id IS ? AND mode = ? AND name = ? COLLATE NOCASE",
+            (model_id, mode, name),
+        ).fetchone()
+        return SlotTemplate.from_row(row) if row else None
+
+    def count_for_scope(self, model_id: int | None, mode: str) -> int:
+        return self.db.conn.execute(
+            "SELECT COUNT(*) FROM slot_templates WHERE model_id IS ? AND mode = ?",
+            (model_id, mode),
+        ).fetchone()[0]
+
+    def create(
+        self,
+        model_id: int | None,
+        mode: str,
+        name: str,
+        assignments: dict[str, Any] | None = None,
+    ) -> SlotTemplate:
+        if mode not in SLOT_TEMPLATE_MODES:
+            raise ValueError(f"Unsupported slot-template mode: {mode!r}")
+        payload = assignments or {}
+        cur = self.db.conn.execute(
+            "INSERT INTO slot_templates(model_id, mode, name, assignments_json) "
+            "VALUES (?, ?, ?, ?)",
+            (model_id, mode, name, json.dumps(payload)),
+        )
+        return SlotTemplate(
+            id=cur.lastrowid, model_id=model_id, mode=mode,
+            name=name, assignments=payload,
+        )
+
+    def rename(self, template_id: int, new_name: str) -> None:
+        self.db.conn.execute(
+            "UPDATE slot_templates SET name = ?, updated_at = datetime('now') "
+            "WHERE id = ?",
+            (new_name, template_id),
+        )
+
+    def update_assignments(self, template_id: int, assignments: dict[str, Any]) -> None:
+        self.db.conn.execute(
+            "UPDATE slot_templates SET assignments_json = ?, "
+            "updated_at = datetime('now') WHERE id = ?",
+            (json.dumps(assignments or {}), template_id),
+        )
+
+    def delete(self, template_id: int) -> None:
+        self.db.conn.execute("DELETE FROM slot_templates WHERE id = ?", (template_id,))
 
 
 class SettingsRepo:

--- a/sorter/ui/dialog_slot_template.py
+++ b/sorter/ui/dialog_slot_template.py
@@ -1,0 +1,183 @@
+"""Modal dialogs for the Run tab's sorting templates.
+
+Two small dialogs, both driven by ``Config``'s template API:
+
+  * ``NewSlotTemplateDialog``  — name + "copy current layout" / "start empty"
+  * ``EditSlotTemplateDialog`` — rename, or delete (never the last one)
+
+They deliberately stay tiny: the template list itself lives in the Run tab's
+toolbar, so these only handle the two operations that need typing.
+"""
+from __future__ import annotations
+
+import tkinter as tk
+from tkinter import messagebox, ttk
+from typing import Callable
+
+
+def _mode_noun(mode: str) -> str:
+    """Wording that reminds the user which template list they're editing."""
+    return "package-mode " if mode == "package" else ""
+
+
+class _TemplateDialog(tk.Toplevel):
+    """Shared chrome: transient, non-resizable, Return/Escape bindings."""
+
+    def __init__(self, parent: tk.Misc, title: str) -> None:
+        super().__init__(parent)
+        self.title(title)
+        self.transient(parent)
+        self.resizable(False, False)
+
+        self.body = ttk.Frame(self, padding=(14, 12, 14, 8))
+        self.body.pack(fill=tk.BOTH, expand=True)
+
+        self.buttons = ttk.Frame(self, padding=(14, 0, 14, 12))
+        self.buttons.pack(fill=tk.X)
+
+        self.bind("<Escape>", lambda _e: self.destroy())
+
+    def _name_entry(self, variable: tk.StringVar) -> ttk.Entry:
+        ttk.Label(self.body, text="Template name", style="Muted.TLabel")\
+            .pack(anchor=tk.W)
+        entry = ttk.Entry(self.body, textvariable=variable, width=34)
+        entry.pack(fill=tk.X, pady=(3, 0))
+        entry.focus_set()
+        return entry
+
+
+class NewSlotTemplateDialog(_TemplateDialog):
+    """Create a sorting template, optionally seeded from the current layout."""
+
+    def __init__(
+        self,
+        parent: tk.Misc,
+        *,
+        config,
+        mode: str,
+        current_name: str,
+        on_created: Callable[[object], None] | None = None,
+    ) -> None:
+        super().__init__(parent, "New Sorting Template")
+        self.config_obj = config
+        self.mode = mode
+        self.on_created = on_created
+
+        self.name_var = tk.StringVar()
+        entry = self._name_entry(self.name_var)
+
+        ttk.Separator(self.body, orient=tk.HORIZONTAL).pack(fill=tk.X, pady=(12, 8))
+
+        self.copy_var = tk.BooleanVar(value=True)
+        ttk.Radiobutton(
+            self.body, text=f"Copy the slot assignments from “{current_name}”",
+            variable=self.copy_var, value=True,
+        ).pack(anchor=tk.W)
+        ttk.Radiobutton(
+            self.body, text="Start fresh with no slot assignments",
+            variable=self.copy_var, value=False,
+        ).pack(anchor=tk.W, pady=(2, 0))
+
+        ttk.Label(
+            self.body,
+            text=(
+                f"Saved as a {_mode_noun(mode)}template for the active model. "
+                "Switching templates swaps the whole slot layout."
+            ),
+            style="Subtle.TLabel", wraplength=330, justify=tk.LEFT,
+        ).pack(anchor=tk.W, pady=(10, 0))
+
+        ttk.Button(self.buttons, text="Cancel", command=self.destroy)\
+            .pack(side=tk.RIGHT, padx=(8, 0))
+        ttk.Button(
+            self.buttons, text="Create", command=self._create, style="Accent.TButton",
+        ).pack(side=tk.RIGHT)
+
+        entry.bind("<Return>", lambda _e: self._create())
+
+    def _create(self) -> None:
+        try:
+            template = self.config_obj.create_slot_template(
+                self.name_var.get(), copy_current=self.copy_var.get(), mode=self.mode,
+            )
+        except ValueError as exc:
+            messagebox.showwarning("Can't create template", str(exc), parent=self)
+            return
+        if self.on_created is not None:
+            self.on_created(template)
+        self.destroy()
+
+
+class EditSlotTemplateDialog(_TemplateDialog):
+    """Rename or delete an existing sorting template."""
+
+    def __init__(
+        self,
+        parent: tk.Misc,
+        *,
+        config,
+        template,
+        can_delete: bool,
+        on_changed: Callable[[object | None], None] | None = None,
+    ) -> None:
+        super().__init__(parent, "Edit Sorting Template")
+        self.config_obj = config
+        self.template = template
+        self.on_changed = on_changed
+
+        self.name_var = tk.StringVar(value=template.name)
+        entry = self._name_entry(self.name_var)
+        entry.selection_range(0, tk.END)
+
+        ttk.Label(
+            self.body,
+            text=(
+                f"A {_mode_noun(template.mode)}template for the active model. "
+                + (
+                    "Deleting one drops its slot layout — the headstamps themselves "
+                    "are untouched."
+                    if can_delete
+                    else "This is the only one, so it can't be deleted."
+                )
+            ),
+            style="Subtle.TLabel", wraplength=330, justify=tk.LEFT,
+        ).pack(anchor=tk.W, pady=(10, 2))
+
+        if can_delete:
+            ttk.Button(
+                self.buttons, text="Delete", command=self._delete, style="Danger.TButton",
+            ).pack(side=tk.LEFT, padx=(0, 12))
+        ttk.Button(self.buttons, text="Cancel", command=self.destroy)\
+            .pack(side=tk.RIGHT, padx=(8, 0))
+        ttk.Button(
+            self.buttons, text="Save", command=self._save, style="Accent.TButton",
+        ).pack(side=tk.RIGHT)
+
+        entry.bind("<Return>", lambda _e: self._save())
+
+    def _save(self) -> None:
+        try:
+            self.config_obj.rename_slot_template(self.template.id, self.name_var.get())
+        except ValueError as exc:
+            messagebox.showwarning("Can't rename template", str(exc), parent=self)
+            return
+        if self.on_changed is not None:
+            self.on_changed(self.template)
+        self.destroy()
+
+    def _delete(self) -> None:
+        if not messagebox.askyesno(
+            "Delete template",
+            f"Delete the sorting template “{self.template.name}”?\n\n"
+            "Its slot assignments are lost; the headstamps themselves are untouched.",
+            parent=self,
+        ):
+            return
+        try:
+            active = self.config_obj.delete_slot_template(self.template.id)
+        except ValueError as exc:
+            messagebox.showwarning("Can't delete template", str(exc), parent=self)
+            return
+        if self.on_changed is not None:
+            self.on_changed(active)
+        self.destroy()

--- a/sorter/ui/tab_run.py
+++ b/sorter/ui/tab_run.py
@@ -766,6 +766,33 @@ class RunTab(ttk.Frame):
         grid_box = ttk.LabelFrame(top_pane, text="Slots")
         grid_box.pack(fill=tk.BOTH, expand=True, padx=6, pady=6)
 
+        # Sorting-template bar: the slot layout below is whatever the selected
+        # template holds. Package mode has its own template list (its
+        # assignments are many-to-many), so this bar re-populates on mode change.
+        self._templates: list = []
+        template_bar = ttk.Frame(grid_box)
+        template_bar.pack(fill=tk.X, padx=8, pady=(8, 0))
+        ttk.Label(template_bar, text="Sorting template", style="Muted.TLabel")\
+            .pack(side=tk.LEFT, padx=(0, 8))
+        self._template_var = tk.StringVar()
+        self._template_combo = ttk.Combobox(
+            template_bar, state="readonly", textvariable=self._template_var, width=26,
+        )
+        self._template_combo.pack(side=tk.LEFT)
+        self._template_combo.bind(
+            "<<ComboboxSelected>>", lambda _e: self._on_template_selected()
+        )
+        ttk.Button(
+            template_bar, text="+ New", width=7, command=self._new_template,
+        ).pack(side=tk.LEFT, padx=(6, 0))
+        ttk.Button(
+            template_bar, text="✎ Edit", width=7, command=self._edit_template,
+        ).pack(side=tk.LEFT, padx=(4, 0))
+        self._template_hint_var = tk.StringVar(value="")
+        ttk.Label(
+            template_bar, textvariable=self._template_hint_var, style="Subtle.TLabel",
+        ).pack(side=tk.LEFT, padx=(10, 0))
+
         self.slot_grid = SlotGrid(grid_box)
         self.slot_grid.pack(fill=tk.BOTH, expand=True, padx=4, pady=4)
 
@@ -948,6 +975,7 @@ class RunTab(ttk.Frame):
         self.details.pack(fill=tk.BOTH, expand=True, padx=6, pady=6)
 
         self._build_slot_cards()
+        self._refresh_templates()
         self._refresh_card_headstamps()
         self._update_parent_option_visibility()
         # Initial sash placement once the FlowGrid has a real width.
@@ -1084,6 +1112,84 @@ class RunTab(ttk.Frame):
         for card in self._slot_cards:
             card.set_headstamps(sorted(slot_map.get(card.slot_number, []), key=str.casefold))
 
+    # ----- sorting templates --------------------------------------------------
+
+    def _refresh_templates(self) -> None:
+        """Repopulate the dropdown for the active model + current run mode."""
+        mode = self.config.slot_template_mode()
+        self._templates = self.config.list_slot_templates(mode)
+        active = self.config.active_slot_template(mode)
+        self._template_combo["values"] = [t.name for t in self._templates]
+        self._template_var.set(active.name)
+        self._template_hint_var.set(
+            "Package-mode layout" if mode == "package" else ""
+        )
+
+    def _template_busy(self) -> bool:
+        """Templates swap the whole layout, so keep them out of a live run."""
+        if not self._is_running:
+            return False
+        messagebox.showinfo(
+            "Run in progress",
+            "Stop the run before changing sorting templates — switching one "
+            "reassigns every slot.",
+            parent=self,
+        )
+        return True
+
+    def _on_template_selected(self) -> None:
+        idx = self._template_combo.current()
+        if idx < 0 or idx >= len(self._templates):
+            return
+        target = self._templates[idx]
+        if self._template_busy():
+            self._refresh_templates()  # snap the combobox back to the active one
+            return
+        if self.config.activate_slot_template(target.id) is None:
+            self._refresh_templates()
+            return
+        self._after_template_change(f"Loaded sorting template “{target.name}”.")
+
+    def _new_template(self) -> None:
+        if self._template_busy():
+            return
+        from .dialog_slot_template import NewSlotTemplateDialog
+
+        mode = self.config.slot_template_mode()
+        NewSlotTemplateDialog(
+            self, config=self.config, mode=mode,
+            current_name=self.config.active_slot_template(mode).name,
+            on_created=lambda t: self._after_template_change(
+                f"Created sorting template “{t.name}”."
+            ),
+        )
+
+    def _edit_template(self) -> None:
+        if self._template_busy():
+            return
+        from .dialog_slot_template import EditSlotTemplateDialog
+
+        mode = self.config.slot_template_mode()
+        EditSlotTemplateDialog(
+            self, config=self.config,
+            template=self.config.active_slot_template(mode),
+            can_delete=len(self.config.list_slot_templates(mode)) > 1,
+            on_changed=lambda _t: self._after_template_change("Sorting templates updated."),
+        )
+
+    def _after_template_change(self, status: str) -> None:
+        """Re-render everything the layout drives, then report what happened.
+
+        Counters are per-layout, so they're zeroed — a slot that held one
+        headstamp before the swap may hold another now.
+        """
+        self._refresh_templates()
+        self._reset_counters()
+        self._refresh_card_headstamps()
+        if self.details.current_slot is not None:
+            self.details.show_slot(self.details.current_slot)
+        self.app.set_status(status)
+
     def _update_parent_option_visibility(self) -> None:
         """Show the parent-classification toggle only when the active model has
         parent groups; sync its checked state from the persisted preference."""
@@ -1143,8 +1249,10 @@ class RunTab(ttk.Frame):
             self._batch_row.pack_forget()
         for card in self._slot_cards:
             card.set_package_mode(enabled)
-        # Counts and assignments are mode-specific; reset and re-render both.
+        # Counts, assignments and templates are all mode-specific; package mode
+        # swaps to its own template list (and its own stored layout).
         self._reset_counters()
+        self._refresh_templates()
         self._refresh_card_headstamps()
         if self.details.current_slot is not None:
             self.details.show_slot(self.details.current_slot)
@@ -1225,6 +1333,7 @@ class RunTab(ttk.Frame):
         """
         self._reset_counters()
         self._update_parent_option_visibility()
+        self._refresh_templates()
         self._refresh_card_headstamps()
         if self.details.current_slot is not None:
             self.details.show_slot(self.details.current_slot)

--- a/tests/test_slot_templates.py
+++ b/tests/test_slot_templates.py
@@ -1,0 +1,251 @@
+"""Sorting templates: named slot layouts per model + run mode."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sorter.config import Config, DEFAULT_SLOT_TEMPLATE_NAME
+from sorter.db import Database
+from sorter.models import Model
+from sorter.repository import HeadstampParentRepo, ModelRepo, SettingsRepo, SlotTemplateRepo
+
+
+def _new_db(tmp_path: Path) -> Database:
+    db = Database(tmp_path / "templates.db")
+    db.ensure_initialized()
+    return db
+
+
+def _activate_seeded_model(db: Database) -> int:
+    seed = ModelRepo(db).list()[0]
+    SettingsRepo(db).set_active_model_id(seed.id)
+    return seed.id
+
+
+def _cfg(tmp_path: Path) -> Config:
+    db = _new_db(tmp_path)
+    _activate_seeded_model(db)
+    cfg = Config(db).load()
+    cfg.add_headstamp("WIN")
+    cfg.add_headstamp("FC")
+    cfg.add_headstamp("CBC")
+    return cfg
+
+
+def _slots(cfg: Config) -> dict[str, int]:
+    return {h["name"]: int(h["slot"]) for h in cfg.headstamps}
+
+
+# ----- seeding ---------------------------------------------------------------
+
+
+def test_default_template_seeded_from_existing_assignments(tmp_path: Path) -> None:
+    """Upgrading users keep their layout: it becomes the "Default" template."""
+    cfg = _cfg(tmp_path)
+    cfg.set_headstamp_slot("WIN", 3)
+
+    templates = cfg.list_slot_templates()
+    assert [t.name for t in templates] == [DEFAULT_SLOT_TEMPLATE_NAME]
+    assert cfg.active_slot_template().assignments["headstamps"] == {"WIN": 3}
+
+
+def test_assignment_changes_sync_into_the_active_template(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    active = cfg.active_slot_template()
+    cfg.set_headstamp_slot("FC", 2)
+
+    stored = SlotTemplateRepo(cfg.db).get(active.id)
+    assert stored.assignments["headstamps"] == {"FC": 2}
+
+
+# ----- create / switch -------------------------------------------------------
+
+
+def test_create_copy_keeps_layout_and_switching_restores_each(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    cfg.set_headstamp_slot("WIN", 3)
+    default = cfg.active_slot_template()
+
+    match = cfg.create_slot_template("Match prep", copy_current=True)
+    assert _slots(cfg)["WIN"] == 3            # copied layout stays live
+    cfg.set_headstamp_slot("WIN", 5)          # diverge from Default
+
+    cfg.activate_slot_template(default.id)
+    assert _slots(cfg)["WIN"] == 3
+
+    cfg.activate_slot_template(match.id)
+    assert _slots(cfg)["WIN"] == 5
+
+
+def test_create_fresh_clears_the_live_layout(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    cfg.set_headstamp_slot("WIN", 3)
+    cfg.set_headstamp_slot("FC", 4)
+    default = cfg.active_slot_template()
+
+    cfg.create_slot_template("Blank", copy_current=False)
+    assert _slots(cfg) == {"WIN": 0, "FC": 0, "CBC": 0}
+
+    # ...and the template we came from kept its own assignments.
+    cfg.activate_slot_template(default.id)
+    assert _slots(cfg) == {"WIN": 3, "FC": 4, "CBC": 0}
+
+
+def test_applying_a_template_clears_slots_it_does_not_mention(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    default = cfg.active_slot_template()
+    other = cfg.create_slot_template("Other", copy_current=False)
+    cfg.set_headstamp_slot("CBC", 6)
+
+    cfg.activate_slot_template(default.id)
+    assert _slots(cfg)["CBC"] == 0
+    cfg.activate_slot_template(other.id)
+    assert _slots(cfg)["CBC"] == 6
+
+
+def test_parent_slots_travel_with_the_template(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    mid = cfg.settings.get_active_model_id()
+    parent = HeadstampParentRepo(cfg.db).add(mid, "Federal")
+    cfg.set_parent_slot(parent.id, 4)
+    default = cfg.active_slot_template()
+
+    cfg.create_slot_template("No parents", copy_current=False)
+    assert cfg.parents_with_slots()[0]["slot"] == 0
+
+    cfg.activate_slot_template(default.id)
+    assert cfg.parents_with_slots()[0]["slot"] == 4
+
+
+def test_duplicate_names_are_rejected_case_insensitively(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    cfg.create_slot_template("Range brass")
+    with pytest.raises(ValueError):
+        cfg.create_slot_template("range BRASS")
+    with pytest.raises(ValueError):
+        cfg.create_slot_template("   ")
+
+
+# ----- rename / delete -------------------------------------------------------
+
+
+def test_rename_and_duplicate_rename(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    default = cfg.active_slot_template()
+    other = cfg.create_slot_template("Other")
+
+    cfg.rename_slot_template(other.id, "Renamed")
+    assert cfg.active_slot_template().name == "Renamed"
+    with pytest.raises(ValueError):
+        cfg.rename_slot_template(other.id, default.name)
+
+
+def test_delete_active_template_loads_the_next_one(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    cfg.set_headstamp_slot("WIN", 3)
+    default = cfg.active_slot_template()
+    fresh = cfg.create_slot_template("Fresh", copy_current=False)
+
+    now_active = cfg.delete_slot_template(fresh.id)
+    assert now_active.id == default.id
+    assert _slots(cfg)["WIN"] == 3            # Default's layout came back
+
+
+def test_delete_inactive_template_leaves_the_layout_alone(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    default = cfg.active_slot_template()
+    cfg.create_slot_template("Scratch", copy_current=False)
+    cfg.set_headstamp_slot("FC", 7)
+
+    cfg.delete_slot_template(default.id)
+    assert _slots(cfg)["FC"] == 7
+
+
+def test_last_template_cannot_be_deleted(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    only = cfg.active_slot_template()
+    with pytest.raises(ValueError):
+        cfg.delete_slot_template(only.id)
+
+
+# ----- scoping ---------------------------------------------------------------
+
+
+def test_package_mode_has_its_own_template_list(tmp_path: Path) -> None:
+    cfg = _cfg(tmp_path)
+    cfg.create_slot_template("Standard only")
+    assert cfg.slot_template_mode() == "standard"
+
+    cfg.set_run_package_mode(True)
+    assert cfg.slot_template_mode() == "package"
+    assert [t.name for t in cfg.list_slot_templates()] == [DEFAULT_SLOT_TEMPLATE_NAME]
+
+    # Package assignments are many-to-many and swap as a unit.
+    cfg.set_package_slot_headstamp(1, "WIN", True)
+    cfg.set_package_slot_headstamp(2, "WIN", True)
+    packed = cfg.active_slot_template()
+    cfg.create_slot_template("Empty batch", copy_current=False)
+    assert cfg.slots_for_headstamp_package("WIN") == []
+
+    cfg.activate_slot_template(packed.id)
+    assert cfg.slots_for_headstamp_package("WIN") == [1, 2]
+
+    # Standard-mode templates are untouched by any of that.
+    cfg.set_run_package_mode(False)
+    assert sorted(t.name for t in cfg.list_slot_templates()) == [
+        DEFAULT_SLOT_TEMPLATE_NAME, "Standard only",
+    ]
+
+
+def test_templates_are_scoped_per_model(tmp_path: Path) -> None:
+    db = _new_db(tmp_path)
+    first = _activate_seeded_model(db)
+    cfg = Config(db).load()
+    cfg.add_headstamp("WIN", slot=2)
+    cfg.create_slot_template("Model one layout")
+
+    models = ModelRepo(db)
+    second = models.create(Model(
+        name="Second", cartridge_id=models.get(first).cartridge_id,
+        model_mode="convnext_tiny",
+    ))
+    SettingsRepo(db).set_active_model_id(second.id)
+
+    assert [t.name for t in cfg.list_slot_templates()] == [DEFAULT_SLOT_TEMPLATE_NAME]
+    SettingsRepo(db).set_active_model_id(first)
+    assert sorted(t.name for t in cfg.list_slot_templates()) == [
+        DEFAULT_SLOT_TEMPLATE_NAME, "Model one layout",
+    ]
+
+
+def test_ai_config_mode_has_its_own_templates(tmp_path: Path) -> None:
+    db = _new_db(tmp_path)
+    cfg = Config(db).load()          # no active model -> AI Config mode
+    cfg.add_headstamp("WIN")
+    cfg.set_headstamp_slot("WIN", 4)
+
+    template = cfg.active_slot_template()
+    assert template.model_id is None
+    assert template.assignments["headstamps"] == {"WIN": 4}
+
+    cfg.create_slot_template("AI blank", copy_current=False)
+    assert _slots(cfg) == {"WIN": 0}
+    cfg.activate_slot_template(template.id)
+    assert _slots(cfg) == {"WIN": 4}
+
+
+def test_templates_are_dropped_with_their_model(tmp_path: Path) -> None:
+    db = _new_db(tmp_path)
+    first = _activate_seeded_model(db)
+    cfg = Config(db).load()
+    cfg.create_slot_template("Doomed")
+
+    models = ModelRepo(db)
+    keeper = models.create(Model(
+        name="Keeper", cartridge_id=models.get(first).cartridge_id,
+        model_mode="convnext_tiny",
+    ))
+    models.delete(first, replacement_active_id=keeper.id)
+
+    assert SlotTemplateRepo(db).list_for_scope(first, "standard") == []

--- a/tests/test_tab_run_templates.py
+++ b/tests/test_tab_run_templates.py
@@ -1,0 +1,145 @@
+"""Run-tab sorting-template bar wiring (needs a Tk display)."""
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("tkinter")
+pytest.importorskip("cv2")
+
+import tkinter as tk  # noqa: E402
+
+from sorter.config import Config, DEFAULT_SLOT_TEMPLATE_NAME  # noqa: E402
+from sorter.db import Database  # noqa: E402
+from sorter.events import EventBus  # noqa: E402
+from sorter.repository import ModelRepo, SettingsRepo  # noqa: E402
+from sorter.ui.tab_run import RunTab  # noqa: E402
+
+
+@pytest.fixture
+def root():
+    try:
+        r = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no Tk display: {exc}")
+    r.withdraw()
+    yield r
+    r.destroy()
+
+
+class _FakeApp:
+    def __init__(self, db, root) -> None:
+        self.db = db
+        self.root = root
+        self.auth = None
+        self.run_controller = None
+        self.broker = None
+        self.status = ""
+
+    def run_worker(self, fn, *, on_done=None, on_error=None):
+        pass
+
+    def set_status(self, msg):
+        self.status = msg
+
+
+def _make(root, tmp_path, monkeypatch):
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    db = Database(tmp_path / "ui.db")
+    db.ensure_initialized()
+    seed = ModelRepo(db).list()[0]
+    SettingsRepo(db).set_active_model_id(seed.id)
+    cfg = Config(db).load()
+    cfg.add_headstamp("CBC")
+    cfg.add_headstamp("FC")
+    app = _FakeApp(db, root)
+    tab = RunTab(root, config=cfg, bus=EventBus(), app=app)
+    return tab, app, cfg
+
+
+def test_bar_shows_the_default_template(root, tmp_path, monkeypatch) -> None:
+    tab, _app, _cfg = _make(root, tmp_path, monkeypatch)
+    try:
+        assert list(tab._template_combo["values"]) == [DEFAULT_SLOT_TEMPLATE_NAME]
+        assert tab._template_var.get() == DEFAULT_SLOT_TEMPLATE_NAME
+        assert tab._template_hint_var.get() == ""
+    finally:
+        tab.destroy()
+
+
+def test_selecting_a_template_applies_its_layout(root, tmp_path, monkeypatch) -> None:
+    tab, app, cfg = _make(root, tmp_path, monkeypatch)
+    try:
+        cfg.set_headstamp_slot("CBC", 2)
+        default = cfg.active_slot_template()
+        cfg.create_slot_template("Blank", copy_current=False)
+        tab._refresh_templates()
+
+        tab._template_combo.current(
+            [t.name for t in tab._templates].index(default.name)
+        )
+        tab._on_template_selected()
+
+        assert cfg.active_slot_template().id == default.id
+        assert {h["name"]: h["slot"] for h in cfg.headstamps}["CBC"] == 2
+        assert "Default" in app.status
+        # Slot cards re-rendered against the loaded layout.
+        card = next(c for c in tab._slot_cards if c.slot_number == 2)
+        assert card._headstamps_var.get() == "CBC"
+    finally:
+        tab.destroy()
+
+
+def test_package_mode_swaps_the_template_list(root, tmp_path, monkeypatch) -> None:
+    tab, _app, cfg = _make(root, tmp_path, monkeypatch)
+    try:
+        cfg.create_slot_template("Standard only")
+        tab._refresh_templates()
+        assert "Standard only" in list(tab._template_combo["values"])
+
+        tab._package_var.set(True)
+        tab._on_toggle_package_mode()
+        assert list(tab._template_combo["values"]) == [DEFAULT_SLOT_TEMPLATE_NAME]
+        assert tab._template_hint_var.get() == "Package-mode layout"
+
+        tab._package_var.set(False)
+        tab._on_toggle_package_mode()
+        assert "Standard only" in list(tab._template_combo["values"])
+    finally:
+        tab.destroy()
+
+
+def test_templates_are_locked_while_a_run_is_active(root, tmp_path, monkeypatch) -> None:
+    tab, _app, cfg = _make(root, tmp_path, monkeypatch)
+    try:
+        default = cfg.active_slot_template()
+        other = cfg.create_slot_template("Other", copy_current=False)
+        tab._refresh_templates()
+        tab._set_running(True)
+
+        warned = {}
+        monkeypatch.setattr(
+            "sorter.ui.tab_run.messagebox.showinfo",
+            lambda *a, **k: warned.setdefault("shown", True),
+        )
+        tab._template_combo.current(
+            [t.name for t in tab._templates].index(default.name)
+        )
+        tab._on_template_selected()
+
+        assert warned.get("shown") is True
+        assert cfg.active_slot_template().id == other.id     # unchanged
+        assert tab._template_var.get() == other.name         # combobox snapped back
+    finally:
+        tab.destroy()
+
+
+def test_active_model_change_reloads_the_template_list(root, tmp_path, monkeypatch) -> None:
+    tab, _app, cfg = _make(root, tmp_path, monkeypatch)
+    try:
+        cfg.create_slot_template("Model one")
+        tab._refresh_templates()
+        SettingsRepo(cfg.db).clear_active_model()      # -> AI Config mode
+        tab._on_active_model_changed()
+        assert list(tab._template_combo["values"]) == [DEFAULT_SLOT_TEMPLATE_NAME]
+    finally:
+        tab.destroy()


### PR DESCRIPTION
## Summary
Introduces a **sorting templates** feature that lets users save and switch between named slot-assignment layouts without re-ticking every headstamp. Templates are scoped per model and per run mode (standard vs. package), with automatic seeding from existing assignments on first access.

## Key Changes

**Data model & persistence:**
- Add `slot_templates` table to schema (SCHEMA_VERSION 4) with model_id, mode, name, and JSON-encoded assignments
- Add `SlotTemplate` dataclass in `models.py` with `SLOT_TEMPLATE_MODES = ("standard", "package")`
- Add `SlotTemplateRepo` in `repository.py` with full CRUD: `list_for_scope()`, `get()`, `find_by_name()`, `create()`, `rename()`, `update_assignments()`, `delete()`

**Config API (`config.py`):**
- `capture_slot_assignments(mode)` — snapshot live assignments into a template payload (headstamps + parents for standard mode, slot→names map for package mode)
- `apply_slot_assignments(assignments, mode)` — restore a template payload to live assignments (clears unmentioned names to slot 0)
- `list_slot_templates(mode)` — list templates for active model + mode; lazily seeds "Default" from current layout on first read (upgrades users keep their layout)
- `active_slot_template(mode)` — get the currently active template; adopts first one if pointer is stale
- `sync_active_slot_template(mode)` — persist live assignments into the active template (called after every slot mutation)
- `activate_slot_template(template_id, mode)` — switch templates: save outgoing, load incoming, update pointer
- `create_slot_template(name, copy_current, mode)` — create and activate a new template
- `rename_slot_template(template_id, new_name)` — rename with duplicate-name validation
- `delete_slot_template(template_id)` — delete (never the last one); loads next if deleting active
- `slot_template_mode()` — return "package" or "standard" based on run mode

All slot-mutation methods (`add_headstamp`, `set_headstamp_slot`, `set_parent_slot`, `set_package_slot_headstamp`) now call `sync_active_slot_template()` to keep the active template in lock-step with live assignments.

**UI (`tab_run.py`):**
- Add template dropdown + "New" / "Edit" buttons in the Slots grid header
- `_refresh_templates()` — repopulate dropdown for active model + current mode
- `_on_template_selected()` — load selected template (blocked during active run)
- `_new_template()` — spawn `NewSlotTemplateDialog`
- `_edit_template()` — spawn `EditSlotTemplateDialog`
- `_after_template_change()` — refresh UI and post status message

**Dialogs (`ui/dialog_slot_template.py`):**
- `NewSlotTemplateDialog` — name entry + radio buttons for "copy current" / "start fresh"
- `EditSlotTemplateDialog` — rename or delete (with confirmation); delete button hidden if it's the only template

**Tests:**
- `tests/test_slot_templates.py` — 20 tests covering seeding, create/switch, parent slots, duplicate names, rename/delete, scoping (per model, per mode, AI Config mode), and cascade delete
- `tests/test_tab_run_templates.py` — 6 UI tests for dropdown, selection, package-mode swap, run-time locking, and model-change reload

## Notable Implementation Details

- **Lazy seeding:** First read of a scope with no templates creates "Default" holding current assignments, so upgrading users land on a named template without action
- **Dual-mode scoping:** Standard and package modes keep separate template lists because their assignment rules differ (1:1 vs. many-to-many)
- **AI Config mode:** Templates work in AI Config mode too (model_id=NULL); switching models reloads the template list
- **Live sync:** Active

https://claude.ai/code/session_01JnNcZbTYVWxMrCtxSSagQX