### PR TITLE
Add in-app software updater and Windows installer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,11 +1,15 @@
 .venv/
 .installed
 .env
-data/config/.env
 __pycache__/
 *.pyc
-data/config.json
-data/log_*.txt
-data/tmp/
 .pytest_cache/
 *.egg-info/
+build/
+dist/
+
+# Runtime state. The data root normally lives outside the repo (see README);
+# `data/` only appears here for portable installs and legacy checkouts.
+data/
+# Marker that pins the data root to <app>/data — a local choice, never committed.
+portable.txt

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,16 +59,18 @@ torch, torchvision.
 
 ```
 AI-Case-Sorter-Py/
-├── main.py                  # entry point
-├── start.sh / start.bat     # bootstrap launchers (venv + system deps)
+├── main.py                  # entry point (+ `--apply-update` pre-launch hook)
+├── start.sh / start.bat     # bootstrap launchers (venv + system deps + update)
 ├── pyproject.toml           # package metadata; [ml] extra = torch/torchvision
 ├── requirements.txt
 ├── sorter/                  # all application code
 │   ├── ui/                  # Tkinter UI (tabs + dialogs + theme)
 │   └── training/            # out-of-process ConvNeXt trainer
-├── tests/                   # pytest suite (logic, not UI)
-└── data/                    # created at runtime; gitignored (see §6)
+├── installer/               # Windows bootstrapper (see §7)
+└── tests/                   # pytest suite
 ```
+
+The data root lives **outside** the repo by default — see §6.
 
 ---
 
@@ -136,8 +138,10 @@ sanctioned way for worker threads to update the UI.
 - **`models.py`** — dataclasses: `Model`, `Headstamp`, `Cartridge`, `SlotTemplate`,
   `TrainingConfig`, `AIModelConfig`, `ImageProcessingConfig`, plus normalizers
   (`normalize_upload_mode`, `SUPPORTED_MODEL_MODES`, `SLOT_TEMPLATE_MODES`).
-- **`paths.py`** — single source of truth for the on-disk layout (see §6).
-  `CASESORTER_DATA_DIR` overrides the data root.
+- **`paths.py`** — single source of truth for the on-disk layout (see §6) and
+  the legacy-data migration. `CASESORTER_DATA_DIR` overrides the data root.
+  **Stdlib-only and import-light on purpose:** the pre-launch update step
+  imports it before the venv has any third-party packages.
 - **`appenv.py`** — developer overrides for the community backend, read from the
   environment with an optional `.env` (real env vars always win; see
   `.env.example`). `api_base()` applies `CASESORTER_API_BASE` over the
@@ -264,6 +268,12 @@ between them from the Run tab's template dropdown.
   tells a caller which path an archive will take; `update_existing=False`
   forces a separate copy.
 
+### Self-update (see §7 for the full flow)
+- **`updater.py`** — GitHub Releases check, version comparison, and download →
+  verify → stage. Needs `requests`. Never writes to the app folder.
+- **`apply_update.py`** — the pre-launch half: copies a staged tree over the app
+  folder, with backup/rollback. **Stdlib-only** — it runs before `pip install`.
+
 ### Community / cloud
 - **`auth.py`** — `AuthManager`: MSAL `PublicClientApplication` against Azure AD
   B2C (hardcoded tenant/client/authority/redirect, mirroring WinForms). Token
@@ -330,7 +340,8 @@ opt-in), `dialog_install_torch` (pip-installs torch/torchvision into the venv),
 `dialog_login` (MSAL interactive sign-in), `dialog_model_evaluator` (run eval +
 HTML report + history), `dialog_model_images` + `dialog_image_preview` (training
 image browser/reclassify/delete), `dialog_share_model` (publish to community),
-`dialog_slot_template` (new / rename / delete a sorting template).
+`dialog_slot_template` (new / rename / delete a sorting template),
+`dialog_update` (release notes → download progress → "Restart to update"; §7).
 
 ### Shared UI infrastructure
 - **`theme.py`** — `PALETTE`, `apply_theme(root)` (fonts + ttk styles, single
@@ -350,22 +361,38 @@ image browser/reclassify/delete), `dialog_share_model` (publish to community),
 
 ## 6. Data & on-disk layout
 
-Everything the app writes lives under `data/` next to `main.py` (override with
-`CASESORTER_DATA_DIR`). Delete the folder, delete all state. **`data/` is
-gitignored** and must never be committed.
+Everything the app writes lives under a single **data root**, resolved once by
+`paths.app_data_dir()`:
+
+1. `CASESORTER_DATA_DIR` — explicit override, wins over everything.
+2. A `portable.txt` marker next to `main.py` → `<app>/data` (USB-stick installs).
+3. Otherwise the per-user OS location: `%LOCALAPPDATA%\CaseSorter` on Windows,
+   `$XDG_DATA_HOME/CaseSorter` (default `~/.local/share/CaseSorter`) elsewhere.
+
+**The data root is outside the app folder by default, and that is load-bearing:**
+the in-app updater replaces the app folder wholesale (§7). Keeping user data out
+of it makes the updater safe by construction rather than by maintaining an
+exclusion list. `paths.migrate_legacy_data_dir()` moves a pre-0.2 `<app>/data`
+up on first run, so upgrades are invisible. `<app>/data` is still **gitignored**
+and must never be committed.
 
 ```
-data/
+<data root>/
 ├── config/
 │   ├── casesorter.db      # SQLite (all settings, models, headstamps)
 │   └── msal_cache.bin     # MSAL token cache (chmod 0600 on POSIX)
-└── models/
-    └── <model_id>/
-        ├── images/          # raw training images   {label}__{ticks}.jpg
-        ├── run_images/      # opt-in run captures
-        ├── feedback_images/ # below-threshold feedback queue (folder == queue)
-        ├── reports/         # evaluator HTML reports
-        └── trainedmodel/    # <model_id>.pth checkpoint
+├── models/
+│   └── <model_id>/
+│       ├── images/          # raw training images   {label}__{ticks}.jpg
+│       ├── run_images/      # opt-in run captures
+│       ├── feedback_images/ # below-threshold feedback queue (folder == queue)
+│       ├── reports/         # evaluator HTML reports
+│       └── trainedmodel/    # <model_id>.pth checkpoint
+└── updates/               # staged app updates (§7)
+    ├── pending/             # extracted tree awaiting the next launch
+    ├── pending.json         # its metadata — a SIBLING, never inside pending/
+    ├── backup/              # previous version, kept for rollback
+    └── last_applied.json
 ```
 
 **Filename convention** (WinForms-compatible): training images are
@@ -374,11 +401,68 @@ where `ticks` is the .NET `DateTime.Ticks` value.
 
 ---
 
-## 7. Conventions & gotchas
+## 7. Updates & Windows install
+
+Non-developers get the app without git, and keep it current from inside the app.
+There is no git dependency anywhere in this path: a release ZIP over HTTPS has
+the same trust anchor as `git pull` over HTTPS, and the source tree is ~1 MB, so
+delta transfer buys nothing.
+
+**Version:** `sorter/__init__.py.__version__` is the single source.
+`pyproject.toml` reads it via `[tool.setuptools.dynamic]`, and the updater
+compares it against the latest release tag. **Bump it in the same commit you tag
+a release** — otherwise the updater re-offers a release users already have.
+
+**The flow is stage now, apply at next launch:**
+
+```
+updater.check_for_update()   GET /releases/latest, compare tags   [needs requests]
+        ↓
+updater.stage_update()       download → verify → <data>/updates/pending/
+        ↓                    (the app folder is NOT touched)
+     [restart]
+        ↓
+main.py --apply-update       run by start.bat/start.sh BEFORE pip  [stdlib ONLY]
+        ↓
+sorter.apply_update          backup → copy over app dir → prune → clear pending
+```
+
+- **`updater.py`** — check/download/stage. Traversal-safe extraction (same
+  rejections as `model_io`), strips GitHub's `<repo>-<tag>/` wrapper, requires
+  `main.py` + `sorter/__init__.py` to be present before trusting an archive, and
+  caps the archive size. Staging is atomic: `pending/` only ever exists complete.
+- **`apply_update.py`** — **must stay stdlib-only.** It runs against a venv that
+  may hold nothing but pip; importing `requests` here would break the very launch
+  it exists to fix. Backs up everything it will overwrite, rolls back on failure,
+  and **always exits 0** so a broken updater can never stop the app starting.
+  Pruning stale files is confined to `sorter/`; `PROTECTED_TOP_LEVEL` (`.git`,
+  `.venv`, `data`, `.env`, `.installed`, `portable.txt`) is never touched.
+- **Why a pre-launch step at all:** on Windows the venv's `.pyd`/`.dll` files
+  (opencv, numpy) are locked while the app runs, so in-place replacement is
+  unreliable. Applying before Python loads anything sidesteps locking — and puts
+  a new `requirements.txt` in place *before* the launcher's hash check, so
+  dependency changes install on the same restart.
+- **UI** — `dialog_update.py` (notes → progress → "Restart to update") reached
+  from a status-bar button in `app.py` that appears only when there's something
+  to do. A silent check runs 2.5 s after startup; opt out via the dialog's
+  checkbox (`updates.check_on_startup`) or `CASESORTER_UPDATE_DISABLED=1`.
+- **`installer/`** — `install-windows.ps1` (+ `.bat` wrapper) provisions Python
+  via winget or a silent python.org install, lays the app down in
+  `%LOCALAPPDATA%\Programs\CaseSorter`, and hands off to `start.bat`. Per-user,
+  no admin. See `installer/README.md`.
+
+---
+
+## 8. Conventions & gotchas
 
 - **Threading rule:** never touch Tk widgets off the main thread. Do blocking
   work in `run_worker`/daemon threads and `bus.post(...)`; the drain loop
-  delivers handlers on the main thread.
+  delivers handlers on the main thread. **`widget.after()` is not an escape
+  hatch** — it registers a Tcl command and is itself unsafe off the main
+  thread. A worker must hand results to a `Queue` (the bus, or a dialog-local
+  one as in `dialog_update.py`) that a main-thread poller drains.
+  `dialog_install_torch.py` predates this note and still calls `after()` from
+  its pip-pump thread; don't copy that pattern.
 - **Legacy-app interop is intentional.** Many odd choices (PascalCase manifest
   keys, .NET ticks filenames, ConvNeXt-mode integer mapping, the exact serial
   command strings, the verbatim HTML report) exist so this app round-trips with
@@ -396,6 +480,12 @@ where `ticks` is the .NET `DateTime.Ticks` value.
   local copy of the backend; the **Azure B2C tenant/client/scopes in `auth.py`
   are still hardcoded**, so a fork pointing at its own identity provider has to
   edit that file. The backend itself is a separate service, not in this repo.
-- **No CI yet.** Run `pytest` before pushing; UI is not covered by tests.
+- **Releases drive the updater.** Bump `sorter/__init__.py.__version__` in the
+  same commit you tag a release, and keep the tag and that value in step.
+  `/releases/latest` excludes pre-releases, so tagging an rc won't reach
+  stable users.
+- **No CI yet.** Run `pytest` before pushing. Most UI modules need a display —
+  `xvfb-run -a python -m pytest` covers them on a headless box; without
+  tkinter installed those modules skip rather than fail.
 - See **`OPEN_SOURCE_READINESS.md`** for the open-source readiness assessment and
   **`CONTRIBUTING.md`** for how to set up and contribute.

--- a/README.md
+++ b/README.md
@@ -86,6 +86,26 @@ The app can predict a headstamp in one of two modes:
 
 ## Install & run
 
+### Windows — just want to use it
+
+No git, no Python, no terminal. Download **`install-windows.bat`** and
+**`install-windows.ps1`** from [`installer/`](installer/) into the same folder
+and double-click the `.bat`.
+
+It installs Python if you don't have it, puts the app in
+`%LOCALAPPDATA%\Programs\CaseSorter` (per-user — no admin rights), and adds a
+Start Menu entry. First launch installs dependencies and takes a few minutes.
+
+**Updates happen inside the app.** When a new release is out, the status bar
+shows *Update available*; once it has downloaded it changes to *Restart to
+update*, and the update is applied the next time you start. You never need to
+re-run the installer. Full details in [`installer/README.md`](installer/README.md).
+
+> The installer is unsigned, so Windows SmartScreen will warn the first time.
+> Choose **More info → Run anyway**.
+
+### From source
+
 The launch scripts create a virtual environment and install dependencies on
 first run.
 
@@ -139,15 +159,42 @@ pip install ".[ml]"        # torch + torchvision
 
 ## Where your data lives
 
-Everything the app writes lives under `data/` next to `main.py` (override with
-the `CASESORTER_DATA_DIR` environment variable). Delete the folder to reset all
-state. It is **gitignored** and never committed.
+Everything the app writes — trained models, training images, settings — lives
+in one folder, **outside** the app directory:
+
+| Platform | Location |
+|---|---|
+| Windows | `%LOCALAPPDATA%\CaseSorter` |
+| Linux   | `~/.local/share/CaseSorter` (or `$XDG_DATA_HOME/CaseSorter`) |
+| macOS   | `~/Library/Application Support/CaseSorter` |
 
 ```
-data/
+<data folder>/
 ├── config/   casesorter.db (settings/models/headstamps) + msal_cache.bin (token cache)
-└── models/<id>/  images · run_images · feedback_images · reports · trainedmodel
+├── models/<id>/  images · run_images · feedback_images · reports · trainedmodel
+└── updates/  staged app update, applied on next launch
 ```
+
+Keeping it separate is what makes updating safe — the updater replaces the app
+folder, and nothing of yours is in it. Delete the folder to reset all state.
+
+**Upgrading from an older version?** If your data is still in `data/` next to
+`main.py`, it's moved to the new location automatically the first time you run
+the app. Nothing to do.
+
+**Overrides:**
+- Set `CASESORTER_DATA_DIR` to put the data anywhere you like.
+- Create an empty `portable.txt` next to `main.py` to keep data in `<app>/data`
+  instead — for USB-stick or fully self-contained installs.
+
+### Updating
+
+- **Installed on Windows via the installer:** the app tells you when an update
+  is available and installs it on the next restart.
+- **Running from a git checkout:** `git pull` as usual. The in-app updater is
+  still available, but a source checkout is normally managed with git.
+- Disable update checks entirely with `CASESORTER_UPDATE_DISABLED=1`, or the
+  checkbox in the update dialog.
 
 ---
 

--- a/installer/README.md
+++ b/installer/README.md
@@ -1,0 +1,73 @@
+# Windows installer
+
+For people who just want to run the app — no git, no Python, no terminal.
+
+## For users
+
+1. Download **`install-windows.bat`** and **`install-windows.ps1`** into the
+   same folder (or grab them from a release archive).
+2. Double-click `install-windows.bat`.
+
+It installs to `%LOCALAPPDATA%\Programs\CaseSorter` (per-user, no admin
+rights) and adds a Start Menu entry. First launch installs the Python
+dependencies and takes a few minutes; after that the app starts immediately.
+
+**Updates are handled inside the app** — the status bar shows *Update
+available* when there's a new release, and *Restart to update* once it has
+downloaded. There's no need to re-run this installer, though re-running it is
+a safe way to repair a broken install.
+
+## What it does
+
+| Step | Detail |
+|---|---|
+| Python | Uses an existing Python 3.10+ **with Tcl/Tk** if one is present. Otherwise installs one via `winget`, falling back to a silent per-user python.org install. |
+| App | Downloads the latest GitHub release ZIP over HTTPS and extracts it. **No git.** |
+| Launch | Hands off to `start.bat`, which owns the virtualenv and `pip install`. |
+
+## Where things live
+
+```
+%LOCALAPPDATA%\Programs\CaseSorter\   ← the app (replaced by updates)
+%LOCALAPPDATA%\CaseSorter\            ← your data (never touched by updates)
+    ├── config\casesorter.db
+    ├── models\<id>\...
+    └── updates\                      ← staged update, pending restart
+```
+
+Keeping data out of the app folder is what makes the in-app updater safe: it
+overwrites the app directory, and there is nothing of yours in it. An install
+that predates this layout is migrated automatically on first run.
+
+## Options
+
+```powershell
+# Install somewhere else
+powershell -ExecutionPolicy Bypass -File install-windows.ps1 -InstallDir D:\CaseSorter
+
+# Pin a specific release
+powershell -ExecutionPolicy Bypass -File install-windows.ps1 -Version v0.2.0
+
+# Install without launching
+powershell -ExecutionPolicy Bypass -File install-windows.ps1 -NoLaunch
+```
+
+## Portable installs
+
+Drop an empty file named `portable.txt` next to `main.py` and the app keeps
+its data in `<app>\data` instead of `%LOCALAPPDATA%`, for USB-stick or
+self-contained use. The updater still works — it just won't be able to rely
+on your data being outside the app folder, so it leaves `data\` alone
+explicitly.
+
+## Notes for maintainers
+
+- The installer is unsigned, so SmartScreen will warn on first run. Signing
+  (Azure Trusted Signing, or an OV/EV certificate) is the fix; until then,
+  expect a "More info → Run anyway" step.
+- `casesorter.ico` in this folder is picked up as the shortcut icon if
+  present. It isn't in the repo yet — drop one in and shortcuts will use it.
+- The updater reads `/releases/latest`, which excludes drafts and
+  pre-releases, so tagging a pre-release won't push it to stable users.
+- Bump `__version__` in `sorter/__init__.py` in the same commit you tag a
+  release — that value is what the updater compares against the tag.

--- a/installer/install-windows.bat
+++ b/installer/install-windows.bat
@@ -1,0 +1,38 @@
+@echo off
+REM Double-clickable entry point for the Windows installer.
+REM
+REM Works two ways:
+REM   * next to install-windows.ps1 (a repo checkout / release archive) — runs
+REM     the local copy;
+REM   * on its own (downloaded by itself) — fetches the script from GitHub.
+REM
+REM The -ExecutionPolicy Bypass is scoped to this one invocation: a .ps1 that
+REM carries the internet's Mark-of-the-Web is blocked by the default policy,
+REM and this avoids telling users to loosen the policy machine-wide.
+
+setlocal
+set "HERE=%~dp0"
+set "PS1=%HERE%install-windows.ps1"
+set "RAW=https://raw.githubusercontent.com/sjseth/AI-Case-Sorter-Py/main/installer/install-windows.ps1"
+
+if exist "%PS1%" (
+    powershell -NoProfile -ExecutionPolicy Bypass -File "%PS1%" %*
+    goto :done
+)
+
+echo Downloading the installer...
+set "PS1=%TEMP%\casesorter-install-windows.ps1"
+powershell -NoProfile -ExecutionPolicy Bypass -Command ^
+    "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%RAW%' -OutFile '%PS1%' -UseBasicParsing"
+if errorlevel 1 (
+    echo.
+    echo Could not download the installer. Check your internet connection.
+    goto :done
+)
+powershell -NoProfile -ExecutionPolicy Bypass -File "%PS1%" %*
+del "%PS1%" >nul 2>&1
+
+:done
+echo.
+pause
+endlocal

--- a/installer/install-windows.ps1
+++ b/installer/install-windows.ps1
@@ -1,0 +1,285 @@
+<#
+.SYNOPSIS
+    Installs (or updates) the AI Case Sorter on Windows. No git required.
+
+.DESCRIPTION
+    Provisions the two things a non-developer machine is missing — a Python
+    runtime and a copy of the app — then hands off to start.bat, which owns
+    the virtualenv and dependency install.
+
+    Deliberately git-free. `git pull` over HTTPS and a release ZIP over HTTPS
+    have the same trust anchor (TLS to github.com), and this repo is ~1 MB, so
+    git's delta transfer buys nothing. Not installing a 60 MB dependency to
+    deliver a 1 MB update is the whole point.
+
+    Installs per-user to %LOCALAPPDATA%\Programs\CaseSorter — no admin rights,
+    and the folder stays writable so the venv and the in-app updater work.
+    User data lives in %LOCALAPPDATA%\CaseSorter, outside the app folder, so
+    reinstalling never touches trained models or settings.
+
+    Re-running this script updates an existing install in place.
+
+.PARAMETER InstallDir
+    Override the install location.
+
+.PARAMETER Version
+    Install a specific release tag (e.g. "v0.2.0") instead of the latest.
+
+.PARAMETER NoLaunch
+    Install without starting the app afterwards.
+
+.EXAMPLE
+    powershell -ExecutionPolicy Bypass -File install-windows.ps1
+#>
+[CmdletBinding()]
+param(
+    [string]$InstallDir = "$env:LOCALAPPDATA\Programs\CaseSorter",
+    [string]$Version = "",
+    [switch]$NoLaunch
+)
+
+Set-StrictMode -Version Latest
+$ErrorActionPreference = 'Stop'
+
+$Repo         = 'sjseth/AI-Case-Sorter-Py'
+$PythonWinget = 'Python.Python.3.12'
+$PythonMinor  = 12
+# Keep in step with requires-python in pyproject.toml.
+$PythonMin    = [Version]'3.10'
+
+function Write-Step  { param([string]$m) Write-Host "==> $m" -ForegroundColor Cyan }
+function Write-Note  { param([string]$m) Write-Host "    $m" -ForegroundColor DarkGray }
+function Write-Ok    { param([string]$m) Write-Host "    $m" -ForegroundColor Green }
+function Write-Warn2 { param([string]$m) Write-Host "    $m" -ForegroundColor Yellow }
+
+# TLS 1.2 for Invoke-WebRequest on older Windows PowerShell defaults.
+try {
+    [Net.ServicePointManager]::SecurityProtocol =
+        [Net.ServicePointManager]::SecurityProtocol -bor [Net.SecurityProtocolType]::Tls12
+} catch { }
+
+# ---------------------------------------------------------------------------
+# Python
+# ---------------------------------------------------------------------------
+
+function Get-PythonCommand {
+    <#
+      Returns the path to a python.exe meeting $PythonMin that also has
+      tkinter, or $null. tkinter matters: the whole UI is Tkinter, and a
+      Python without Tcl/Tk fails at launch with a confusing ImportError
+      rather than here where we can do something about it.
+    #>
+    $candidates = @()
+
+    $cmd = Get-Command python -ErrorAction SilentlyContinue
+    if ($cmd) { $candidates += $cmd.Source }
+
+    # The py launcher knows about installs that aren't on PATH.
+    if (Get-Command py -ErrorAction SilentlyContinue) {
+        try {
+            $p = & py "-3" -c "import sys; print(sys.executable)" 2>$null
+            if ($LASTEXITCODE -eq 0 -and $p) { $candidates += $p.Trim() }
+        } catch { }
+    }
+
+    $candidates += @(
+        "$env:LOCALAPPDATA\Programs\Python\Python313\python.exe",
+        "$env:LOCALAPPDATA\Programs\Python\Python312\python.exe",
+        "$env:LOCALAPPDATA\Programs\Python\Python311\python.exe",
+        "$env:LOCALAPPDATA\Programs\Python\Python310\python.exe"
+    )
+
+    foreach ($candidate in ($candidates | Where-Object { $_ } | Select-Object -Unique)) {
+        if (-not (Test-Path $candidate)) { continue }
+        try {
+            $out = & $candidate -c "import sys, tkinter; print('%d.%d' % sys.version_info[:2])" 2>$null
+            if ($LASTEXITCODE -ne 0 -or -not $out) { continue }
+            if ([Version]$out.Trim() -ge $PythonMin) { return $candidate }
+        } catch { continue }
+    }
+    return $null
+}
+
+function Install-Python {
+    Write-Step "Installing Python (none suitable was found)"
+
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        Write-Note "Using winget: $PythonWinget"
+        try {
+            & winget install --id $PythonWinget --exact --source winget `
+                --accept-package-agreements --accept-source-agreements `
+                --scope user --silent
+        } catch {
+            Write-Warn2 "winget failed: $($_.Exception.Message)"
+        }
+        $found = Get-PythonCommand
+        if ($found) { return $found }
+        Write-Warn2 "winget did not produce a usable Python; falling back to python.org."
+    }
+
+    # python.org fallback. Per-user, silent, and explicitly including Tcl/Tk.
+    $arch = if ([Environment]::Is64BitOperatingSystem) { 'amd64' } else { 'win32' }
+    $pyVer = "3.$PythonMinor.8"
+    $url = "https://www.python.org/ftp/python/$pyVer/python-$pyVer-$arch.exe"
+    $exe = Join-Path $env:TEMP "python-$pyVer-$arch.exe"
+
+    Write-Note "Downloading $url"
+    Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
+
+    Write-Note "Running the installer (per-user, silent)…"
+    $proc = Start-Process -FilePath $exe -Wait -PassThru -ArgumentList @(
+        '/quiet', 'InstallAllUsers=0', 'PrependPath=1',
+        'Include_tcltk=1', 'Include_pip=1', 'Include_launcher=1'
+    )
+    Remove-Item $exe -Force -ErrorAction SilentlyContinue
+    if ($proc.ExitCode -ne 0) {
+        throw "The Python installer exited with code $($proc.ExitCode)."
+    }
+
+    # PrependPath only affects *new* processes, so this shell still can't see
+    # it — re-read the user PATH rather than trusting `where python`.
+    $env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' +
+                [Environment]::GetEnvironmentVariable('Path', 'User')
+
+    $found = Get-PythonCommand
+    if (-not $found) {
+        throw "Python was installed but could not be located. Open a new terminal and re-run this script."
+    }
+    return $found
+}
+
+# ---------------------------------------------------------------------------
+# App payload
+# ---------------------------------------------------------------------------
+
+function Get-ReleaseInfo {
+    <# Latest release tag + ZIP URL. Falls back to the default branch if the
+       repo has no published releases yet. #>
+    if ($Version) {
+        return [pscustomobject]@{
+            Tag = $Version
+            Url = "https://github.com/$Repo/archive/refs/tags/$Version.zip"
+        }
+    }
+    try {
+        $resp = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" `
+            -Headers @{ 'User-Agent' = 'CaseSorter-Installer' } -UseBasicParsing
+    } catch {
+        Write-Warn2 "No published release found; installing the current main branch."
+        return [pscustomobject]@{
+            Tag = 'main'
+            Url = "https://github.com/$Repo/archive/refs/heads/main.zip"
+        }
+    }
+
+    # Prefer a purpose-built .zip asset; fall back to the source archive.
+    $asset = $resp.assets | Where-Object { $_.name -like '*.zip' } | Select-Object -First 1
+    $url = if ($asset) { $asset.browser_download_url }
+           else { "https://github.com/$Repo/archive/refs/tags/$($resp.tag_name).zip" }
+    return [pscustomobject]@{ Tag = $resp.tag_name; Url = $url }
+}
+
+function Install-App {
+    param([string]$Url, [string]$Tag, [string]$Dest)
+
+    $work = Join-Path $env:TEMP "casesorter-install-$([guid]::NewGuid().ToString('N'))"
+    New-Item -ItemType Directory -Path $work -Force | Out-Null
+    try {
+        $zip = Join-Path $work 'app.zip'
+        Write-Note "Downloading $Tag…"
+        Invoke-WebRequest -Uri $Url -OutFile $zip -UseBasicParsing
+
+        Write-Note "Extracting…"
+        $unpack = Join-Path $work 'unpacked'
+        Expand-Archive -Path $zip -DestinationPath $unpack -Force
+
+        # GitHub source archives nest everything under <repo>-<tag>/.
+        $entries = @(Get-ChildItem -Path $unpack)
+        $src = if ($entries.Count -eq 1 -and $entries[0].PSIsContainer) {
+            $entries[0].FullName
+        } else { $unpack }
+
+        if (-not (Test-Path (Join-Path $src 'main.py'))) {
+            throw "The downloaded archive does not look like the app (no main.py)."
+        }
+
+        New-Item -ItemType Directory -Path $Dest -Force | Out-Null
+
+        # Copy over the top. The venv (.venv), the dependency marker
+        # (.installed), and any local .env are left alone; user data lives
+        # outside $Dest entirely, so nothing here can touch it.
+        Write-Note "Installing to $Dest"
+        Copy-Item -Path (Join-Path $src '*') -Destination $Dest -Recurse -Force
+    } finally {
+        Remove-Item $work -Recurse -Force -ErrorAction SilentlyContinue
+    }
+}
+
+function New-Shortcuts {
+    param([string]$Dest)
+
+    $target = Join-Path $Dest 'start.bat'
+    if (-not (Test-Path $target)) { return }
+
+    $startMenu = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
+    $lnk = Join-Path $startMenu 'AI Case Sorter.lnk'
+    try {
+        $shell = New-Object -ComObject WScript.Shell
+        $sc = $shell.CreateShortcut($lnk)
+        $sc.TargetPath = $target
+        $sc.WorkingDirectory = $Dest
+        $sc.Description = 'AI Case Sorter'
+        $sc.WindowStyle = 7   # start minimised; start.bat is a console host
+        $icon = Join-Path $Dest 'installer\casesorter.ico'
+        if (Test-Path $icon) { $sc.IconLocation = $icon }
+        $sc.Save()
+        Write-Ok "Start Menu shortcut created."
+    } catch {
+        Write-Warn2 "Could not create the Start Menu shortcut: $($_.Exception.Message)"
+    }
+}
+
+# ---------------------------------------------------------------------------
+# Main
+# ---------------------------------------------------------------------------
+
+Write-Host ""
+Write-Host "  AI Case Sorter — Windows installer" -ForegroundColor White
+Write-Host "  ----------------------------------" -ForegroundColor DarkGray
+Write-Host ""
+
+$existing = Test-Path (Join-Path $InstallDir 'main.py')
+if ($existing) { Write-Step "Updating the existing install at $InstallDir" }
+else           { Write-Step "Installing to $InstallDir" }
+
+Write-Step "Checking for Python $PythonMin or newer (with Tcl/Tk)"
+$python = Get-PythonCommand
+if ($python) {
+    Write-Ok "Found $python"
+} else {
+    $python = Install-Python
+    Write-Ok "Installed $python"
+}
+
+Write-Step "Fetching the app"
+$release = Get-ReleaseInfo
+Install-App -Url $release.Url -Tag $release.Tag -Dest $InstallDir
+Write-Ok "$($release.Tag) installed."
+
+Write-Step "Creating shortcuts"
+New-Shortcuts -Dest $InstallDir
+
+Write-Host ""
+Write-Ok "Done. The app is installed at:"
+Write-Host "      $InstallDir"
+Write-Ok "Your models and settings are kept separately at:"
+Write-Host "      $env:LOCALAPPDATA\CaseSorter"
+Write-Host ""
+Write-Note "First launch installs the Python dependencies and takes a few minutes."
+Write-Note "After that, updates are offered inside the app — no need to re-run this."
+Write-Host ""
+
+if (-not $NoLaunch) {
+    Write-Step "Starting the app"
+    Start-Process -FilePath (Join-Path $InstallDir 'start.bat') -WorkingDirectory $InstallDir
+}

--- a/main.py
+++ b/main.py
@@ -1,19 +1,42 @@
-"""Entry point — initialize SQLite, load config, launch the Tk main window."""
+"""Entry point — initialize SQLite, load config, launch the Tk main window.
+
+Also hosts the ``--apply-update`` pre-launch hook: ``start.bat`` / ``start.sh``
+invoke it before installing dependencies so a staged update's own
+``requirements.txt`` is the one that gets installed. That path is stdlib-only
+and must stay that way — it runs against a virtualenv that may not have any
+third-party packages in it yet.
+"""
 from __future__ import annotations
 
 import sys
 from pathlib import Path
 
 
-def main() -> int:
+def main(argv: list[str] | None = None) -> int:
+    args = list(sys.argv[1:] if argv is None else argv)
+
     here = Path(__file__).resolve().parent
     if str(here) not in sys.path:
         sys.path.insert(0, str(here))
+
+    # Pre-launch update hook. Deliberately ahead of every other import so it
+    # cannot pull in a dependency the venv doesn't have yet.
+    if "--apply-update" in args:
+        from sorter.apply_update import main as apply_main
+
+        return apply_main()
 
     from sorter import appenv, paths
     from sorter.config import Config
     from sorter.db import Database
     from sorter.ui.app import MainWindow
+
+    # One-time move of a pre-0.2 `<app>/data` folder to the per-user location.
+    # No-op for portable installs, an explicit CASESORTER_DATA_DIR, or once
+    # it has already run.
+    moved = paths.migrate_legacy_data_dir()
+    if moved is not None:
+        print(f"[casesorter] moved data folder to {moved}")
 
     # Developer overrides (community API base URL / TLS trust). Silent unless
     # something is actually configured — see sorter/appenv.py and .env.example.
@@ -21,7 +44,7 @@ def main() -> int:
         print(f"[casesorter] {line}")
 
     paths.ensure_directories()
-    legacy_json = here / "data" / "config.json"
+    legacy_json = paths.app_data_dir() / "config.json"
 
     db = Database()
     db.ensure_initialized(legacy_config_json=legacy_json if legacy_json.exists() else None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,9 @@
 [project]
 name = "ai-case-sorter-py"
-version = "0.1.0"
-description = "Cross-platform desktop app that sorts spent brass cartridge casings by headstamp using a camera, an image classifier, and a serial-connected sorting machine."
+# Single-sourced from sorter/__init__.py so the packaged version, the version
+# the in-app updater compares against, and the release tag can't drift apart.
+dynamic = ["version"]
+description ="Cross-platform desktop app that sorts spent brass cartridge casings by headstamp using a camera, an image classifier, and a serial-connected sorting machine."
 readme = "README.md"
 requires-python = ">=3.10"
 license = { text = "GPL-3.0-or-later" }
@@ -45,3 +47,6 @@ build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["sorter", "sorter.ui", "sorter.training"]
+
+[tool.setuptools.dynamic]
+version = { attr = "sorter.__version__" }

--- a/sorter/__init__.py
+++ b/sorter/__init__.py
@@ -1,3 +1,6 @@
 """Case Sorter Open Source Client package."""
 
+# Single source of truth for the app version. `pyproject.toml` reads it via
+# `[tool.setuptools.dynamic]`, and `sorter/updater.py` compares it against the
+# latest GitHub release tag. Bump it in the same commit you tag a release.
 __version__ = "0.1.0"

--- a/sorter/apply_update.py
+++ b/sorter/apply_update.py
@@ -1,0 +1,243 @@
+"""Apply a staged update — the pre-launch half of the updater.
+
+Run by ``start.bat`` / ``start.sh`` via ``python main.py --apply-update``,
+*before* the dependency install, so a staged update's own
+``requirements.txt`` is the one the launcher then installs.
+
+**This module must stay stdlib-only.** It runs against a virtualenv that may
+contain nothing but pip — importing ``requests`` here would break the very
+launch it is supposed to fix. That is also why it re-reads ``pending.json``
+itself instead of importing ``sorter.updater``.
+
+Why a separate pre-launch step at all: on Windows the venv's ``.pyd``/``.dll``
+files (opencv, numpy) are locked while the app is running, so replacing files
+in-place is unreliable. Applying before Python loads anything sidesteps
+file-locking entirely.
+
+Safety model:
+
+* Everything about to be overwritten or pruned is copied to
+  ``<data>/updates/backup/`` first, and restored if any step raises.
+* Pruning is confined to ``sorter/`` — a package directory that never holds
+  user data — so removed-upstream modules don't linger as importable stale
+  code. Every other path is overwrite-only.
+* The exit code is **always 0**. A broken updater must never stop the app
+  from starting; it reports on stderr and leaves the previous version running.
+"""
+from __future__ import annotations
+
+import json
+import shutil
+import sys
+from pathlib import Path
+
+from . import __version__, paths
+
+# Never overwritten, never pruned, regardless of what an archive contains.
+PROTECTED_TOP_LEVEL = frozenset(
+    {".git", ".venv", "venv", "data", ".env", ".installed", "portable.txt"}
+)
+
+# Pruning stale files is confined to these directories.
+PRUNE_ROOTS = ("sorter",)
+
+
+def _log(msg: str) -> None:
+    print(f"[update] {msg}", file=sys.stderr)
+
+
+def _meta_path() -> Path:
+    return paths.updates_dir() / "pending.json"
+
+
+def _pending_dir() -> Path:
+    return paths.updates_dir() / "pending"
+
+
+def _backup_dir() -> Path:
+    return paths.updates_dir() / "backup"
+
+
+def _is_protected(rel: Path) -> bool:
+    return bool(rel.parts) and rel.parts[0] in PROTECTED_TOP_LEVEL
+
+
+def _archive_files(root: Path) -> list[Path]:
+    """Relative paths of every file in the staged tree, protected ones dropped."""
+    out: list[Path] = []
+    for p in root.rglob("*"):
+        if not p.is_file():
+            continue
+        rel = p.relative_to(root)
+        if _is_protected(rel):
+            continue
+        out.append(rel)
+    return out
+
+
+def _stale_files(app_dir: Path, keep: set[Path]) -> list[Path]:
+    """Files under PRUNE_ROOTS that the new version no longer ships."""
+    out: list[Path] = []
+    for root_name in PRUNE_ROOTS:
+        root = app_dir / root_name
+        if not root.is_dir():
+            continue
+        for p in root.rglob("*"):
+            if not p.is_file():
+                continue
+            rel = p.relative_to(app_dir)
+            if _is_protected(rel) or rel in keep:
+                continue
+            out.append(rel)
+    return out
+
+
+def _backup(app_dir: Path, backup: Path, rel: Path) -> None:
+    dest = backup / rel
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(app_dir / rel, dest)
+
+
+def _rollback(app_dir: Path, backup: Path, created: list[Path]) -> int:
+    """Undo a half-applied update: drop new files, restore saved ones.
+
+    Returns the number of files it could **not** restore. A non-zero count
+    means the install is genuinely inconsistent, which the caller reports
+    loudly — the backup is left on disk so it can be recovered by hand.
+    """
+    failures = 0
+    for rel in created:
+        try:
+            (app_dir / rel).unlink(missing_ok=True)
+        except OSError:
+            failures += 1
+    if not backup.is_dir():
+        return failures
+    for src in backup.rglob("*"):
+        if not src.is_file():
+            continue
+        rel = src.relative_to(backup)
+        dest = app_dir / rel
+        try:
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(src, dest)
+        except OSError as exc:
+            failures += 1
+            _log(f"rollback could not restore {rel}: {exc}")
+    return failures
+
+
+def apply_pending(app_dir: Path | None = None) -> bool:
+    """Apply the staged update if there is one. Returns True if applied."""
+    root = Path(app_dir) if app_dir is not None else paths.app_root()
+    meta_path = _meta_path()
+    pending = _pending_dir()
+
+    if not meta_path.is_file() or not pending.is_dir():
+        return False
+
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError) as exc:
+        _log(f"staged update metadata is unreadable ({exc}); discarding it.")
+        _discard()
+        return False
+
+    version = str(meta.get("version") or "")
+    if not version:
+        _log("staged update has no version; discarding it.")
+        _discard()
+        return False
+
+    files = _archive_files(pending)
+    if not files:
+        _log("staged update is empty; discarding it.")
+        _discard()
+        return False
+
+    keep = set(files)
+    stale = _stale_files(root, keep)
+
+    backup = _backup_dir()
+    shutil.rmtree(backup, ignore_errors=True)
+    backup.mkdir(parents=True, exist_ok=True)
+
+    created: list[Path] = []
+    _log(f"applying {__version__} → {version} ({len(files)} files)")
+    try:
+        for rel in stale:
+            _backup(root, backup, rel)
+            (root / rel).unlink()
+
+        for rel in files:
+            dest = root / rel
+            if dest.exists():
+                _backup(root, backup, rel)
+            else:
+                created.append(rel)
+            dest.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(pending / rel, dest)
+    except (OSError, shutil.Error) as exc:
+        _log(f"failed: {exc}")
+        _log("rolling back to the previous version…")
+        failures = _rollback(root, backup, created)
+        if failures:
+            _log(
+                f"WARNING: rollback could not restore {failures} file(s). "
+                f"A copy of the previous version is at {backup}."
+            )
+        else:
+            _log("rollback complete; keeping the staged update for a later retry.")
+        return False
+
+    _discard()
+    try:
+        (paths.updates_dir() / "last_applied.json").write_text(
+            json.dumps(
+                {
+                    "version": version,
+                    "tag": str(meta.get("tag") or version),
+                    "from_version": str(meta.get("from_version") or __version__),
+                    "pruned": len(stale),
+                },
+                indent=2,
+            ),
+            encoding="utf-8",
+        )
+    except OSError:
+        pass
+
+    _log(f"updated to {version}." + (f" Pruned {len(stale)} stale file(s)." if stale else ""))
+    return True
+
+
+def _discard() -> None:
+    shutil.rmtree(_pending_dir(), ignore_errors=True)
+    try:
+        _meta_path().unlink()
+    except OSError:
+        pass
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Entry point. Always returns 0 — never block the app from launching."""
+    args = list(sys.argv[1:] if argv is None else argv)
+    app_dir: Path | None = None
+    if "--app-dir" in args:
+        idx = args.index("--app-dir")
+        if idx + 1 < len(args):
+            app_dir = Path(args[idx + 1])
+
+    try:
+        # A pre-0.2 install still has its data inside the app folder; move it
+        # before looking for staged updates, so both halves agree on where
+        # the updates/ tree lives.
+        paths.migrate_legacy_data_dir()
+        apply_pending(app_dir)
+    except Exception as exc:  # noqa: BLE001 — must not stop the launcher
+        _log(f"unexpected error: {exc}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/sorter/paths.py
+++ b/sorter/paths.py
@@ -1,44 +1,132 @@
 """File-system locations.
 
-The app is intentionally portable: everything it writes lives inside
-``<app folder>/data/``, next to ``main.py``. Delete the folder, delete the
-state. Layout:
+Everything the app writes lives under a single **data root**, resolved once
+per process. Layout:
 
-    <app>/
-    └── data/
-        ├── config/
-        │   ├── casesorter.db    ← SQLite database
-        │   └── msal_cache.bin   ← MSAL token cache (chmod 0600 on POSIX)
-        └── models/
-            └── <model_id>/
-                ├── images/          ← raw training images
-                ├── run_images/      ← images captured during a run (opt-in)
-                ├── feedback_images/ ← below-threshold community feedback queue
-                ├── reports/         ← evaluator HTML reports
-                └── trainedmodel/    ← <model_id>.pth (PyTorch zip archive)
+    <data root>/
+    ├── config/
+    │   ├── casesorter.db    ← SQLite database
+    │   └── msal_cache.bin   ← MSAL token cache (chmod 0600 on POSIX)
+    ├── models/
+    │   └── <model_id>/
+    │       ├── images/          ← raw training images
+    │       ├── run_images/      ← images captured during a run (opt-in)
+    │       ├── feedback_images/ ← below-threshold community feedback queue
+    │       ├── reports/         ← evaluator HTML reports
+    │       └── trainedmodel/    ← <model_id>.pth (PyTorch zip archive)
+    └── updates/             ← staged app updates (see sorter/updater.py)
 
-A ``CASESORTER_DATA_DIR`` env var overrides the data root — used by tests
-and operators who want the data on a different volume.
+Resolution order:
+
+1. ``CASESORTER_DATA_DIR`` — explicit override; wins over everything.
+2. A ``portable.txt`` marker next to ``main.py`` — keeps the data in
+   ``<app>/data`` for USB-stick / self-contained installs.
+3. The per-user OS location: ``%LOCALAPPDATA%\\CaseSorter`` on Windows,
+   ``$XDG_DATA_HOME/CaseSorter`` (default ``~/.local/share/CaseSorter``)
+   elsewhere.
+
+**Why the data root is no longer app-local by default:** the in-app updater
+replaces the app folder in place. Keeping user data — trained models,
+databases, captured images — outside that folder makes the updater safe by
+construction rather than by remembering to exclude the right paths.
+``migrate_legacy_data_dir()`` moves an existing ``<app>/data`` up on first
+run so this is invisible to anyone upgrading.
+
+This module is deliberately **stdlib-only and import-light**: the pre-launch
+update step (``main.py --apply-update``) imports it before the virtualenv has
+any third-party packages in it.
 """
 from __future__ import annotations
 
 import os
+import shutil
+import sys
 from pathlib import Path
 
 APP_NAME = "CaseSorter"
 
+# Presence of this file next to main.py pins the data root to <app>/data.
+PORTABLE_MARKER = "portable.txt"
 
-def _app_root() -> Path:
-    """App folder (one level above ``sorter/``)."""
+
+def app_root() -> Path:
+    """App folder (one level above ``sorter/``) — where ``main.py`` lives."""
     return Path(__file__).resolve().parent.parent
 
 
+# Retained for callers that predate the rename.
+_app_root = app_root
+
+
+def legacy_data_dir() -> Path:
+    """The pre-0.2 location: ``<app>/data``."""
+    return app_root() / "data"
+
+
+def is_portable() -> bool:
+    """True when the portable marker pins the data root inside the app folder."""
+    return (app_root() / PORTABLE_MARKER).exists()
+
+
+def _os_data_dir() -> Path:
+    """Per-user data location for the current platform."""
+    if sys.platform == "win32":
+        base = os.environ.get("LOCALAPPDATA")
+        if base:
+            return Path(base) / APP_NAME
+        return Path.home() / "AppData" / "Local" / APP_NAME
+    if sys.platform == "darwin":
+        return Path.home() / "Library" / "Application Support" / APP_NAME
+    base = os.environ.get("XDG_DATA_HOME")
+    if base:
+        return Path(base) / APP_NAME
+    return Path.home() / ".local" / "share" / APP_NAME
+
+
 def app_data_dir() -> Path:
-    """Root for everything the app writes. Default: ``<app>/data``."""
+    """Root for everything the app writes. See the module docstring."""
     override = os.environ.get("CASESORTER_DATA_DIR")
     if override:
         return Path(override).expanduser()
-    return _app_root() / "data"
+    if is_portable():
+        return legacy_data_dir()
+    return _os_data_dir()
+
+
+def migrate_legacy_data_dir() -> Path | None:
+    """Move a pre-0.2 ``<app>/data`` folder to the new root. Idempotent.
+
+    Returns the destination when a migration happened, else ``None``. Never
+    raises: a failed migration leaves the legacy folder untouched, and the
+    caller carries on with an empty new root rather than refusing to start.
+
+    A ``os.replace`` is tried first (atomic, instant); if the two live on
+    different volumes it falls back to a copy, and the legacy folder is only
+    removed once the copy has fully succeeded.
+    """
+    if os.environ.get("CASESORTER_DATA_DIR") or is_portable():
+        return None
+
+    legacy = legacy_data_dir()
+    dest = _os_data_dir()
+    if not legacy.is_dir() or dest.exists():
+        return None
+
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    try:
+        os.replace(legacy, dest)
+        return dest
+    except OSError:
+        pass
+
+    # Cross-volume (or Windows holding a handle): copy, then drop the original.
+    try:
+        shutil.copytree(legacy, dest)
+    except OSError:
+        shutil.rmtree(dest, ignore_errors=True)
+        return None
+    shutil.rmtree(legacy, ignore_errors=True)
+    return dest
 
 
 def config_dir() -> Path:
@@ -56,6 +144,11 @@ def token_cache_path() -> Path:
 def models_dir() -> Path:
     """Root for all per-model folders."""
     return app_data_dir() / "models"
+
+
+def updates_dir() -> Path:
+    """Scratch + staging area for in-app updates (see ``sorter/updater.py``)."""
+    return app_data_dir() / "updates"
 
 
 def export_temp_dir() -> Path:

--- a/sorter/ui/app.py
+++ b/sorter/ui/app.py
@@ -79,6 +79,17 @@ class MainWindow:
             status_bar, textvariable=self.signin_var, command=self._on_signin_click,
         )
         self.signin_button.pack(side=tk.RIGHT, padx=12, pady=4)
+        # Update affordance — created here but not packed: it appears only once
+        # a check finds a newer release, or an update is staged and waiting for
+        # a restart. Blue "update" hue per theme.py's colour rules.
+        self._update_status_bar = status_bar
+        self._update_info: Any | None = None
+        self._pending_update: Any | None = None
+        self.update_button_var = tk.StringVar(value="Update available")
+        self.update_button = ttk.Button(
+            status_bar, textvariable=self.update_button_var,
+            style="Update.TButton", command=self.open_update_dialog,
+        )
         # Pack serial first so it ends up rightmost; camera sits to its left.
         # Each indicator is a [dot][text] pair grouped in a sub-frame so the
         # dot stays glued to its label when the bar resizes.
@@ -149,6 +160,91 @@ class MainWindow:
         # race with that probe trying to open the same device.
         # Auto-connect to the board once the UI is on screen.
         self.root.after(200, self._auto_connect_serial)
+        # Update check runs well after startup so a slow or blocked network
+        # never delays the window appearing or the board connecting.
+        self.root.after(2500, self._check_for_updates_on_startup)
+
+    # ----- software updates ---------------------------------------------------
+
+    def _check_for_updates_on_startup(self) -> None:
+        """Silent startup check. Never surfaces an error — only good news."""
+        from .. import updater
+
+        try:
+            # An already-staged update outranks a fresh check: what the user
+            # needs is the restart prompt, not another download.
+            pending = updater.pending_update()
+        except Exception:
+            pending = None
+        if pending is not None:
+            self.note_pending_update(pending)
+            return
+
+        if updater.checks_disabled() or not self._auto_check_enabled():
+            return
+        self.check_for_updates(silent=True)
+
+    def _auto_check_enabled(self) -> bool:
+        if self.db is None:
+            return True
+        try:
+            from ..repository import SettingsRepo
+            from ..updater import SETTING_CHECK_ON_STARTUP
+
+            return bool(SettingsRepo(self.db).get(SETTING_CHECK_ON_STARTUP, True))
+        except Exception:
+            return True
+
+    def check_for_updates(self, *, silent: bool = True) -> None:
+        """Look for a newer release on a worker thread.
+
+        `silent=True` (startup) only reveals the status-bar button on a hit;
+        `silent=False` (explicit request) always opens the dialog so the user
+        gets an answer either way.
+        """
+        from .. import updater
+
+        def _work() -> Any:
+            return updater.check_for_update()
+
+        def _done(info: Any) -> None:
+            self._update_info = info
+            if info is not None:
+                self._show_update_button(f"Update to {info.version}")
+            elif not silent:
+                self.open_update_dialog()
+
+        def _error(exc: Exception) -> None:
+            if not silent:
+                self.set_status(f"Update check failed: {exc}")
+
+        if not silent:
+            self.set_status("Checking for updates…")
+        self.run_worker(_work, on_done=_done, on_error=_error)
+
+    def note_pending_update(self, pending: Any) -> None:
+        """Record a staged update and switch the button to the restart prompt."""
+        self._pending_update = pending
+        self._show_update_button("Restart to update")
+
+    def _show_update_button(self, label: str) -> None:
+        self.update_button_var.set(label)
+        try:
+            # `winfo_manager()` reports the geometry manager ("" until packed).
+            # Deliberately not `winfo_ismapped()`, which is false whenever the
+            # window is withdrawn or minimised and would re-pack every call.
+            if not self.update_button.winfo_manager():
+                self.update_button.pack(side=tk.RIGHT, padx=(0, 4), pady=4)
+        except tk.TclError:
+            pass
+
+    def open_update_dialog(self) -> None:
+        from .dialog_update import UpdateDialog
+
+        UpdateDialog(
+            self.root, info=self._update_info, app=self,
+            pending=self._pending_update,
+        )
 
     # ----- status -------------------------------------------------------------
 

--- a/sorter/ui/dialog_update.py
+++ b/sorter/ui/dialog_update.py
@@ -1,0 +1,364 @@
+"""Update dialog — review, download, restart to install.
+
+Three states, in order:
+
+    available   → version summary + release notes, "Download & Install"
+    downloading → progress bar, cancellable
+    ready       → "Restart to update"
+
+The dialog never writes to the app folder. Downloading only *stages* the
+update under the data root; the launcher applies it on the next start (see
+``sorter/apply_update.py``). "Restart Now" re-execs the launcher script and
+closes the app — which is what makes the staged update take effect.
+
+Opening the dialog when an update is already staged jumps straight to
+``ready``, so a user who picked "Later" can come back and restart.
+"""
+from __future__ import annotations
+
+import queue
+import subprocess
+import sys
+import threading
+import tkinter as tk
+from tkinter import ttk
+
+from .. import updater
+from ..updater import PendingUpdate, UpdateError, UpdateInfo
+from .theme import PALETTE
+
+
+class UpdateDialog(tk.Toplevel):
+    def __init__(
+        self,
+        parent: tk.Misc,
+        *,
+        info: UpdateInfo | None,
+        app=None,
+        pending: PendingUpdate | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.title("Software Update")
+        self.transient(parent)
+        self.resizable(True, True)
+        self.geometry("620x520")
+        self.minsize(520, 420)
+        self.configure(bg=PALETTE["bg_surface"])
+        self.protocol("WM_DELETE_WINDOW", self._close)
+
+        self._info = info
+        self._app = app
+        self._pending = pending if pending is not None else updater.pending_update()
+        self._cancelled = False
+        self._downloading = False
+        self._events: queue.Queue[tuple[str, object]] = queue.Queue()
+        self._poll_id: str | None = None
+
+        # Buttons first with side=BOTTOM so the resizable notes area above
+        # can't squeeze them off-screen (same ordering trick as the PyTorch
+        # install dialog).
+        self._btns = ttk.Frame(self, padding=(12, 0, 12, 12))
+        self._btns.pack(side=tk.BOTTOM, fill=tk.X)
+
+        wrap = ttk.Frame(self, padding=12)
+        wrap.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        self._build_header(wrap)
+        self._build_notes(wrap)
+        self._build_progress(wrap)
+        self._build_buttons()
+        self._render()
+
+    # ----- UI build -----------------------------------------------------------
+
+    def _build_header(self, parent: tk.Misc) -> None:
+        self._title_var = tk.StringVar()
+        ttk.Label(parent, textvariable=self._title_var,
+                  style="Header.TLabel").pack(anchor="w")
+        self._version_var = tk.StringVar()
+        ttk.Label(parent, textvariable=self._version_var,
+                  style="Accent.TLabel").pack(anchor="w", pady=(4, 0))
+        self._detail_var = tk.StringVar()
+        ttk.Label(parent, textvariable=self._detail_var, style="Muted.TLabel",
+                  wraplength=560, justify=tk.LEFT).pack(
+            anchor="w", pady=(6, 8), fill=tk.X,
+        )
+
+    def _build_notes(self, parent: tk.Misc) -> None:
+        self._notes_wrap = ttk.Frame(parent, style="Card.TFrame", padding=4)
+        self._notes_wrap.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        self._notes = tk.Text(
+            self._notes_wrap, height=10, wrap=tk.WORD, state=tk.DISABLED,
+            bg=PALETTE["bg_input"], fg=PALETTE["text"],
+            insertbackground=PALETTE["accent"],
+            highlightthickness=0, borderwidth=0, padx=8, pady=6,
+        )
+        self._notes.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        ttk.Scrollbar(self._notes_wrap, orient=tk.VERTICAL,
+                      command=self._notes.yview).pack(side=tk.RIGHT, fill=tk.Y)
+
+    def _build_progress(self, parent: tk.Misc) -> None:
+        self._progress_row = ttk.Frame(parent)
+        self._progress = ttk.Progressbar(self._progress_row, mode="determinate",
+                                         maximum=100)
+        self._progress.pack(side=tk.TOP, fill=tk.X)
+        self._progress_var = tk.StringVar(value="")
+        ttk.Label(self._progress_row, textvariable=self._progress_var,
+                  style="Muted.TLabel").pack(anchor="w", pady=(4, 0))
+
+    def _build_buttons(self) -> None:
+        self._secondary = ttk.Button(self._btns, text="Later", command=self._close)
+        self._secondary.pack(side=tk.RIGHT)
+        # Blue "update" hue: refreshing something already installed.
+        self._primary = ttk.Button(self._btns, text="Download & Install",
+                                   style="Update.TButton", command=self._on_primary)
+        self._primary.pack(side=tk.RIGHT, padx=(0, 8))
+
+        self._auto_var = tk.BooleanVar(value=self._read_auto_check())
+        self._auto_check = ttk.Checkbutton(
+            self._btns, text="Check for updates on startup",
+            variable=self._auto_var, command=self._on_toggle_auto,
+        )
+        self._auto_check.pack(side=tk.LEFT)
+
+    # ----- settings -----------------------------------------------------------
+
+    def _settings(self):
+        db = getattr(self._app, "db", None)
+        if db is None:
+            return None
+        from ..repository import SettingsRepo
+
+        return SettingsRepo(db)
+
+    def _read_auto_check(self) -> bool:
+        repo = self._settings()
+        if repo is None:
+            return True
+        return bool(repo.get(updater.SETTING_CHECK_ON_STARTUP, True))
+
+    def _on_toggle_auto(self) -> None:
+        repo = self._settings()
+        if repo is None:
+            return
+        try:
+            repo.set(updater.SETTING_CHECK_ON_STARTUP, bool(self._auto_var.get()))
+        except Exception:
+            pass
+
+    # ----- rendering ----------------------------------------------------------
+
+    def _set_notes(self, text: str) -> None:
+        self._notes.config(state=tk.NORMAL)
+        self._notes.delete("1.0", tk.END)
+        self._notes.insert("1.0", text)
+        self._notes.config(state=tk.DISABLED)
+
+    def _render(self) -> None:
+        current = updater.current_version()
+        if self._pending is not None:
+            self._title_var.set("Update ready to install")
+            self._version_var.set(f"{current}  →  {self._pending.version}")
+            self._detail_var.set(
+                "The update has been downloaded. It installs the next time the "
+                "app starts — restart now, or keep working and it will be "
+                "applied on your next launch."
+            )
+            self._set_notes(
+                "Nothing is changed until you restart.\n\n"
+                "Your models, training images, and settings are stored "
+                "separately from the app and are not affected by an update."
+            )
+            self._progress_row.pack_forget()
+            self._primary.config(text="Restart Now", state=tk.NORMAL)
+            self._secondary.config(text="Later", command=self._close)
+            return
+
+        info = self._info
+        if info is None:
+            self._title_var.set("You're up to date")
+            self._version_var.set(f"Version {current}")
+            self._detail_var.set("No newer release is available.")
+            self._set_notes("")
+            self._progress_row.pack_forget()
+            self._primary.pack_forget()
+            self._secondary.config(text="Close", command=self._close)
+            return
+
+        self._title_var.set("Update available")
+        self._version_var.set(f"{current}  →  {info.version}")
+        size = f" ({info.size / 1_000_000:.1f} MB)" if info.size else ""
+        self._detail_var.set(
+            f"Release {info.tag}{size} is available. It downloads in the "
+            "background and installs the next time you start the app."
+        )
+        self._set_notes(info.notes or "No release notes were provided.")
+        self._progress_row.pack_forget()
+        self._primary.config(text="Download & Install", state=tk.NORMAL)
+        self._secondary.config(text="Later", command=self._close)
+
+    # ----- actions ------------------------------------------------------------
+
+    def _on_primary(self) -> None:
+        if self._pending is not None:
+            self._restart()
+        else:
+            self._start_download()
+
+    def _start_download(self) -> None:
+        if self._downloading or self._info is None:
+            return
+        self._downloading = True
+        self._cancelled = False
+        self._primary.config(state=tk.DISABLED, text="Downloading…")
+        self._secondary.config(text="Cancel", command=self._cancel_download)
+        self._progress_row.pack(side=tk.TOP, fill=tk.X, pady=(10, 0))
+        self._progress.config(value=0)
+        self._progress_var.set("Starting download…")
+
+        info = self._info
+
+        # Tkinter is not thread-safe and `after()` is not an exception to
+        # that — calling it from a worker thread registers a Tcl command off
+        # the main thread. So the worker only ever touches this queue, and a
+        # main-thread poller below turns its messages into widget updates.
+        # Same shape as the app-wide EventBus, scoped to one dialog.
+        self._events: queue.Queue[tuple[str, object]] = queue.Queue()
+
+        def _work() -> None:
+            try:
+                pending = updater.stage_update(info, progress=self._on_progress)
+            except UpdateError as exc:
+                self._events.put(("error", str(exc)))
+            except Exception as exc:  # noqa: BLE001 — surface, don't crash
+                self._events.put(("error", f"Unexpected error: {exc}"))
+            else:
+                self._events.put(("done", pending))
+
+        threading.Thread(target=_work, daemon=True).start()
+        self._poll_events()
+
+    def _poll_events(self) -> None:
+        """Drain worker messages on the main thread. Rescheduled while active."""
+        self._poll_id = None
+        terminal = False
+        try:
+            while True:
+                kind, payload = self._events.get_nowait()
+                if kind == "progress":
+                    done, total = payload  # type: ignore[misc]
+                    self._show_progress(done, total)
+                elif kind == "done":
+                    self._download_done(payload)  # type: ignore[arg-type]
+                    terminal = True
+                    break
+                elif kind == "error":
+                    self._download_failed(str(payload))
+                    terminal = True
+                    break
+        except queue.Empty:
+            pass
+        except tk.TclError:
+            return  # dialog went away mid-drain
+
+        if not terminal and self._downloading:
+            try:
+                self._poll_id = self.after(50, self._poll_events)
+            except tk.TclError:
+                pass
+
+    def _on_progress(self, done: int, total: int | None) -> None:
+        """Called on the download thread — hand off, never touch a widget."""
+        if self._cancelled:
+            raise UpdateError("Download cancelled.")
+        self._events.put(("progress", (done, total)))
+
+    def _show_progress(self, done: int, total: int | None) -> None:
+        mb = done / 1_000_000
+        if total:
+            pct = min(100.0, done * 100.0 / total)
+            self._progress.config(mode="determinate", value=pct)
+            self._progress_var.set(f"{mb:.1f} MB of {total / 1_000_000:.1f} MB")
+        else:
+            self._progress.config(mode="determinate", value=0)
+            self._progress_var.set(f"{mb:.1f} MB downloaded")
+
+    def _cancel_download(self) -> None:
+        self._cancelled = True
+        self._progress_var.set("Cancelling…")
+        self._secondary.config(state=tk.DISABLED)
+
+    def _download_failed(self, message: str) -> None:
+        self._downloading = False
+        self._progress.config(value=0)
+        if self._cancelled:
+            self._progress_row.pack_forget()
+            self._progress_var.set("")
+            self._primary.config(state=tk.NORMAL, text="Download & Install")
+            self._secondary.config(text="Later", state=tk.NORMAL,
+                                   command=self._close)
+            return
+        self._progress_var.set(message)
+        self._primary.config(state=tk.NORMAL, text="Try Again")
+        self._secondary.config(text="Close", state=tk.NORMAL, command=self._close)
+
+    def _download_done(self, pending: PendingUpdate) -> None:
+        self._downloading = False
+        self._pending = pending
+        self._progress_var.set("")
+        self._secondary.config(state=tk.NORMAL)
+        self._render()
+        if self._app is not None and hasattr(self._app, "note_pending_update"):
+            self._app.note_pending_update(pending)
+
+    def _restart(self) -> None:
+        """Re-exec the launcher, then shut the app down so the swap can happen."""
+        launcher = updater.launcher_path()
+        if launcher is None:
+            self._detail_var.set(
+                "Close the app and start it again to finish installing the "
+                "update."
+            )
+            self._primary.config(state=tk.DISABLED)
+            return
+
+        root = launcher.parent
+        try:
+            if sys.platform == "win32":
+                flags = getattr(subprocess, "DETACHED_PROCESS", 0) | getattr(
+                    subprocess, "CREATE_NEW_PROCESS_GROUP", 0
+                )
+                subprocess.Popen(
+                    [str(launcher)], cwd=str(root), close_fds=True,
+                    creationflags=flags, shell=True,
+                )
+            else:
+                subprocess.Popen(
+                    ["/bin/bash", str(launcher)], cwd=str(root),
+                    start_new_session=True, close_fds=True,
+                )
+        except OSError as exc:
+            self._detail_var.set(
+                f"Could not relaunch automatically ({exc}). Close the app and "
+                "start it again to finish installing the update."
+            )
+            return
+
+        self._close()
+        if self._app is not None and hasattr(self._app, "_on_close"):
+            self._app._on_close()
+
+    def _close(self) -> None:
+        # Stop the poller before the widgets go away. The download thread is a
+        # daemon and its queue writes are harmless once nothing drains them.
+        self._cancelled = True
+        self._downloading = False
+        if self._poll_id is not None:
+            try:
+                self.after_cancel(self._poll_id)
+            except tk.TclError:
+                pass
+            self._poll_id = None
+        try:
+            self.destroy()
+        except tk.TclError:
+            pass

--- a/sorter/updater.py
+++ b/sorter/updater.py
@@ -1,0 +1,422 @@
+"""In-app updater — check GitHub Releases, download, stage.
+
+Deliberately **git-free**: `git clone`/`git pull` over HTTPS and a release
+ZIP over HTTPS have the same trust anchor (TLS to github.com), and at this
+repo's size the delta-transfer advantage is worth nothing. Dropping git means
+non-developers never install a 60 MB dependency to receive a 1 MB update.
+
+The flow is **stage now, apply at next launch**:
+
+    check_for_update()  →  stage_update()  →  [restart]  →  sorter.apply_update
+
+Staging never touches the app folder. Windows keeps the venv's ``.pyd``/
+``.dll`` files (opencv, numpy) locked while the app is running, so replacing
+files in-place is unreliable by construction; the launcher applies the staged
+tree before Python loads anything. That also means a staged update's own
+``requirements.txt`` is in place before the launcher's dependency check runs,
+so dependency changes install on the same restart.
+
+Everything in the ``updates/`` tree lives under the data root, which is
+outside the app folder (see ``sorter/paths.py``).
+
+Environment overrides:
+  ``CASESORTER_UPDATE_REPO``      — ``owner/repo`` to check (default: upstream)
+  ``CASESORTER_UPDATE_API_BASE``  — GitHub API base, for testing
+  ``CASESORTER_UPDATE_DISABLED``  — ``1`` disables checking entirely
+"""
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import zipfile
+from dataclasses import dataclass
+from pathlib import Path, PurePosixPath
+from typing import Any, Callable
+
+import requests
+
+from . import __version__, paths
+
+DEFAULT_REPO = "sjseth/AI-Case-Sorter-Py"
+DEFAULT_API_BASE = "https://api.github.com"
+
+# Settings key (SettingsRepo) for the startup check opt-out.
+SETTING_CHECK_ON_STARTUP = "updates.check_on_startup"
+
+# GitHub's unauthenticated API allows 60 requests/hour per IP. A once-per-launch
+# check is nowhere near that, but keep the timeout tight so a slow or blocked
+# network never delays startup.
+CHECK_TIMEOUT = 10
+DOWNLOAD_TIMEOUT = 60
+
+# An update archive must look like this repo before we let it near the app
+# folder — cheap insurance against a mis-tagged or truncated release.
+REQUIRED_ENTRIES = ("main.py", "sorter/__init__.py")
+
+# Refuse absurd archives outright rather than filling the user's disk. The
+# source tree is ~1 MB; 200 MB is orders of magnitude of headroom.
+MAX_ARCHIVE_BYTES = 200 * 1024 * 1024
+
+
+class UpdateError(RuntimeError):
+    """Raised when a check or download fails in a way worth showing the user."""
+
+
+@dataclass(frozen=True)
+class UpdateInfo:
+    """A release newer than what's running."""
+
+    version: str          # normalized, no leading "v"
+    tag: str              # the tag as GitHub reports it
+    url: str              # ZIP to download
+    notes: str = ""       # release body (markdown)
+    size: int | None = None
+    published_at: str = ""
+
+
+@dataclass(frozen=True)
+class PendingUpdate:
+    """A downloaded, verified update waiting for the next launch."""
+
+    version: str
+    tag: str
+    path: Path
+    staged_at: str = ""
+
+
+# ----- version comparison -----------------------------------------------------
+
+
+def _parse_version(text: str) -> tuple[tuple[int, ...], int]:
+    """Parse ``v1.2.3`` / ``1.2.3-rc1`` into a sortable key.
+
+    Returns ``(numbers, rank)`` where rank is 0 for a pre-release and 1 for a
+    final release, so ``1.2.0-rc1 < 1.2.0``. Non-numeric junk is ignored
+    rather than raising — a malformed upstream tag should read as "not newer",
+    never as a crash on startup.
+    """
+    s = (text or "").strip().lstrip("vV")
+    pre = 0 if any(c in s for c in "-+") else 1
+    core = s.split("-", 1)[0].split("+", 1)[0]
+
+    nums: list[int] = []
+    for part in core.split("."):
+        digits = ""
+        for ch in part:
+            if not ch.isdigit():
+                break
+            digits += ch
+        if not digits:
+            break
+        nums.append(int(digits))
+    return tuple(nums), pre
+
+
+def is_newer(candidate: str, current: str) -> bool:
+    """True when ``candidate`` is a strictly newer version than ``current``."""
+    cand_nums, cand_pre = _parse_version(candidate)
+    cur_nums, cur_pre = _parse_version(current)
+    if not cand_nums:
+        return False
+    # Zero-pad so 1.2 and 1.2.0 compare equal.
+    width = max(len(cand_nums), len(cur_nums))
+    cand_padded = cand_nums + (0,) * (width - len(cand_nums))
+    cur_padded = cur_nums + (0,) * (width - len(cur_nums))
+    return (cand_padded, cand_pre) > (cur_padded, cur_pre)
+
+
+def current_version() -> str:
+    return __version__
+
+
+def launcher_path() -> Path | None:
+    """The launcher script to re-exec on "Restart Now", if the install has one.
+
+    Running from a bare ``python main.py`` checkout there may not be one — the
+    caller then tells the user to relaunch by hand rather than guessing.
+    """
+    import sys
+
+    name = "start.bat" if sys.platform == "win32" else "start.sh"
+    candidate = paths.app_root() / name
+    return candidate if candidate.is_file() else None
+
+
+# ----- checking ---------------------------------------------------------------
+
+
+def update_repo() -> str:
+    return os.environ.get("CASESORTER_UPDATE_REPO") or DEFAULT_REPO
+
+
+def checks_disabled() -> bool:
+    return os.environ.get("CASESORTER_UPDATE_DISABLED", "").strip() in ("1", "true", "yes")
+
+
+def _api_base() -> str:
+    return (os.environ.get("CASESORTER_UPDATE_API_BASE") or DEFAULT_API_BASE).rstrip("/")
+
+
+def _pick_asset(release: dict[str, Any], tag: str) -> tuple[str, int | None]:
+    """Prefer a published ``.zip`` asset; fall back to the tag source archive.
+
+    A purpose-built asset lets the maintainer ship a trimmed archive (no tests,
+    no CI config); the source archive means a release with no assets still
+    updates correctly.
+    """
+    for asset in release.get("assets") or []:
+        name = str(asset.get("name") or "")
+        url = asset.get("browser_download_url")
+        if name.lower().endswith(".zip") and url:
+            size = asset.get("size")
+            return str(url), int(size) if isinstance(size, int) else None
+    repo = update_repo()
+    return f"https://github.com/{repo}/archive/refs/tags/{tag}.zip", None
+
+
+def check_for_update(
+    *,
+    current: str | None = None,
+    session: requests.Session | None = None,
+    timeout: int = CHECK_TIMEOUT,
+) -> UpdateInfo | None:
+    """Return the latest release if it's newer than what's running, else None.
+
+    ``/releases/latest`` already excludes drafts and pre-releases, so users on
+    the stable channel never see a release candidate.
+    """
+    if checks_disabled():
+        return None
+
+    cur = current or current_version()
+    url = f"{_api_base()}/repos/{update_repo()}/releases/latest"
+    get = (session or requests).get
+    try:
+        resp = get(
+            url,
+            timeout=timeout,
+            headers={
+                "Accept": "application/vnd.github+json",
+                "User-Agent": f"CaseSorter/{cur}",
+            },
+        )
+    except requests.RequestException as exc:
+        raise UpdateError(f"Could not reach the update server: {exc}") from exc
+
+    if resp.status_code == 404:
+        # No releases published yet — not an error worth surfacing.
+        return None
+    if resp.status_code != 200:
+        raise UpdateError(f"Update check failed (HTTP {resp.status_code}).")
+
+    try:
+        release = resp.json()
+    except ValueError as exc:
+        raise UpdateError("Update server returned a malformed response.") from exc
+
+    tag = str(release.get("tag_name") or "").strip()
+    if not tag:
+        return None
+    version = tag.lstrip("vV")
+    if not is_newer(version, cur):
+        return None
+
+    asset_url, size = _pick_asset(release, tag)
+    return UpdateInfo(
+        version=version,
+        tag=tag,
+        url=asset_url,
+        notes=str(release.get("body") or "").strip(),
+        size=size,
+        published_at=str(release.get("published_at") or ""),
+    )
+
+
+# ----- staging ----------------------------------------------------------------
+
+
+def _pending_meta_path() -> Path:
+    # Sibling of the payload, never inside it: anything in `pending/` gets
+    # copied into the app folder verbatim.
+    return paths.updates_dir() / "pending.json"
+
+
+def pending_dir() -> Path:
+    return paths.updates_dir() / "pending"
+
+
+def pending_update() -> PendingUpdate | None:
+    """The staged update waiting for the next launch, if any."""
+    meta_path = _pending_meta_path()
+    payload = pending_dir()
+    if not meta_path.is_file() or not payload.is_dir():
+        return None
+    try:
+        meta = json.loads(meta_path.read_text(encoding="utf-8"))
+    except (OSError, ValueError):
+        return None
+    version = str(meta.get("version") or "")
+    if not version:
+        return None
+    return PendingUpdate(
+        version=version,
+        tag=str(meta.get("tag") or version),
+        path=payload,
+        staged_at=str(meta.get("staged_at") or ""),
+    )
+
+
+def clear_pending() -> None:
+    """Discard any staged update. Safe to call when there isn't one."""
+    shutil.rmtree(pending_dir(), ignore_errors=True)
+    try:
+        _pending_meta_path().unlink()
+    except FileNotFoundError:
+        pass
+    except OSError:
+        pass
+
+
+def _safe_members(zf: zipfile.ZipFile) -> list[tuple[zipfile.ZipInfo, PurePosixPath]]:
+    """Validate archive entries and strip GitHub's top-level folder.
+
+    Rejects the same shapes ``model_io`` rejects — ``..`` traversal and
+    absolute paths — because this archive is written straight into the app
+    folder. GitHub's source archives nest everything under
+    ``<repo>-<tag>/``; that single wrapper is stripped so the tree lines up
+    with the app folder.
+    """
+    raw: list[tuple[zipfile.ZipInfo, PurePosixPath]] = []
+    total = 0
+    for entry in zf.infolist():
+        name = entry.filename.replace("\\", "/")
+        if name.endswith("/"):
+            continue
+        if name.startswith("/") or (len(name) > 1 and name[1] == ":"):
+            raise UpdateError(f"Update archive contains an absolute path: {entry.filename}")
+        rel = PurePosixPath(name.lstrip("/"))
+        if any(part == ".." for part in rel.parts):
+            raise UpdateError(f"Update archive contains a traversal path: {entry.filename}")
+        total += entry.file_size
+        if total > MAX_ARCHIVE_BYTES:
+            raise UpdateError("Update archive is implausibly large; refusing to extract.")
+        raw.append((entry, rel))
+
+    if not raw:
+        raise UpdateError("Update archive is empty.")
+
+    # Strip a single common top-level directory, if every entry shares one.
+    tops = {rel.parts[0] for _, rel in raw if len(rel.parts) > 1}
+    singles = [rel for _, rel in raw if len(rel.parts) == 1]
+    if len(tops) == 1 and not singles:
+        return [(entry, PurePosixPath(*rel.parts[1:])) for entry, rel in raw]
+    return raw
+
+
+def _download(url: str, dest: Path, progress: Callable[[int, int | None], None] | None,
+              session: requests.Session | None, timeout: int) -> Path:
+    """Stream ``url`` to ``dest`` with an atomic ``.tmp`` → ``os.replace``."""
+    dest.parent.mkdir(parents=True, exist_ok=True)
+    tmp = dest.with_suffix(dest.suffix + ".tmp")
+    get = (session or requests).get
+    try:
+        with get(url, stream=True, timeout=timeout) as resp:
+            resp.raise_for_status()
+            total: int | None = None
+            cl = resp.headers.get("Content-Length")
+            if cl is not None:
+                try:
+                    total = int(cl)
+                except ValueError:
+                    total = None
+            done = 0
+            with open(tmp, "wb") as fh:
+                for chunk in resp.iter_content(chunk_size=64 * 1024):
+                    if not chunk:
+                        continue
+                    done += len(chunk)
+                    if done > MAX_ARCHIVE_BYTES:
+                        raise UpdateError("Update download exceeded the size limit.")
+                    fh.write(chunk)
+                    if progress is not None:
+                        progress(done, total)
+    except requests.RequestException as exc:
+        tmp.unlink(missing_ok=True)
+        raise UpdateError(f"Download failed: {exc}") from exc
+    except BaseException:
+        tmp.unlink(missing_ok=True)
+        raise
+
+    os.replace(tmp, dest)
+    return dest
+
+
+def stage_update(
+    info: UpdateInfo,
+    *,
+    progress: Callable[[int, int | None], None] | None = None,
+    session: requests.Session | None = None,
+    timeout: int = DOWNLOAD_TIMEOUT,
+) -> PendingUpdate:
+    """Download and verify ``info``, leaving it staged for the next launch.
+
+    The app folder is not touched. On any failure the previous staged update
+    (if any) is left intact and the partial work is cleaned up.
+    """
+    updates = paths.updates_dir()
+    updates.mkdir(parents=True, exist_ok=True)
+    archive = updates / "download.zip"
+    staging = updates / "staging"
+
+    shutil.rmtree(staging, ignore_errors=True)
+    try:
+        _download(info.url, archive, progress, session, timeout)
+
+        if not zipfile.is_zipfile(archive):
+            raise UpdateError("Downloaded file is not a valid ZIP archive.")
+
+        with zipfile.ZipFile(archive) as zf:
+            members = _safe_members(zf)
+            names = {str(rel) for _, rel in members}
+            missing = [e for e in REQUIRED_ENTRIES if e not in names]
+            if missing:
+                raise UpdateError(
+                    "Update archive does not look like the app "
+                    f"(missing {', '.join(missing)})."
+                )
+            staging.mkdir(parents=True, exist_ok=True)
+            for entry, rel in members:
+                out = staging / Path(*rel.parts)
+                out.parent.mkdir(parents=True, exist_ok=True)
+                with zf.open(entry) as src, open(out, "wb") as dst:
+                    shutil.copyfileobj(src, dst)
+    except BaseException:
+        shutil.rmtree(staging, ignore_errors=True)
+        archive.unlink(missing_ok=True)
+        raise
+
+    archive.unlink(missing_ok=True)
+
+    # Swap staging into place last, so `pending/` only ever exists complete.
+    clear_pending()
+    os.replace(staging, pending_dir())
+
+    from datetime import datetime, timezone
+
+    staged_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
+    _pending_meta_path().write_text(
+        json.dumps(
+            {
+                "version": info.version,
+                "tag": info.tag,
+                "staged_at": staged_at,
+                "from_version": current_version(),
+            },
+            indent=2,
+        ),
+        encoding="utf-8",
+    )
+    return PendingUpdate(
+        version=info.version, tag=info.tag, path=pending_dir(), staged_at=staged_at
+    )

--- a/start.bat
+++ b/start.bat
@@ -24,6 +24,12 @@ if not exist "%ROOT%.venv" (
 
 call "%ROOT%.venv\Scripts\activate.bat"
 
+REM Apply a staged in-app update BEFORE the dependency check below, so an
+REM update that changes requirements.txt gets its new dependencies installed
+REM on this same launch. Stdlib-only and always exits 0 — a broken updater
+REM must never stop the app from starting.
+python "%ROOT%main.py" --apply-update
+
 REM Compute a SHA-256 of requirements.txt and store it in .installed so any
 REM edit to requirements.txt triggers a refresh on the next launch. Matches
 REM the hash-based marker used by start.sh.

--- a/start.sh
+++ b/start.sh
@@ -190,6 +190,14 @@ fi
 source .venv/bin/activate
 
 # ---------------------------------------------------------------------------
+# 4b. Apply a staged in-app update BEFORE the dependency check below, so an
+#     update that changes requirements.txt gets its new dependencies installed
+#     on this same launch. Stdlib-only and always exits 0 — a broken updater
+#     must never stop the app from starting.
+# ---------------------------------------------------------------------------
+python main.py --apply-update || true
+
+# ---------------------------------------------------------------------------
 # 5. Install pip deps. Use a hash of requirements.txt as the install marker so
 #    edits to requirements.txt trigger a refresh instead of being silently
 #    ignored.

--- a/tests/test_apply_update.py
+++ b/tests/test_apply_update.py
@@ -1,0 +1,195 @@
+"""Tests for the pre-launch apply step.
+
+The invariants that matter: user data survives, stale modules get pruned, a
+failure rolls back, and the launcher is never blocked.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+from sorter import apply_update, paths
+
+
+@pytest.fixture()
+def install(monkeypatch, tmp_path: Path):
+    """A fake install: app folder, separate data root, a staged update."""
+    app = tmp_path / "app"
+    data = tmp_path / "data"
+    (app / "sorter").mkdir(parents=True)
+    (app / "main.py").write_text("old main\n", encoding="utf-8")
+    (app / "sorter" / "__init__.py").write_text('__version__ = "0.1.0"\n', encoding="utf-8")
+    (app / "sorter" / "gone.py").write_text("removed upstream\n", encoding="utf-8")
+    (app / "requirements.txt").write_text("requests\n", encoding="utf-8")
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(data))
+    monkeypatch.setattr(paths, "app_root", lambda: app)
+    return app, data
+
+
+def _stage(data: Path, files: dict[str, str], *, version: str = "0.9.0") -> None:
+    pending = data / "updates" / "pending"
+    for rel, content in files.items():
+        p = pending / rel
+        p.parent.mkdir(parents=True, exist_ok=True)
+        p.write_text(content, encoding="utf-8")
+    (data / "updates" / "pending.json").write_text(
+        json.dumps({"version": version, "tag": f"v{version}", "from_version": "0.1.0"}),
+        encoding="utf-8",
+    )
+
+
+def test_no_pending_update_is_a_noop(install) -> None:
+    app, _ = install
+    assert apply_update.apply_pending() is False
+    assert (app / "main.py").read_text(encoding="utf-8") == "old main\n"
+
+
+def test_applies_staged_files(install) -> None:
+    app, data = install
+    _stage(data, {
+        "main.py": "new main\n",
+        "sorter/__init__.py": '__version__ = "0.9.0"\n',
+        "sorter/updater.py": "brand new\n",
+        "requirements.txt": "requests\nnumpy\n",
+    })
+
+    assert apply_update.apply_pending() is True
+    assert (app / "main.py").read_text(encoding="utf-8") == "new main\n"
+    assert (app / "sorter" / "updater.py").read_text(encoding="utf-8") == "brand new\n"
+    # requirements.txt must land before the launcher's hash check runs.
+    assert (app / "requirements.txt").read_text(encoding="utf-8") == "requests\nnumpy\n"
+
+
+def test_prunes_modules_removed_upstream(install) -> None:
+    app, data = install
+    _stage(data, {"main.py": "new\n", "sorter/__init__.py": "new\n"})
+
+    assert apply_update.apply_pending() is True
+    assert not (app / "sorter" / "gone.py").exists()
+
+
+def test_pruning_is_confined_to_the_package_dir(install) -> None:
+    """A top-level file the archive omits is left alone, not deleted."""
+    app, data = install
+    (app / "notes.txt").write_text("mine", encoding="utf-8")
+    _stage(data, {"main.py": "new\n", "sorter/__init__.py": "new\n"})
+
+    apply_update.apply_pending()
+    assert (app / "notes.txt").read_text(encoding="utf-8") == "mine"
+
+
+def test_protected_paths_survive(install) -> None:
+    app, data = install
+    (app / ".venv" / "lib").mkdir(parents=True)
+    (app / ".venv" / "lib" / "pyvenv.cfg").write_text("venv", encoding="utf-8")
+    (app / ".env").write_text("SECRET=1", encoding="utf-8")
+    (app / ".installed").write_text("hash", encoding="utf-8")
+    (app / "data").mkdir()
+    (app / "data" / "casesorter.db").write_text("portable db", encoding="utf-8")
+
+    # A hostile/mistaken archive that tries to overwrite all of them.
+    _stage(data, {
+        "main.py": "new\n",
+        "sorter/__init__.py": "new\n",
+        ".env": "STOLEN=1",
+        ".installed": "bogus",
+        "data/casesorter.db": "clobbered",
+        ".venv/lib/pyvenv.cfg": "clobbered",
+    })
+
+    assert apply_update.apply_pending() is True
+    assert (app / ".env").read_text(encoding="utf-8") == "SECRET=1"
+    assert (app / ".installed").read_text(encoding="utf-8") == "hash"
+    assert (app / "data" / "casesorter.db").read_text(encoding="utf-8") == "portable db"
+    assert (app / ".venv" / "lib" / "pyvenv.cfg").read_text(encoding="utf-8") == "venv"
+
+
+def test_pending_is_cleared_after_success(install) -> None:
+    app, data = install
+    _stage(data, {"main.py": "new\n", "sorter/__init__.py": "new\n"})
+    apply_update.apply_pending()
+
+    assert not (data / "updates" / "pending").exists()
+    assert not (data / "updates" / "pending.json").exists()
+    # Second launch must not re-apply.
+    assert apply_update.apply_pending() is False
+
+
+def test_records_what_was_applied(install) -> None:
+    app, data = install
+    _stage(data, {"main.py": "new\n", "sorter/__init__.py": "new\n"})
+    apply_update.apply_pending()
+
+    record = json.loads((data / "updates" / "last_applied.json").read_text())
+    assert record["version"] == "0.9.0"
+    assert record["from_version"] == "0.1.0"
+
+
+def test_rollback_restores_the_previous_version(install, monkeypatch) -> None:
+    app, data = install
+    _stage(data, {
+        "main.py": "new main\n",
+        "sorter/__init__.py": "new init\n",
+        "sorter/updater.py": "new module\n",
+    })
+
+    real_copy = apply_update.shutil.copy2
+    staged_root = data / "updates" / "pending"
+
+    def _flaky_copy(src, dst, *a, **k):
+        # Simulate the realistic failure: one staged file can't be written
+        # (locked, permissions). Copies *out of* the backup still work, which
+        # is what lets the rollback do its job.
+        if Path(src).is_relative_to(staged_root) and Path(src).name == "updater.py":
+            raise OSError("permission denied")
+        return real_copy(src, dst, *a, **k)
+
+    monkeypatch.setattr(apply_update.shutil, "copy2", _flaky_copy)
+
+    assert apply_update.apply_pending() is False
+    # Everything back the way it was.
+    assert (app / "main.py").read_text(encoding="utf-8") == "old main\n"
+    assert (app / "sorter" / "__init__.py").read_text(encoding="utf-8") == '__version__ = "0.1.0"\n'
+    assert (app / "sorter" / "gone.py").read_text(encoding="utf-8") == "removed upstream\n"
+    assert not (app / "sorter" / "updater.py").exists()
+    # Kept for a later retry rather than silently dropped.
+    assert (data / "updates" / "pending.json").is_file()
+
+
+def test_empty_staged_tree_is_discarded(install) -> None:
+    app, data = install
+    (data / "updates" / "pending").mkdir(parents=True)
+    (data / "updates" / "pending.json").write_text(
+        json.dumps({"version": "0.9.0"}), encoding="utf-8"
+    )
+    assert apply_update.apply_pending() is False
+    assert not (data / "updates" / "pending.json").exists()
+
+
+def test_corrupt_metadata_is_discarded(install) -> None:
+    app, data = install
+    (data / "updates" / "pending").mkdir(parents=True)
+    (data / "updates" / "pending" / "main.py").write_text("x", encoding="utf-8")
+    (data / "updates" / "pending.json").write_text("{not json", encoding="utf-8")
+
+    assert apply_update.apply_pending() is False
+    assert not (data / "updates" / "pending.json").exists()
+    assert (app / "main.py").read_text(encoding="utf-8") == "old main\n"
+
+
+def test_main_always_exits_zero(install, monkeypatch) -> None:
+    """A broken updater must never stop the launcher."""
+    def _boom(*a, **k):
+        raise RuntimeError("kaboom")
+
+    monkeypatch.setattr(apply_update, "apply_pending", _boom)
+    assert apply_update.main([]) == 0
+
+
+def test_main_accepts_an_app_dir_override(install) -> None:
+    app, data = install
+    _stage(data, {"main.py": "new\n", "sorter/__init__.py": "new\n"})
+    assert apply_update.main(["--app-dir", str(app)]) == 0
+    assert (app / "main.py").read_text(encoding="utf-8") == "new\n"

--- a/tests/test_paths.py
+++ b/tests/test_paths.py
@@ -1,27 +1,58 @@
-"""Tests for the portable-data path layout."""
+"""Tests for the data-root layout and the legacy-folder migration."""
 from __future__ import annotations
 
-import os
+import sys
 from pathlib import Path
+
+import pytest
 
 from sorter import paths
 
 
-def test_default_root_is_inside_oss_client_folder(monkeypatch) -> None:
+@pytest.fixture(autouse=True)
+def _no_override(monkeypatch):
+    """Every test here decides its own root; never inherit the caller's."""
     monkeypatch.delenv("CASESORTER_DATA_DIR", raising=False)
-    root = paths.app_data_dir()
-    # paths.py lives at `<oss>/sorter/paths.py`; the data root must be `<oss>/data`.
-    expected = Path(paths.__file__).resolve().parent.parent / "data"
-    assert root == expected
 
 
-def test_env_override(monkeypatch, tmp_path: Path) -> None:
+def test_env_override_wins(monkeypatch, tmp_path: Path) -> None:
     monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path))
     assert paths.app_data_dir() == tmp_path
     assert paths.config_dir() == tmp_path / "config"
     assert paths.db_path() == tmp_path / "config" / "casesorter.db"
     assert paths.token_cache_path() == tmp_path / "config" / "msal_cache.bin"
     assert paths.models_dir() == tmp_path / "models"
+    assert paths.updates_dir() == tmp_path / "updates"
+
+
+def test_default_root_is_outside_the_app_folder(monkeypatch, tmp_path: Path) -> None:
+    """The updater overwrites the app folder — user data must not live in it."""
+    monkeypatch.setattr(paths, "app_root", lambda: tmp_path / "app")
+    monkeypatch.setattr(paths, "_os_data_dir", lambda: tmp_path / "userdata")
+    root = paths.app_data_dir()
+    assert root == tmp_path / "userdata"
+    assert (tmp_path / "app") not in root.parents
+
+
+def test_portable_marker_pins_data_into_the_app_folder(
+    monkeypatch, tmp_path: Path
+) -> None:
+    app = tmp_path / "app"
+    app.mkdir()
+    (app / paths.PORTABLE_MARKER).write_text("", encoding="utf-8")
+    monkeypatch.setattr(paths, "app_root", lambda: app)
+    assert paths.is_portable() is True
+    assert paths.app_data_dir() == app / "data"
+
+
+def test_os_data_dir_per_platform(monkeypatch, tmp_path: Path) -> None:
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "local"))
+    monkeypatch.setattr(sys, "platform", "win32")
+    assert paths._os_data_dir() == tmp_path / "local" / "CaseSorter"
+
+    monkeypatch.setattr(sys, "platform", "linux")
+    monkeypatch.setenv("XDG_DATA_HOME", str(tmp_path / "xdg"))
+    assert paths._os_data_dir() == tmp_path / "xdg" / "CaseSorter"
 
 
 def test_per_model_layout(monkeypatch, tmp_path: Path) -> None:
@@ -48,9 +79,83 @@ def test_ensure_model_subtree(monkeypatch, tmp_path: Path) -> None:
     assert paths.model_trained_dir(42).is_dir()
 
 
-def test_export_temp_dir_is_app_local(monkeypatch, tmp_path: Path) -> None:
+def test_export_temp_dir_is_under_the_data_root(monkeypatch, tmp_path: Path) -> None:
     # The share/export scratch folder must live under the app's own data dir,
     # never the OS temp dir (which on Windows can be locked or cleaned mid-write).
     monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path))
     assert paths.export_temp_dir() == tmp_path / "tmp"
     assert paths.export_temp_dir().parent == paths.app_data_dir()
+
+
+# ----- legacy migration -------------------------------------------------------
+
+
+def _fake_install(monkeypatch, tmp_path: Path) -> tuple[Path, Path]:
+    app = tmp_path / "app"
+    dest = tmp_path / "userdata"
+    app.mkdir()
+    monkeypatch.setattr(paths, "app_root", lambda: app)
+    monkeypatch.setattr(paths, "_os_data_dir", lambda: dest)
+    return app, dest
+
+
+def test_migration_moves_legacy_data(monkeypatch, tmp_path: Path) -> None:
+    app, dest = _fake_install(monkeypatch, tmp_path)
+    legacy = app / "data"
+    (legacy / "config").mkdir(parents=True)
+    (legacy / "config" / "casesorter.db").write_text("db", encoding="utf-8")
+    (legacy / "models" / "3" / "images").mkdir(parents=True)
+    (legacy / "models" / "3" / "images" / "WIN__1.jpg").write_text("x", encoding="utf-8")
+
+    moved = paths.migrate_legacy_data_dir()
+
+    assert moved == dest
+    assert (dest / "config" / "casesorter.db").read_text(encoding="utf-8") == "db"
+    assert (dest / "models" / "3" / "images" / "WIN__1.jpg").is_file()
+    assert not legacy.exists()
+
+
+def test_migration_is_idempotent(monkeypatch, tmp_path: Path) -> None:
+    app, dest = _fake_install(monkeypatch, tmp_path)
+    (app / "data" / "config").mkdir(parents=True)
+    assert paths.migrate_legacy_data_dir() == dest
+    # Second run is a no-op, not a second move.
+    assert paths.migrate_legacy_data_dir() is None
+
+
+def test_migration_does_not_clobber_an_existing_root(
+    monkeypatch, tmp_path: Path
+) -> None:
+    app, dest = _fake_install(monkeypatch, tmp_path)
+    (app / "data").mkdir()
+    (app / "data" / "stale.txt").write_text("old", encoding="utf-8")
+    dest.mkdir(parents=True)
+    (dest / "casesorter.db").write_text("live", encoding="utf-8")
+
+    assert paths.migrate_legacy_data_dir() is None
+    assert (dest / "casesorter.db").read_text(encoding="utf-8") == "live"
+    assert (app / "data" / "stale.txt").is_file()
+
+
+def test_migration_skipped_when_portable(monkeypatch, tmp_path: Path) -> None:
+    app, dest = _fake_install(monkeypatch, tmp_path)
+    (app / paths.PORTABLE_MARKER).write_text("", encoding="utf-8")
+    (app / "data").mkdir()
+    assert paths.migrate_legacy_data_dir() is None
+    assert (app / "data").is_dir()
+    assert not dest.exists()
+
+
+def test_migration_skipped_when_env_override_set(
+    monkeypatch, tmp_path: Path
+) -> None:
+    app, dest = _fake_install(monkeypatch, tmp_path)
+    (app / "data").mkdir()
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "elsewhere"))
+    assert paths.migrate_legacy_data_dir() is None
+    assert not dest.exists()
+
+
+def test_migration_no_legacy_folder(monkeypatch, tmp_path: Path) -> None:
+    _fake_install(monkeypatch, tmp_path)
+    assert paths.migrate_legacy_data_dir() is None

--- a/tests/test_updater.py
+++ b/tests/test_updater.py
@@ -1,0 +1,264 @@
+"""Tests for the update check + staging half of the updater."""
+from __future__ import annotations
+
+import io
+import json
+import zipfile
+from pathlib import Path
+
+import pytest
+import requests
+
+from sorter import updater
+from sorter.updater import UpdateError, UpdateInfo
+
+
+@pytest.fixture(autouse=True)
+def _isolated_data_root(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.delenv("CASESORTER_UPDATE_DISABLED", raising=False)
+    monkeypatch.delenv("CASESORTER_UPDATE_REPO", raising=False)
+    monkeypatch.delenv("CASESORTER_UPDATE_API_BASE", raising=False)
+    return tmp_path
+
+
+# ----- version comparison -----------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "candidate,current,expected",
+    [
+        ("0.2.0", "0.1.0", True),
+        ("v0.2.0", "0.1.0", True),
+        ("0.1.0", "0.1.0", False),
+        ("0.1.0", "0.2.0", False),
+        ("1.0.0", "0.9.9", True),
+        ("0.10.0", "0.9.0", True),        # numeric, not lexicographic
+        ("0.2", "0.2.0", False),          # zero-padded to equal
+        ("0.2.1", "0.2", True),
+        ("0.2.0-rc1", "0.1.0", True),     # prerelease still newer than 0.1.0
+        ("0.2.0-rc1", "0.2.0", False),    # ...but older than its own release
+        ("0.2.0", "0.2.0-rc1", True),
+        ("garbage", "0.1.0", False),      # malformed tag reads as "not newer"
+        ("", "0.1.0", False),
+    ],
+)
+def test_is_newer(candidate: str, current: str, expected: bool) -> None:
+    assert updater.is_newer(candidate, current) is expected
+
+
+# ----- checking ---------------------------------------------------------------
+
+
+class _Resp:
+    def __init__(self, status: int, payload=None) -> None:
+        self.status_code = status
+        self._payload = payload
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("no json")
+        return self._payload
+
+
+def _release(tag: str = "v0.9.0", assets=None, body: str = "notes") -> dict:
+    return {"tag_name": tag, "body": body, "assets": assets or [],
+            "published_at": "2026-01-01T00:00:00Z"}
+
+
+def test_check_returns_info_when_newer(monkeypatch) -> None:
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _Resp(200, _release()))
+    info = updater.check_for_update(current="0.1.0")
+    assert info is not None
+    assert info.version == "0.9.0"
+    assert info.tag == "v0.9.0"
+    assert info.notes == "notes"
+    # No .zip asset published → fall back to the tag source archive.
+    assert info.url.endswith("/archive/refs/tags/v0.9.0.zip")
+
+
+def test_check_prefers_a_published_zip_asset(monkeypatch) -> None:
+    assets = [
+        {"name": "checksums.txt", "browser_download_url": "https://x/c.txt"},
+        {"name": "casesorter-0.9.0.zip",
+         "browser_download_url": "https://x/app.zip", "size": 4242},
+    ]
+    monkeypatch.setattr(requests, "get",
+                        lambda *a, **k: _Resp(200, _release(assets=assets)))
+    info = updater.check_for_update(current="0.1.0")
+    assert info is not None
+    assert info.url == "https://x/app.zip"
+    assert info.size == 4242
+
+
+def test_check_returns_none_when_current(monkeypatch) -> None:
+    monkeypatch.setattr(requests, "get",
+                        lambda *a, **k: _Resp(200, _release(tag="v0.1.0")))
+    assert updater.check_for_update(current="0.1.0") is None
+
+
+def test_check_returns_none_when_no_releases(monkeypatch) -> None:
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _Resp(404))
+    assert updater.check_for_update(current="0.1.0") is None
+
+
+def test_check_disabled_by_env(monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_UPDATE_DISABLED", "1")
+
+    def _boom(*a, **k):
+        raise AssertionError("network must not be touched when disabled")
+
+    monkeypatch.setattr(requests, "get", _boom)
+    assert updater.check_for_update(current="0.1.0") is None
+
+
+def test_check_raises_on_server_error(monkeypatch) -> None:
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _Resp(500))
+    with pytest.raises(UpdateError):
+        updater.check_for_update(current="0.1.0")
+
+
+def test_check_wraps_network_failure(monkeypatch) -> None:
+    def _boom(*a, **k):
+        raise requests.ConnectionError("no route to host")
+
+    monkeypatch.setattr(requests, "get", _boom)
+    with pytest.raises(UpdateError, match="Could not reach"):
+        updater.check_for_update(current="0.1.0")
+
+
+# ----- staging ----------------------------------------------------------------
+
+
+def _zip_bytes(entries: dict[str, str]) -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        for name, content in entries.items():
+            zf.writestr(name, content)
+    return buf.getvalue()
+
+
+def _good_archive(prefix: str = "AI-Case-Sorter-Py-v0.9.0/") -> bytes:
+    return _zip_bytes({
+        f"{prefix}main.py": "print('new')\n",
+        f"{prefix}sorter/__init__.py": '__version__ = "0.9.0"\n',
+        f"{prefix}sorter/updater.py": "# new\n",
+        f"{prefix}requirements.txt": "requests\n",
+    })
+
+
+class _StreamResp:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self.headers = {"Content-Length": str(len(payload))}
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_content(self, chunk_size: int = 1):
+        for i in range(0, len(self._payload), chunk_size):
+            yield self._payload[i:i + chunk_size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+def _serve(monkeypatch, payload: bytes) -> None:
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _StreamResp(payload))
+
+
+def _info() -> UpdateInfo:
+    return UpdateInfo(version="0.9.0", tag="v0.9.0", url="https://x/app.zip")
+
+
+def test_stage_extracts_and_strips_the_github_wrapper(monkeypatch) -> None:
+    _serve(monkeypatch, _good_archive())
+    pending = updater.stage_update(_info())
+
+    assert pending.version == "0.9.0"
+    assert (pending.path / "main.py").read_text(encoding="utf-8") == "print('new')\n"
+    assert (pending.path / "sorter" / "__init__.py").is_file()
+    # The wrapper directory must be gone, not nested.
+    assert not (pending.path / "AI-Case-Sorter-Py-v0.9.0").exists()
+
+
+def test_stage_records_pending_metadata(monkeypatch) -> None:
+    _serve(monkeypatch, _good_archive())
+    updater.stage_update(_info())
+
+    found = updater.pending_update()
+    assert found is not None
+    assert found.version == "0.9.0"
+    assert found.tag == "v0.9.0"
+    assert found.staged_at
+
+    meta = json.loads((updater.paths.updates_dir() / "pending.json").read_text())
+    assert meta["from_version"] == updater.current_version()
+
+
+def test_stage_reports_progress(monkeypatch) -> None:
+    _serve(monkeypatch, _good_archive())
+    seen: list[tuple[int, int | None]] = []
+    updater.stage_update(_info(), progress=lambda d, t: seen.append((d, t)))
+    assert seen
+    assert seen[-1][0] == seen[-1][1]  # finished at 100%
+
+
+def test_stage_rejects_traversal_entries(monkeypatch) -> None:
+    _serve(monkeypatch, _zip_bytes({
+        "pkg/main.py": "x",
+        "pkg/sorter/__init__.py": "x",
+        "pkg/../../evil.py": "pwned",
+    }))
+    with pytest.raises(UpdateError, match="traversal"):
+        updater.stage_update(_info())
+    assert updater.pending_update() is None
+
+
+def test_stage_rejects_an_archive_that_is_not_the_app(monkeypatch) -> None:
+    _serve(monkeypatch, _zip_bytes({"wrong/readme.txt": "hello"}))
+    with pytest.raises(UpdateError, match="does not look like the app"):
+        updater.stage_update(_info())
+    assert updater.pending_update() is None
+
+
+def test_stage_rejects_a_non_zip(monkeypatch) -> None:
+    _serve(monkeypatch, b"definitely not a zip")
+    with pytest.raises(UpdateError, match="not a valid ZIP"):
+        updater.stage_update(_info())
+    assert updater.pending_update() is None
+
+
+def test_failed_stage_leaves_the_previous_pending_update_intact(monkeypatch) -> None:
+    _serve(monkeypatch, _good_archive())
+    updater.stage_update(_info())
+    assert updater.pending_update() is not None
+
+    _serve(monkeypatch, b"corrupt")
+    with pytest.raises(UpdateError):
+        updater.stage_update(UpdateInfo(version="1.0.0", tag="v1.0.0", url="https://x/b.zip"))
+
+    still = updater.pending_update()
+    assert still is not None and still.version == "0.9.0"
+
+
+def test_stage_leaves_no_scratch_files_behind(monkeypatch) -> None:
+    _serve(monkeypatch, _good_archive())
+    updater.stage_update(_info())
+    updates = updater.paths.updates_dir()
+    assert not (updates / "download.zip").exists()
+    assert not (updates / "staging").exists()
+
+
+def test_clear_pending(monkeypatch) -> None:
+    _serve(monkeypatch, _good_archive())
+    updater.stage_update(_info())
+    updater.clear_pending()
+    assert updater.pending_update() is None
+
+
+def test_pending_update_none_without_metadata() -> None:
+    assert updater.pending_update() is None

--- a/tests/test_updater_ui.py
+++ b/tests/test_updater_ui.py
@@ -1,0 +1,353 @@
+"""Update dialog + MainWindow update wiring (needs a Tk display)."""
+from __future__ import annotations
+
+import io
+import time
+import zipfile
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tkinter")
+pytest.importorskip("cv2")
+
+import tkinter as tk  # noqa: E402
+from tkinter import ttk  # noqa: E402
+
+import requests  # noqa: E402
+
+from sorter import updater  # noqa: E402
+from sorter.db import Database  # noqa: E402
+from sorter.repository import SettingsRepo  # noqa: E402
+from sorter.ui.app import MainWindow  # noqa: E402
+from sorter.ui.dialog_update import UpdateDialog  # noqa: E402
+from sorter.ui.theme import apply_theme  # noqa: E402
+from sorter.updater import PendingUpdate, UpdateInfo  # noqa: E402
+
+
+@pytest.fixture
+def root():
+    try:
+        r = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no Tk display: {exc}")
+    r.withdraw()
+    apply_theme(r)
+    yield r
+    r.destroy()
+
+
+@pytest.fixture(autouse=True)
+def _data_root(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    monkeypatch.delenv("CASESORTER_UPDATE_DISABLED", raising=False)
+
+
+class _FakeApp:
+    def __init__(self, db=None) -> None:
+        self.db = db
+        self.noted: PendingUpdate | None = None
+        self.closed = False
+
+    def note_pending_update(self, pending) -> None:
+        self.noted = pending
+
+    def _on_close(self) -> None:
+        self.closed = True
+
+
+def _info() -> UpdateInfo:
+    return UpdateInfo(version="9.9.9", tag="v9.9.9", url="https://x/app.zip",
+                      notes="- Faster sorting", size=2_500_000)
+
+
+def _archive() -> bytes:
+    buf = io.BytesIO()
+    with zipfile.ZipFile(buf, "w") as zf:
+        zf.writestr("AI-Case-Sorter-Py-v9.9.9/main.py", "new\n")
+        zf.writestr("AI-Case-Sorter-Py-v9.9.9/sorter/__init__.py", '__version__ = "9.9.9"\n')
+    return buf.getvalue()
+
+
+def _pump_until(root, predicate, *, timeout: float = 5.0) -> bool:
+    """Drive the Tk event loop until `predicate` holds or we give up.
+
+    The download runs on a worker thread and marshals results back with
+    `after(0, ...)`, so the test has to both wait for the thread and pump the
+    event loop for those callbacks to fire.
+    """
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        root.update()
+        if predicate():
+            return True
+        time.sleep(0.01)
+    return False
+
+
+class _StreamResp:
+    def __init__(self, payload: bytes) -> None:
+        self._payload = payload
+        self.headers = {"Content-Length": str(len(payload))}
+
+    def raise_for_status(self) -> None: ...
+
+    def iter_content(self, chunk_size: int = 1):
+        for i in range(0, len(self._payload), chunk_size):
+            yield self._payload[i:i + chunk_size]
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *exc):
+        return False
+
+
+# ----- dialog states ----------------------------------------------------------
+
+
+def test_dialog_shows_an_available_update(root) -> None:
+    dlg = UpdateDialog(root, info=_info(), app=_FakeApp())
+    assert dlg._title_var.get() == "Update available"
+    assert updater.current_version() in dlg._version_var.get()
+    assert "9.9.9" in dlg._version_var.get()
+    assert "2.5 MB" in dlg._detail_var.get()
+    assert "Faster sorting" in dlg._notes.get("1.0", tk.END)
+    assert dlg._primary.cget("text") == "Download & Install"
+    dlg.destroy()
+
+
+def test_dialog_reports_being_up_to_date(root) -> None:
+    dlg = UpdateDialog(root, info=None, app=_FakeApp())
+    assert dlg._title_var.get() == "You're up to date"
+    # Nothing to do -> no primary action offered.
+    assert dlg._primary.winfo_manager() == ""
+    assert dlg._secondary.cget("text") == "Close"
+    dlg.destroy()
+
+
+def test_dialog_jumps_straight_to_restart_when_already_staged(root) -> None:
+    pending = PendingUpdate(version="9.9.9", tag="v9.9.9",
+                            path=Path("/tmp/x"), staged_at="now")
+    dlg = UpdateDialog(root, info=None, app=_FakeApp(), pending=pending)
+    assert dlg._title_var.get() == "Update ready to install"
+    assert dlg._primary.cget("text") == "Restart Now"
+    dlg.destroy()
+
+
+def test_dialog_picks_up_a_staged_update_it_was_not_told_about(root, monkeypatch) -> None:
+    """A user who picked "Later" reopens the dialog and gets the restart prompt."""
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _StreamResp(_archive()))
+    updater.stage_update(_info())
+
+    dlg = UpdateDialog(root, info=None, app=_FakeApp())
+    assert dlg._title_var.get() == "Update ready to install"
+    dlg.destroy()
+
+
+# ----- download flow ----------------------------------------------------------
+
+
+def test_download_stages_and_switches_to_restart(root, monkeypatch) -> None:
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _StreamResp(_archive()))
+    app = _FakeApp()
+    dlg = UpdateDialog(root, info=_info(), app=app)
+
+    dlg._on_primary()
+    assert _pump_until(root, lambda: dlg._pending is not None), \
+        "download never completed"
+    assert dlg._pending.version == "9.9.9"
+    assert dlg._primary.cget("text") == "Restart Now"
+    # The app is told, so the status-bar button can flip to "Restart to update".
+    assert app.noted is not None and app.noted.version == "9.9.9"
+    # Staged, not applied.
+    assert (updater.pending_dir() / "main.py").is_file()
+    dlg.destroy()
+
+
+def test_download_failure_offers_a_retry(root, monkeypatch) -> None:
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _StreamResp(b"not a zip"))
+    dlg = UpdateDialog(root, info=_info(), app=_FakeApp())
+
+    dlg._on_primary()
+    assert _pump_until(root, lambda: dlg._primary.cget("text") == "Try Again"), \
+        "failure was never surfaced"
+    assert str(dlg._primary.cget("state")) == "normal"
+    assert "ZIP" in dlg._progress_var.get()
+    assert updater.pending_update() is None
+    dlg.destroy()
+
+
+def test_restart_without_a_launcher_does_not_close_the_app(root, monkeypatch) -> None:
+    """A bare `python main.py` checkout has no start script to re-exec."""
+    monkeypatch.setattr(updater, "launcher_path", lambda: None)
+    pending = PendingUpdate(version="9.9.9", tag="v9.9.9",
+                            path=Path("/tmp/x"), staged_at="now")
+    app = _FakeApp()
+    dlg = UpdateDialog(root, info=None, app=app, pending=pending)
+
+    dlg._on_primary()
+    assert app.closed is False
+    assert "start it again" in dlg._detail_var.get()
+    dlg.destroy()
+
+
+# ----- the startup-check opt-out ---------------------------------------------
+
+
+def test_auto_check_setting_round_trips(root, tmp_path: Path) -> None:
+    db = Database()
+    db.ensure_initialized()
+    try:
+        dlg = UpdateDialog(root, info=_info(), app=_FakeApp(db))
+        assert dlg._auto_var.get() is True     # default on
+
+        dlg._auto_var.set(False)
+        dlg._on_toggle_auto()
+        assert SettingsRepo(db).get(updater.SETTING_CHECK_ON_STARTUP) is False
+
+        # A freshly opened dialog reflects the stored choice.
+        dlg2 = UpdateDialog(root, info=_info(), app=_FakeApp(db))
+        assert dlg2._auto_var.get() is False
+        dlg.destroy()
+        dlg2.destroy()
+    finally:
+        db.close()
+
+
+# ----- MainWindow wiring ------------------------------------------------------
+
+
+class _StubWindow:
+    """Just enough MainWindow surface to exercise the update helpers.
+
+    Constructing a real MainWindow starts the camera and serial auto-connect,
+    which no test should do. The methods under test are borrowed from
+    MainWindow unchanged, so this exercises the real implementations against
+    stub state rather than a reimplementation of them.
+    """
+
+    _check_for_updates_on_startup = MainWindow._check_for_updates_on_startup
+    _auto_check_enabled = MainWindow._auto_check_enabled
+    check_for_updates = MainWindow.check_for_updates
+    note_pending_update = MainWindow.note_pending_update
+    _show_update_button = MainWindow._show_update_button
+
+    def __init__(self, root, db=None) -> None:
+        self.db = db
+        self.root = root
+        self.update_button_var = tk.StringVar(value="Update available")
+        self.update_button = ttk.Button(root, textvariable=self.update_button_var)
+        self._update_info = None
+        self._pending_update = None
+        self.status = ""
+        self.worker_calls = 0
+
+    def set_status(self, msg: str) -> None:
+        self.status = msg
+
+    def run_worker(self, fn, *, on_done=None, on_error=None) -> None:
+        self.worker_calls += 1
+        try:
+            result = fn()
+        except Exception as exc:  # noqa: BLE001
+            if on_error:
+                on_error(exc)
+        else:
+            if on_done:
+                on_done(result)
+
+
+def test_startup_check_reveals_the_button_when_an_update_exists(root, monkeypatch) -> None:
+    win = _StubWindow(root)
+    monkeypatch.setattr(updater, "check_for_update", lambda **k: _info())
+
+    win._check_for_updates_on_startup()
+    root.update()
+
+    assert win.update_button.winfo_manager() == "pack"
+    assert win.update_button_var.get() == "Update to 9.9.9"
+
+
+def test_startup_check_stays_quiet_when_current(root, monkeypatch) -> None:
+    win = _StubWindow(root)
+    monkeypatch.setattr(updater, "check_for_update", lambda **k: None)
+
+    win._check_for_updates_on_startup()
+    root.update()
+
+    assert win.update_button.winfo_manager() == ""
+    assert win.status == ""
+
+
+def test_startup_check_swallows_network_errors(root, monkeypatch) -> None:
+    win = _StubWindow(root)
+
+    def _boom(**k):
+        raise updater.UpdateError("offline")
+
+    monkeypatch.setattr(updater, "check_for_update", _boom)
+    win._check_for_updates_on_startup()
+    root.update()
+
+    assert win.update_button.winfo_manager() == ""
+    assert win.status == ""      # a silent check never nags
+
+
+def test_explicit_check_reports_failure(root, monkeypatch) -> None:
+    win = _StubWindow(root)
+
+    def _boom(**k):
+        raise updater.UpdateError("offline")
+
+    monkeypatch.setattr(updater, "check_for_update", _boom)
+    win.check_for_updates(silent=False)
+    root.update()
+
+    assert "offline" in win.status
+
+
+def test_staged_update_outranks_a_fresh_check(root, monkeypatch) -> None:
+    monkeypatch.setattr(requests, "get", lambda *a, **k: _StreamResp(_archive()))
+    updater.stage_update(_info())
+
+    win = _StubWindow(root)
+
+    def _must_not_run(**k):
+        raise AssertionError("must not check when an update is already staged")
+
+    monkeypatch.setattr(updater, "check_for_update", _must_not_run)
+    win._check_for_updates_on_startup()
+    root.update()
+
+    assert win.update_button_var.get() == "Restart to update"
+    assert win.update_button.winfo_manager() == "pack"
+
+
+def test_startup_check_honours_the_disable_env(root, monkeypatch) -> None:
+    monkeypatch.setenv("CASESORTER_UPDATE_DISABLED", "1")
+    win = _StubWindow(root)
+
+    def _must_not_run(**k):
+        raise AssertionError("must not check when disabled")
+
+    monkeypatch.setattr(updater, "check_for_update", _must_not_run)
+    win._check_for_updates_on_startup()
+    assert win.worker_calls == 0
+
+
+def test_startup_check_honours_the_stored_opt_out(root, monkeypatch) -> None:
+    db = Database()
+    db.ensure_initialized()
+    try:
+        SettingsRepo(db).set(updater.SETTING_CHECK_ON_STARTUP, False)
+        win = _StubWindow(root, db)
+
+        def _must_not_run(**k):
+            raise AssertionError("must not check when opted out")
+
+        monkeypatch.setattr(updater, "check_for_update", _must_not_run)
+        win._check_for_updates_on_startup()
+        assert win.worker_calls == 0
+    finally:
+        db.close()


### PR DESCRIPTION
## Summary

Adds a complete self-update system for the app, allowing users to check for new releases on GitHub, download and stage updates, and apply them on the next launch. Includes a Windows installer script for non-developers who want to run the app without git or a terminal.

## Key Changes

**Core updater (`sorter/updater.py`)**
- GitHub Releases API integration to check for newer versions
- Version comparison logic that handles pre-releases and zero-padding correctly
- Download and verification of release ZIPs with integrity checks
- Staging mechanism that stores updates under the data root (outside the app folder) for safe in-place replacement
- Environment variable overrides for testing and custom repos

**Update UI (`sorter/ui/dialog_update.py`)**
- Three-state dialog: available → downloading → ready to restart
- Release notes display and progress tracking
- Persistent "check on startup" preference stored in settings
- Thread-safe download with cancellation support

**Pre-launch update application (`sorter/apply_update.py`)**
- Stdlib-only module that runs before dependency install (critical for fixing broken environments)
- Atomic apply-or-rollback: backs up files before overwriting, restores on any failure
- Pruning of stale modules removed upstream (confined to `sorter/` package directory)
- Protected paths (`.venv`, `data`, `.env`, etc.) never touched

**Data root refactoring (`sorter/paths.py`)**
- User data now lives **outside** the app folder by default (safe for in-place updates)
- Resolution order: env override → portable marker → OS user data dir
- Legacy migration from app-local `data/` to OS-appropriate location
- New `updates/` subdirectory for staged releases

**Windows installer (`installer/install-windows.ps1` + `.bat`)**
- Finds or installs Python 3.10+ with Tcl/Tk (via winget or python.org)
- Downloads latest release ZIP over HTTPS (no git dependency)
- Per-user install to `%LOCALAPPDATA%\Programs\CaseSorter`
- Hands off to `start.bat` for venv and dependency setup

**Launcher integration (`start.sh`, `start.bat`, `main.py`)**
- Pre-launch hook: `python main.py --apply-update` runs before dependency install
- Ensures staged update's `requirements.txt` is installed on the same restart
- Status bar button shows update availability and restart prompt

**Tests**
- `test_updater.py`: version comparison, API check, download, staging
- `test_apply_update.py`: atomic apply, rollback, pruning, protected paths
- `test_updater_ui.py`: dialog states, download flow, error handling

## Notable Implementation Details

- **Deliberately git-free**: TLS to github.com is the only trust anchor; delta transfer gains are negligible at ~1 MB app size
- **Stage now, apply at next launch**: Windows file-locking issues are avoided by applying before Python loads anything
- **Stdlib-only pre-launch step**: `apply_update.py` must not import third-party packages; it runs against a potentially broken venv
- **Protected paths**: `.venv`, `data`, `.env`, `.git` are never touched by updates; user data is safe by construction
- **Graceful degradation**: broken updater never stops the app from starting (exit code always 0, errors logged to stderr)
- **Data root outside app folder**: makes the updater safe without remembering to exclude paths; legacy data is migrated on first run

## Documentation Updates

- `CLAUDE.md` updated with updater architecture and paths refactoring
- `README.md` updated with Windows installer instructions
- `installer/README.md` explains the installer flow and file locations

https://claude.ai/code/session_01SQEt6qoSAr2hXvp4dzbGVY