### PR TITLE
Fix installer parse failure from non-ASCII characters

### DIFF
--- a/installer/install-windows.bat
+++ b/installer/install-windows.bat
@@ -2,9 +2,9 @@
 REM Double-clickable entry point for the Windows installer.
 REM
 REM Works two ways:
-REM   * next to install-windows.ps1 (a repo checkout / release archive) — runs
+REM   * next to install-windows.ps1 (a repo checkout / release archive) - runs
 REM     the local copy;
-REM   * on its own (downloaded by itself) — fetches the script from GitHub.
+REM   * on its own (downloaded by itself) - fetches the script from GitHub.
 REM
 REM The -ExecutionPolicy Bypass is scoped to this one invocation: a .ps1 that
 REM carries the internet's Mark-of-the-Web is blocked by the default policy,
@@ -22,8 +22,9 @@ if exist "%PS1%" (
 
 echo Downloading the installer...
 set "PS1=%TEMP%\casesorter-install-windows.ps1"
-powershell -NoProfile -ExecutionPolicy Bypass -Command ^
-    "[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%RAW%' -OutFile '%PS1%' -UseBasicParsing"
+REM Single line on purpose: `^` continuation inside a quoted -Command string
+REM is brittle under cmd's parser.
+powershell -NoProfile -ExecutionPolicy Bypass -Command "[Net.ServicePointManager]::SecurityProtocol=[Net.SecurityProtocolType]::Tls12; Invoke-WebRequest -Uri '%RAW%' -OutFile '%PS1%' -UseBasicParsing"
 if errorlevel 1 (
     echo.
     echo Could not download the installer. Check your internet connection.

--- a/installer/install-windows.ps1
+++ b/installer/install-windows.ps1
@@ -3,8 +3,8 @@
     Installs (or updates) the AI Case Sorter on Windows. No git required.
 
 .DESCRIPTION
-    Provisions the two things a non-developer machine is missing — a Python
-    runtime and a copy of the app — then hands off to start.bat, which owns
+    Provisions the two things a non-developer machine is missing - a Python
+    runtime and a copy of the app - then hands off to start.bat, which owns
     the virtualenv and dependency install.
 
     Deliberately git-free. `git pull` over HTTPS and a release ZIP over HTTPS
@@ -12,7 +12,7 @@
     git's delta transfer buys nothing. Not installing a 60 MB dependency to
     deliver a 1 MB update is the whole point.
 
-    Installs per-user to %LOCALAPPDATA%\Programs\CaseSorter — no admin rights,
+    Installs per-user to %LOCALAPPDATA%\Programs\CaseSorter - no admin rights,
     and the folder stays writable so the venv and the in-app updater work.
     User data lives in %LOCALAPPDATA%\CaseSorter, outside the app folder, so
     reinstalling never touches trained models or settings.
@@ -40,6 +40,16 @@ param(
 
 Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
+
+# StrictMode makes reading an unset variable a terminating error, and
+# $LASTEXITCODE does not exist until some external program has run.
+$LASTEXITCODE = 0
+
+# NOTE: keep this file pure ASCII. Windows PowerShell 5.1 decodes a
+# BOM-less file as the system ANSI codepage, so a UTF-8 em-dash arrives as
+# 'a', 'EUR', and U+201D - and PowerShell treats U+201D as a closing double
+# quote, which silently truncates the enclosing string and misparses
+# everything after it. tests/test_installer_scripts.py enforces this.
 
 $Repo         = 'sjseth/AI-Case-Sorter-Py'
 $PythonWinget = 'Python.Python.3.12'
@@ -71,8 +81,10 @@ function Get-PythonCommand {
     #>
     $candidates = @()
 
-    $cmd = Get-Command python -ErrorAction SilentlyContinue
-    if ($cmd) { $candidates += $cmd.Source }
+    # -CommandType Application so a function or alias named `python` can't
+    # shadow a real interpreter.
+    $cmd = Get-Command python -CommandType Application -ErrorAction SilentlyContinue
+    if ($cmd) { $candidates += @($cmd | ForEach-Object { $_.Source }) }
 
     # The py launcher knows about installs that aren't on PATH.
     if (Get-Command py -ErrorAction SilentlyContinue) {
@@ -91,6 +103,10 @@ function Get-PythonCommand {
 
     foreach ($candidate in ($candidates | Where-Object { $_ } | Select-Object -Unique)) {
         if (-not (Test-Path $candidate)) { continue }
+        # Skip the Microsoft Store "app execution alias" stub. It exists on a
+        # stock Windows install with no Python behind it, and running it opens
+        # the Store instead of an interpreter.
+        if ($candidate -like '*\WindowsApps\*') { continue }
         try {
             $out = & $candidate -c "import sys, tkinter; print('%d.%d' % sys.version_info[:2])" 2>$null
             if ($LASTEXITCODE -ne 0 -or -not $out) { continue }
@@ -126,7 +142,7 @@ function Install-Python {
     Write-Note "Downloading $url"
     Invoke-WebRequest -Uri $url -OutFile $exe -UseBasicParsing
 
-    Write-Note "Running the installer (per-user, silent)…"
+    Write-Note "Running the installer (per-user, silent)..."
     $proc = Start-Process -FilePath $exe -Wait -PassThru -ArgumentList @(
         '/quiet', 'InstallAllUsers=0', 'PrependPath=1',
         'Include_tcltk=1', 'Include_pip=1', 'Include_launcher=1'
@@ -137,7 +153,7 @@ function Install-Python {
     }
 
     # PrependPath only affects *new* processes, so this shell still can't see
-    # it — re-read the user PATH rather than trusting `where python`.
+    # it - re-read the user PATH rather than trusting `where python`.
     $env:Path = [Environment]::GetEnvironmentVariable('Path', 'Machine') + ';' +
                 [Environment]::GetEnvironmentVariable('Path', 'User')
 
@@ -173,10 +189,18 @@ function Get-ReleaseInfo {
     }
 
     # Prefer a purpose-built .zip asset; fall back to the source archive.
-    $asset = $resp.assets | Where-Object { $_.name -like '*.zip' } | Select-Object -First 1
+    # Property access is guarded: Set-StrictMode turns a missing property into
+    # a terminating error, and a release with no assets is perfectly normal.
+    $tag = $resp.PSObject.Properties['tag_name'].Value
+    $asset = $null
+    if ($resp.PSObject.Properties['assets']) {
+        $asset = $resp.assets |
+            Where-Object { $_.PSObject.Properties['name'] -and $_.name -like '*.zip' } |
+            Select-Object -First 1
+    }
     $url = if ($asset) { $asset.browser_download_url }
-           else { "https://github.com/$Repo/archive/refs/tags/$($resp.tag_name).zip" }
-    return [pscustomobject]@{ Tag = $resp.tag_name; Url = $url }
+           else { "https://github.com/$Repo/archive/refs/tags/$tag.zip" }
+    return [pscustomobject]@{ Tag = $tag; Url = $url }
 }
 
 function Install-App {
@@ -186,10 +210,10 @@ function Install-App {
     New-Item -ItemType Directory -Path $work -Force | Out-Null
     try {
         $zip = Join-Path $work 'app.zip'
-        Write-Note "Downloading $Tag…"
+        Write-Note "Downloading $Tag..."
         Invoke-WebRequest -Uri $Url -OutFile $zip -UseBasicParsing
 
-        Write-Note "Extracting…"
+        Write-Note "Extracting..."
         $unpack = Join-Path $work 'unpacked'
         Expand-Archive -Path $zip -DestinationPath $unpack -Force
 
@@ -244,13 +268,15 @@ function New-Shortcuts {
 # ---------------------------------------------------------------------------
 
 Write-Host ""
-Write-Host "  AI Case Sorter — Windows installer" -ForegroundColor White
+Write-Host "  AI Case Sorter - Windows installer" -ForegroundColor White
 Write-Host "  ----------------------------------" -ForegroundColor DarkGray
 Write-Host ""
 
-$existing = Test-Path (Join-Path $InstallDir 'main.py')
-if ($existing) { Write-Step "Updating the existing install at $InstallDir" }
-else           { Write-Step "Installing to $InstallDir" }
+if (Test-Path (Join-Path $InstallDir 'main.py')) {
+    Write-Step "Updating the existing install at $InstallDir"
+} else {
+    Write-Step "Installing to $InstallDir"
+}
 
 Write-Step "Checking for Python $PythonMin or newer (with Tcl/Tk)"
 $python = Get-PythonCommand
@@ -276,7 +302,7 @@ Write-Ok "Your models and settings are kept separately at:"
 Write-Host "      $env:LOCALAPPDATA\CaseSorter"
 Write-Host ""
 Write-Note "First launch installs the Python dependencies and takes a few minutes."
-Write-Note "After that, updates are offered inside the app — no need to re-run this."
+Write-Note "After that, updates are offered inside the app - no need to re-run this."
 Write-Host ""
 
 if (-not $NoLaunch) {

--- a/tests/test_installer_scripts.py
+++ b/tests/test_installer_scripts.py
@@ -1,0 +1,75 @@
+"""Guards on the Windows installer scripts.
+
+These can't be executed here (no Windows), so the suite enforces the two
+properties that silently broke them once already.
+
+The expensive one to relearn: Windows PowerShell 5.1 decodes a BOM-less file
+using the system ANSI codepage, not UTF-8. A UTF-8 em-dash (``E2 80 94``)
+therefore arrives as ``a``, ``EUR``, ``U+201D`` -- and PowerShell accepts
+U+201D as a **closing double quote**. Inside a string literal that silently
+truncates the string and misparses everything after it, so the reported error
+lands on some unrelated line much further down.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent
+INSTALLER = ROOT / "installer"
+SCRIPTS = ("install-windows.ps1", "install-windows.bat")
+
+
+@pytest.mark.parametrize("name", SCRIPTS)
+def test_script_exists(name: str) -> None:
+    assert (INSTALLER / name).is_file(), f"installer/{name} is missing"
+
+
+@pytest.mark.parametrize("name", SCRIPTS)
+def test_script_is_pure_ascii(name: str) -> None:
+    """Non-ASCII in these files is a parse hazard, not a style preference."""
+    raw = (INSTALLER / name).read_bytes()
+    offenders = [
+        (n, line) for n, line in enumerate(raw.split(b"\n"), 1)
+        if any(b > 0x7F for b in line)
+    ]
+    assert not offenders, (
+        "Non-ASCII bytes in installer/" + name + " at line(s) "
+        + ", ".join(str(n) for n, _ in offenders)
+        + ". Use '-' for dashes and '...' for ellipses -- PowerShell 5.1 reads "
+        "this file as ANSI and a UTF-8 em-dash becomes a closing quote."
+    )
+
+
+@pytest.mark.parametrize("name", SCRIPTS)
+def test_script_uses_crlf(name: str) -> None:
+    """cmd.exe is unforgiving about bare LF in a .bat; keep both CRLF."""
+    raw = (INSTALLER / name).read_bytes()
+    bare_lf = raw.replace(b"\r\n", b"").count(b"\n")
+    assert bare_lf == 0, f"installer/{name} has {bare_lf} bare LF line ending(s)"
+
+
+def test_powershell_script_has_no_unpaired_quotes_per_line() -> None:
+    """Cheap smoke check for the failure mode the em-dash caused.
+
+    Not a parser -- it only flags an odd number of double quotes on a line
+    that isn't a continuation or a here-string, which is what a truncated
+    string literal looks like.
+    """
+    text = (INSTALLER / "install-windows.ps1").read_text(encoding="ascii")
+    in_block_comment = False
+    bad: list[int] = []
+    for n, line in enumerate(text.splitlines(), 1):
+        stripped = line.strip()
+        if stripped.startswith("<#"):
+            in_block_comment = True
+        if in_block_comment:
+            if stripped.endswith("#>"):
+                in_block_comment = False
+            continue
+        if stripped.startswith("#") or line.rstrip().endswith("`"):
+            continue
+        if line.count('"') % 2 != 0:
+            bad.append(n)
+    assert not bad, f"odd number of double quotes on line(s): {bad}"


### PR DESCRIPTION
Windows PowerShell 5.1 decodes a BOM-less script using the system ANSI codepage, not UTF-8. A UTF-8 em-dash (E2 80 94) therefore arrives as 'a', 'EUR', U+201D -- and PowerShell accepts U+201D as a closing double quote. Inside a string literal that truncates the string and misparses the rest of the file, which surfaced as an unrelated error further down:

  The variable '$existing' cannot be retrieved because it has not been set.

$existing was never assigned because the statement before it never parsed.

Make both installer scripts pure ASCII (and CRLF), and add tests/test_installer_scripts.py so this can't silently return.

Also harden the Set-StrictMode landmines that would have been hit on the next run:
- Initialize $LASTEXITCODE; it does not exist until an external program has run, and StrictMode makes reading an unset variable terminating.
- Guard tag_name/assets property access on the release JSON; a release with no assets is normal and StrictMode turns a missing property into an error.
- Constrain the python lookup to -CommandType Application, and skip the Microsoft Store app-execution-alias stub in WindowsApps, which exists on a stock Windows install with no interpreter behind it.
- Put the .bat's download command on one line; `^` continuation inside a quoted -Command string is brittle under cmd's parser.


Claude-Session: https://claude.ai/code/session_01SQEt6qoSAr2hXvp4dzbGVY