### PR TITLE
Report a private/unreachable repo instead of a bare "Not Found"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -484,6 +484,11 @@ sorter.apply_update          backup → copy over app dir → prune → clear pe
   same commit you tag a release, and keep the tag and that value in step.
   `/releases/latest` excludes pre-releases, so tagging an rc won't reach
   stable users.
+- **The distribution path assumes a public repo.** The installer and updater
+  both fetch anonymously over HTTPS; against a private repo every request
+  404s and there is no in-band way to tell that apart from "no releases yet"
+  (the API returns 404 for both). If the repo must stay private, distribution
+  has to move off GitHub — see `installer/README.md`.
 - **No CI yet.** Run `pytest` before pushing. Most UI modules need a display —
   `xvfb-run -a python -m pytest` covers them on a headless box; without
   tkinter installed those modules skip rather than fail.

--- a/installer/README.md
+++ b/installer/README.md
@@ -62,6 +62,24 @@ explicitly.
 
 ## Notes for maintainers
 
+- **The repository must be publicly readable.** Both the installer and the
+  in-app updater download over HTTPS with no credentials, so a private repo
+  makes every request 404 — the release check falls back to the branch
+  archive, and that 404s too:
+
+  ```
+  No published release found (the repo may have none yet).
+  Invoke-WebRequest : Not Found
+  ```
+
+  If you need the repo to stay private, distribution has to move off GitHub
+  (host the ZIP plus a version manifest on your own server and repoint
+  `$Repo` / `updater.DEFAULT_REPO`) — a token is not a workable answer for
+  the audience this installer targets.
+- **Cut a release before relying on the update path.** With no releases,
+  `/releases/latest` 404s: the installer falls back to the default branch
+  and the in-app updater reports "up to date" forever. Tag `v0.1.0`,
+  matching `__version__` in `sorter/__init__.py`.
 - The installer is unsigned, so SmartScreen will warn on first run. Signing
   (Azure Trusted Signing, or an OV/EV certificate) is the fix; until then,
   expect a "More info → Run anyway" step.

--- a/installer/install-windows.ps1
+++ b/installer/install-windows.ps1
@@ -51,7 +51,8 @@ $LASTEXITCODE = 0
 # quote, which silently truncates the enclosing string and misparses
 # everything after it. tests/test_installer_scripts.py enforces this.
 
-$Repo         = 'sjseth/AI-Case-Sorter-Py'
+$Repo          = 'sjseth/AI-Case-Sorter-Py'
+$DefaultBranch = 'main'
 $PythonWinget = 'Python.Python.3.12'
 $PythonMinor  = 12
 # Keep in step with requires-python in pyproject.toml.
@@ -181,10 +182,15 @@ function Get-ReleaseInfo {
         $resp = Invoke-RestMethod -Uri "https://api.github.com/repos/$Repo/releases/latest" `
             -Headers @{ 'User-Agent' = 'CaseSorter-Installer' } -UseBasicParsing
     } catch {
-        Write-Warn2 "No published release found; installing the current main branch."
+        # A 404 here means either "no releases published yet" or "this repo is
+        # not publicly readable" - the API gives an anonymous caller the same
+        # answer for both. Say so, rather than reporting only the happy-path
+        # guess and letting the download fail with a bare "Not Found".
+        Write-Warn2 "No published release found (the repo may have none yet)."
+        Write-Note  "Falling back to the current $DefaultBranch branch."
         return [pscustomobject]@{
-            Tag = 'main'
-            Url = "https://github.com/$Repo/archive/refs/heads/main.zip"
+            Tag = $DefaultBranch
+            Url = "https://github.com/$Repo/archive/refs/heads/$DefaultBranch.zip"
         }
     }
 
@@ -211,7 +217,31 @@ function Install-App {
     try {
         $zip = Join-Path $work 'app.zip'
         Write-Note "Downloading $Tag..."
-        Invoke-WebRequest -Uri $Url -OutFile $zip -UseBasicParsing
+        try {
+            Invoke-WebRequest -Uri $Url -OutFile $zip -UseBasicParsing
+        } catch {
+            $status = $null
+            if ($_.Exception.PSObject.Properties['Response'] -and $_.Exception.Response) {
+                $status = [int]$_.Exception.Response.StatusCode
+            }
+            if ($status -eq 404) {
+                # The overwhelmingly common cause, and invisible from the bare
+                # "Not Found" that Invoke-WebRequest reports on its own.
+                throw @"
+Could not download the app (HTTP 404).
+
+  $Url
+
+The most likely reason is that the repository is private, or the release tag
+does not exist. An anonymous download - which is all this installer does -
+needs the repository to be publicly readable.
+
+If you are the maintainer: make the repository public, or publish a release
+whose tag matches what you asked for.
+"@
+            }
+            throw "Could not download the app from $Url : $($_.Exception.Message)"
+        }
 
         Write-Note "Extracting..."
         $unpack = Join-Path $work 'unpacked'

--- a/tests/test_installer_scripts.py
+++ b/tests/test_installer_scripts.py
@@ -59,9 +59,21 @@ def test_powershell_script_has_no_unpaired_quotes_per_line() -> None:
     """
     text = (INSTALLER / "install-windows.ps1").read_text(encoding="ascii")
     in_block_comment = False
+    in_here_string = False
     bad: list[int] = []
     for n, line in enumerate(text.splitlines(), 1):
         stripped = line.strip()
+
+        # Here-strings (@"..."@) legitimately carry a lone quote on the
+        # opening and closing lines, and arbitrary text between them.
+        if in_here_string:
+            if stripped == '"@':
+                in_here_string = False
+            continue
+        if stripped.endswith('@"'):
+            in_here_string = True
+            continue
+
         if stripped.startswith("<#"):
             in_block_comment = True
         if in_block_comment:


### PR DESCRIPTION
The installer downloads anonymously over HTTPS, so against a private repository every request 404s: /releases/latest returns 404, the script falls back to the branch archive, and that 404s too. The user saw only:

  No published release found; installing the current main branch.
  Invoke-WebRequest : Not Found

which points at neither cause. The GitHub API returns 404 to an anonymous caller for both "no releases yet" and "not publicly readable", so the two cannot be told apart in-band -- say so rather than asserting the happy-path guess.

- Catch the download failure and, on 404, explain that anonymous download needs a public repo or an existing release tag.
- Soften the release-check fallback message, which previously stated "no published release" as fact.
- Hoist the default branch into $DefaultBranch instead of hardcoding 'main' in two places.
- Document the public-repo requirement and the cut-a-first-release step in installer/README.md and CLAUDE.md; neither was written down.
- Teach the quote-balance guard about here-strings.


Claude-Session: https://claude.ai/code/session_01SQEt6qoSAr2hXvp4dzbGVY