### PR TITLE
Add theme system with 6 built-in themes and a user theme editor

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -351,9 +351,15 @@ image browser/reclassify/delete), `dialog_share_model` (publish to community),
   - **Themes.** `THEMES` maps a display name to a full palette; the user picks
     one from the dropdown in the title bar and it's stored in the `ui.theme`
     setting (`theme.SETTING_THEME`). Ships with Dark (the original), Light,
-    Sepia, Midnight Blue, and Gothic. **The role of each key is fixed; only
-    its color changes per theme** — a new theme is a copy of `_DARK` with new
-    values, and it must define exactly the same keys.
+    Sepia, Midnight Blue, Gothic, and Comic Book. **The role of each key is
+    fixed; only its color changes per theme** — a new theme is a copy of
+    `_DARK` with new values, and it must define exactly the same keys.
+    `success` mirrors `action` and `error` mirrors `danger`, so a theme with
+    no green (Comic Book) has a gold "connected" indicator, not a green one.
+  - **Title-bar flourishes.** `HALFTONE_INK` names the themes whose title bar
+    gets a ben-day dot field over the gradient, and the ink to print it in
+    (`paint_halftone`, drawn by `app._repaint_header`). A theme not listed
+    there gets a plain gradient — dots are a comic-book device, not a default.
   - **Switching is live**, so it must stay that way: `apply_theme` reloads the
     ttk styles (which every ttk widget follows on its own) and
     `retheme_widgets` walks the widget tree translating the colors baked into

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -342,6 +342,9 @@ opt-in), `dialog_install_torch` (pip-installs torch/torchvision into the venv),
 HTML report + history), `dialog_model_images` + `dialog_image_preview` (training
 image browser/reclassify/delete), `dialog_share_model` (publish to community),
 `dialog_slot_template` (new / rename / delete a sorting template),
+`dialog_theme_editor` (build a theme from the active one: a color picker per
+palette role, a canvas preview of a miniature app, and JSON export/import —
+reached from the `+` beside the title-bar theme picker),
 `dialog_update` (release notes → download progress → "Restart to update"; §7).
 
 ### Shared UI infrastructure
@@ -382,6 +385,17 @@ image browser/reclassify/delete), `dialog_share_model` (publish to community),
     `action`/`danger` (`tests/test_theme.py` enforces both rules).
   - **`PALETTE` is mutated in place** on a switch. Read it at call time
     (`PALETTE["bg_card"]`); never copy a color into a module-level constant.
+  - **User-made themes.** `BUILTIN_THEMES` is what ships; `THEMES` is the live
+    registry — built-ins plus whatever the theme editor has saved.
+    `register_custom_theme` adds one (and its halftone/outline options),
+    `custom_themes_payload` is what the app persists to the
+    `ui.custom_themes` setting, and `load_custom_themes` re-registers them at
+    startup, before the saved theme name is resolved. From then on a user
+    palette is an ordinary entry in `THEMES` — nothing downstream knows the
+    difference. `normalize_palette` is the gate: it fills gaps from a base
+    theme, drops unknown keys and non-colors, and forces `success`/`error`
+    back onto `action`/`danger`, so neither a hand-edited settings row nor an
+    imported file can produce a broken palette.
   - **Hue is meaning.** Dark keeps its chrome (window, panels, cards, inputs,
     borders, text, focus/selection tints) **neutral grayscale**, reserving hue
     for action buttons (`action*` green = primary/go, `update*` blue = refresh
@@ -389,7 +403,8 @@ image browser/reclassify/delete), `dialog_share_model` (publish to community),
     The tinted themes keep the same discipline internally: their surfaces are
     one low-saturation family so the action buttons stay the most saturated
     thing on screen. Don't add a saturated surface to any theme.
-- **`widgets.py`** — `ScrollableFrame`, `ImagePanel` (shows BGR numpy frames),
+- **`widgets.py`** — `ScrollableFrame` (pass `viewport=(w, h)` to fix how much
+  is visible and let the rest scroll), `ImagePanel` (shows BGR numpy frames),
   `NumericField`, labeled-entry/button-row helpers.
 - **`monitor.py`** — detachable history window: ring buffer of recent
   classifications with a color "snake" trailing the latest. Subscribes `run/history`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -361,12 +361,11 @@ image browser/reclassify/delete), `dialog_share_model` (publish to community),
     ben-day dot field, and the ink to print it in; `paint_halftone` prints
     one over any box of a canvas, fading in from whichever edge you name.
     Only canvases can carry it — ttk widgets always fill their own
-    background, so nothing shows through them. Three places screen
-    themselves: the title bar (`app._repaint_header`), the margin around the
-    notebook (`app._layout_page` — the notebook rides on a backdrop canvas
-    for exactly this reason), and the Run tab's slot-details backdrop. A new
-    one calls `register_halftone(canvas, repaint)` so `repaint_halftone_fields`
-    re-runs it on a theme switch, without app.py having to know about it.
+    background, so nothing shows through them. Two places screen themselves,
+    both app chrome: the title bar (`app._repaint_header`) and the margin
+    around the notebook (`app._layout_page` — the notebook rides on a
+    backdrop canvas for exactly this reason). Keep it to the chrome: a screen
+    behind the working area of a tab is noise, not decoration.
   - **Ink outlines.** `INK_OUTLINE` names the themes that draw comic-book
     borders and how many pixels wide; everything else stays flat and
     borderless. `apply_theme` reads it for panels, cards, buttons and fields.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -344,7 +344,9 @@ image browser/reclassify/delete), `dialog_share_model` (publish to community),
 `dialog_slot_template` (new / rename / delete a sorting template),
 `dialog_theme_editor` (build a theme from the active one: a color picker per
 palette role, a canvas preview of a miniature app, and JSON export/import —
-reached from the `+` beside the title-bar theme picker),
+reached from the gear beside the title-bar theme picker; "Save & apply"
+writes back to a saved theme, rename included, and "Create new…" always makes
+a separate one, so a built-in is never the thing being written to),
 `dialog_update` (release notes → download progress → "Restart to update"; §7).
 
 ### Shared UI infrastructure
@@ -388,9 +390,12 @@ reached from the `+` beside the title-bar theme picker),
   - **User-made themes.** `BUILTIN_THEMES` is what ships; `THEMES` is the live
     registry — built-ins plus whatever the theme editor has saved.
     `register_custom_theme` adds one (and its halftone/outline options),
-    `custom_themes_payload` is what the app persists to the
-    `ui.custom_themes` setting, and `load_custom_themes` re-registers them at
-    startup, before the saved theme name is resolved. From then on a user
+    `rename_custom_theme` moves one (a rename is not copy-and-delete — the
+    theme keeps its place and options), `custom_themes_payload` is what the
+    app persists to the `ui.custom_themes` setting, and `load_custom_themes`
+    re-registers them at startup, before the saved theme name is resolved.
+    Names are capped at `MAX_THEME_NAME` because the picker is sized to the
+    longest of them. From then on a user
     palette is an ordinary entry in `THEMES` — nothing downstream knows the
     difference. `normalize_palette` is the gate: it fills gaps from a base
     theme, drops unknown keys and non-colors, and forces `success`/`error`

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -309,9 +309,10 @@ between them from the Run tab's template dropdown.
 
 ## 5. The UI (`sorter/ui/`)
 
-`MainWindow` (`app.py`) is the shell: gradient title bar, a `ttk.Notebook` of
-tabs (each wrapped in a `ScrollableFrame` for small displays), and a status bar
-with connection indicators + sign-in. It owns the `EventBus`, `SerialBroker`,
+`MainWindow` (`app.py`) is the shell: gradient title bar (with the theme picker
+parked at its right edge), a `ttk.Notebook` of tabs (each wrapped in a
+`ScrollableFrame` for small displays), and a status bar with connection
+indicators + sign-in. It owns the `EventBus`, `SerialBroker`,
 `Camera`, `RunController`, and `AuthManager`, auto-connects serial/camera on
 startup, and runs the bus drain loop. `run_worker(fn, on_done, on_error)` is the
 standard helper for offloading blocking work to a thread and marshaling the
@@ -344,13 +345,31 @@ image browser/reclassify/delete), `dialog_share_model` (publish to community),
 `dialog_update` (release notes → download progress → "Restart to update"; §7).
 
 ### Shared UI infrastructure
-- **`theme.py`** — `PALETTE`, `apply_theme(root)` (fonts + ttk styles, single
-  source of truth), `paint_gradient`. The chrome (window, panels, cards,
-  inputs, borders, text, focus/selection tints) is **neutral grayscale**;
-  hue is reserved for action buttons (`action*` green = primary/go,
-  `update*` blue = refresh something installed, `danger*` red =
-  stop/destructive) and status text. Keep new surfaces gray —
-  the colored buttons read as meaningful only because nothing else does.
+- **`theme.py`** — `THEMES`, the live `PALETTE`, `apply_theme(root, theme=…)`
+  (fonts + ttk styles, single source of truth), `retheme_widgets`,
+  `paint_gradient`. **Every color in the app comes from here.**
+  - **Themes.** `THEMES` maps a display name to a full palette; the user picks
+    one from the dropdown in the title bar and it's stored in the `ui.theme`
+    setting (`theme.SETTING_THEME`). Ships with Dark (the original), Light,
+    Sepia, Midnight Blue, and Gothic. **The role of each key is fixed; only
+    its color changes per theme** — a new theme is a copy of `_DARK` with new
+    values, and it must define exactly the same keys.
+  - **Switching is live**, so it must stay that way: `apply_theme` reloads the
+    ttk styles (which every ttk widget follows on its own) and
+    `retheme_widgets` walks the widget tree translating the colors baked into
+    classic Tk widgets (`tk.Label`, `tk.Canvas`, `tk.Text`) at construction.
+    That translation is by color value, which is why no two roles inside one
+    theme may share a color — except `success`/`error`, which must equal
+    `action`/`danger` (`tests/test_theme.py` enforces both rules).
+  - **`PALETTE` is mutated in place** on a switch. Read it at call time
+    (`PALETTE["bg_card"]`); never copy a color into a module-level constant.
+  - **Hue is meaning.** Dark keeps its chrome (window, panels, cards, inputs,
+    borders, text, focus/selection tints) **neutral grayscale**, reserving hue
+    for action buttons (`action*` green = primary/go, `update*` blue = refresh
+    something installed, `danger*` red = stop/destructive) and status text.
+    The tinted themes keep the same discipline internally: their surfaces are
+    one low-saturation family so the action buttons stay the most saturated
+    thing on screen. Don't add a saturated surface to any theme.
 - **`widgets.py`** — `ScrollableFrame`, `ImagePanel` (shows BGR numpy frames),
   `NumericField`, labeled-entry/button-row helpers.
 - **`monitor.py`** — detachable history window: ring buffer of recent

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -311,8 +311,8 @@ between them from the Run tab's template dropdown.
 
 `MainWindow` (`app.py`) is the shell: gradient title bar (with the theme picker
 parked at its right edge), a `ttk.Notebook` of tabs (each wrapped in a
-`ScrollableFrame` for small displays), and a status bar with connection
-indicators + sign-in. It owns the `EventBus`, `SerialBroker`,
+`ScrollableFrame` for small displays, and hosted on a backdrop canvas that owns
+the margin around it), and a status bar with connection indicators + sign-in. It owns the `EventBus`, `SerialBroker`,
 `Camera`, `RunController`, and `AuthManager`, auto-connects serial/camera on
 startup, and runs the bus drain loop. `run_worker(fn, on_done, on_error)` is the
 standard helper for offloading blocking work to a thread and marshaling the
@@ -355,11 +355,25 @@ image browser/reclassify/delete), `dialog_share_model` (publish to community),
     fixed; only its color changes per theme** — a new theme is a copy of
     `_DARK` with new values, and it must define exactly the same keys.
     `success` mirrors `action` and `error` mirrors `danger`, so a theme with
-    no green (Comic Book) has a gold "connected" indicator, not a green one.
-  - **Title-bar flourishes.** `HALFTONE_INK` names the themes whose title bar
-    gets a ben-day dot field over the gradient, and the ink to print it in
-    (`paint_halftone`, drawn by `app._repaint_header`). A theme not listed
-    there gets a plain gradient — dots are a comic-book device, not a default.
+    no green (Comic Book, where blue is "go") has a blue "connected"
+    indicator, not a green one.
+  - **Halftone screens.** `HALFTONE_INK` names the themes that print a
+    ben-day dot field, and the ink to print it in; `paint_halftone` prints
+    one over any box of a canvas, fading in from whichever edge you name.
+    Only canvases can carry it — ttk widgets always fill their own
+    background, so nothing shows through them. Three places screen
+    themselves: the title bar (`app._repaint_header`), the margin around the
+    notebook (`app._layout_page` — the notebook rides on a backdrop canvas
+    for exactly this reason), and the Run tab's slot-details backdrop. A new
+    one calls `register_halftone(canvas, repaint)` so `repaint_halftone_fields`
+    re-runs it on a theme switch, without app.py having to know about it.
+  - **Ink outlines.** `INK_OUTLINE` names the themes that draw comic-book
+    borders and how many pixels wide; everything else stays flat and
+    borderless. `apply_theme` reads it for panels, cards, buttons and fields.
+    A card's outline belongs to the card, not to the layout rows inside it —
+    those use `row_style(card_style)` (`Card.TFrame` → `CardRow.TFrame`),
+    which shares the fill but never the border. Cards that restyle their
+    children on hover/selection must map through `row_style` too.
   - **Switching is live**, so it must stay that way: `apply_theme` reloads the
     ttk styles (which every ttk widget follows on its own) and
     `retheme_widgets` walks the widget tree translating the colors baked into

--- a/README.md
+++ b/README.md
@@ -69,7 +69,9 @@ The app can predict a headstamp in one of two modes:
   community-published models.
 - **Themes** — pick Dark, Light, Sepia, Midnight Blue, Gothic, or Comic Book
   from the dropdown in the title bar. The change applies immediately and is
-  remembered.
+  remembered. The **+** beside it opens a theme editor: start from the theme
+  you're on, set any color you like with a live preview, and export or import
+  your themes as JSON to share them.
 - A **serial emulator** so you can run and explore the app with no hardware
   attached.
 

--- a/README.md
+++ b/README.md
@@ -67,8 +67,9 @@ The app can predict a headstamp in one of two modes:
   sort-arm testing, and headstamp-crop tuning (Hough circles + primer mask).
 - **Community** tab *(sign-in required)* — browse, search, and download
   community-published models.
-- **Themes** — pick Dark, Light, Sepia, Midnight Blue, or Gothic from the
-  dropdown in the title bar. The change applies immediately and is remembered.
+- **Themes** — pick Dark, Light, Sepia, Midnight Blue, Gothic, or Comic Book
+  from the dropdown in the title bar. The change applies immediately and is
+  remembered.
 - A **serial emulator** so you can run and explore the app with no hardware
   attached.
 

--- a/README.md
+++ b/README.md
@@ -69,9 +69,9 @@ The app can predict a headstamp in one of two modes:
   community-published models.
 - **Themes** — pick Dark, Light, Sepia, Midnight Blue, Gothic, or Comic Book
   from the dropdown in the title bar. The change applies immediately and is
-  remembered. The **+** beside it opens a theme editor: start from the theme
-  you're on, set any color you like with a live preview, and export or import
-  your themes as JSON to share them.
+  remembered. The **gear** beside it opens a theme editor: start from the theme
+  you're on, set any color you like with a live preview, then save, rename, or
+  export it as JSON to share (and import someone else's).
 - A **serial emulator** so you can run and explore the app with no hardware
   attached.
 

--- a/README.md
+++ b/README.md
@@ -67,6 +67,8 @@ The app can predict a headstamp in one of two modes:
   sort-arm testing, and headstamp-crop tuning (Hough circles + primer mask).
 - **Community** tab *(sign-in required)* — browse, search, and download
   community-published models.
+- **Themes** — pick Dark, Light, Sepia, Midnight Blue, or Gothic from the
+  dropdown in the title bar. The change applies immediately and is remembered.
 - A **serial emulator** so you can run and explore the app with no hardware
   attached.
 

--- a/sorter/ui/app.py
+++ b/sorter/ui/app.py
@@ -98,7 +98,8 @@ class MainWindow:
             0, HEADER_HEIGHT // 2, anchor=tk.E, window=self.theme_combo,
         )
         self.theme_new_button = ttk.Button(
-            self.header_canvas, text="+", width=2, command=self.open_theme_editor,
+            self.header_canvas, text="\u2699", width=2,
+            command=self.open_theme_editor,
         )
         self._theme_new_window = self.header_canvas.create_window(
             0, HEADER_HEIGHT // 2, anchor=tk.E, window=self.theme_new_button,

--- a/sorter/ui/app.py
+++ b/sorter/ui/app.py
@@ -28,6 +28,7 @@ from .theme import (
     halftone_ink,
     paint_gradient,
     paint_halftone,
+    repaint_halftone_fields,
     resolve_theme,
     retheme_widgets,
     theme_names,
@@ -39,6 +40,11 @@ PREVIEW_FPS = 20
 HEADER_HEIGHT = 36
 # Gap between the theme picker and the right edge of the title bar.
 HEADER_PAD = 12
+# Margin around the notebook. A screened theme gets a wider one, since that
+# margin is the canvas its halftone prints on.
+PAGE_MARGIN = 12
+PAGE_MARGIN_TOP = 8
+PAGE_MARGIN_SCREENED = 20
 
 
 class MainWindow:
@@ -127,8 +133,24 @@ class MainWindow:
         self.serial_dot = self._build_status_indicator(status_bar, self.serial_status_var)
         self.camera_dot = self._build_status_indicator(status_bar, self.camera_status_var)
 
-        notebook = ttk.Notebook(self.root)
-        notebook.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=12, pady=(8, 0))
+        # The notebook rides on a backdrop canvas rather than being packed
+        # straight into the root: the canvas owns the margin around it, which
+        # is the one place a theme can print a halftone screen behind the UI
+        # (ttk widgets always fill their own background — nothing shows
+        # through them). `_layout_page` keeps the notebook inset and repaints.
+        self.page = tk.Canvas(
+            self.root,
+            bg=PALETTE["bg_window"],
+            highlightthickness=0,
+            borderwidth=0,
+        )
+        self.page.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        notebook = ttk.Notebook(self.page)
+        self._notebook_window = self.page.create_window(
+            0, 0, window=notebook, anchor=tk.NW,
+        )
+        self._page_size = (0, 0)
+        self.page.bind("<Configure>", self._layout_page)
         # Expose the notebook BEFORE constructing tabs so that tabs that
         # want to bind <<NotebookTabChanged>> on it (e.g. TrainTab) can
         # find it via `app.notebook`.
@@ -456,9 +478,13 @@ class MainWindow:
             color_b=PALETTE["bg_gradient_b"],
             direction="horizontal",
         )
-        # Themes that ask for it get a halftone screen over the gradient;
-        # for the rest this clears the field and costs nothing.
-        paint_halftone(canvas, color=halftone_ink())
+        # Themes that ask for it get a halftone screen over the gradient; for
+        # the rest this clears the field and costs nothing. It fades in from
+        # the right so the screen never lands under the app title.
+        paint_halftone(
+            canvas, color=halftone_ink(), fade_from="right",
+            fade_span=max(1, canvas.winfo_width()) * 0.55,
+        )
         canvas.delete("title")
         self._place_theme_picker()
         title_id = canvas.create_text(
@@ -500,6 +526,49 @@ class MainWindow:
             tags="title",
         )
 
+    # ----- page backdrop ------------------------------------------------------
+
+    def _layout_page(self, event=None, *, force: bool = False) -> None:
+        """Inset the notebook in its backdrop and screen the margin.
+
+        The margin is what the halftone prints on, so themes that ask for dots
+        get a wider one — enough to read as a comic panel border rather than
+        padding that happens to have specks in it.
+        """
+        width = self.page.winfo_width()
+        height = self.page.winfo_height()
+        if width < 2 or height < 2:
+            return
+        if not force and (width, height) == self._page_size:
+            return
+        self._page_size = (width, height)
+
+        ink = halftone_ink()
+        margin = PAGE_MARGIN_SCREENED if ink else PAGE_MARGIN
+        top = margin if ink else PAGE_MARGIN_TOP
+        # No bottom margin without dots — the plain themes' notebook has always
+        # run to the status bar, and an empty gap there would just look wrong.
+        bottom = margin if ink else 0
+
+        self.page.coords(self._notebook_window, margin, top)
+        self.page.itemconfigure(
+            self._notebook_window,
+            width=max(1, width - 2 * margin),
+            height=max(1, height - top - bottom),
+        )
+
+        bands = (
+            ((0, 0, margin, height), "left"),
+            ((width - margin, 0, width, height), "right"),
+            ((0, 0, width, top), "top"),
+            ((0, height - bottom, width, height), "bottom"),
+        )
+        for i, (box, edge) in enumerate(bands):
+            paint_halftone(
+                self.page, color=ink, box=box, fade_from=edge,
+                fade_span=margin * 1.4, clear=(i == 0),
+            )
+
     # ----- theme --------------------------------------------------------------
 
     def _load_saved_theme(self) -> str | None:
@@ -530,6 +599,9 @@ class MainWindow:
         # widgets (and any open dialog's) need their baked-in colors remapped.
         retheme_widgets(self.root, previous)
         self._repaint_header()
+        self._layout_page(force=True)
+        # Backdrops elsewhere in the tree (see theme.register_halftone).
+        repaint_halftone_fields(self.root)
         self._refresh_status_indicators()
         self._save_theme(resolved)
         self.set_status(f"Theme: {resolved}.")

--- a/sorter/ui/app.py
+++ b/sorter/ui/app.py
@@ -28,7 +28,6 @@ from .theme import (
     halftone_ink,
     paint_gradient,
     paint_halftone,
-    repaint_halftone_fields,
     resolve_theme,
     retheme_widgets,
     theme_names,
@@ -600,8 +599,6 @@ class MainWindow:
         retheme_widgets(self.root, previous)
         self._repaint_header()
         self._layout_page(force=True)
-        # Backdrops elsewhere in the tree (see theme.register_halftone).
-        repaint_halftone_fields(self.root)
         self._refresh_status_indicators()
         self._save_theme(resolved)
         self.set_status(f"Theme: {resolved}.")

--- a/sorter/ui/app.py
+++ b/sorter/ui/app.py
@@ -21,12 +21,22 @@ from .tab_models import ModelsTab
 from .tab_run import RunTab
 from .tab_serial import SerialTab
 from .tab_train import TrainTab
-from .theme import PALETTE, apply_theme, paint_gradient
+from .theme import (
+    PALETTE,
+    SETTING_THEME,
+    apply_theme,
+    paint_gradient,
+    resolve_theme,
+    retheme_widgets,
+    theme_names,
+)
 from .widgets import ScrollableFrame
 
 
 PREVIEW_FPS = 20
 HEADER_HEIGHT = 36
+# Gap between the theme picker and the right edge of the title bar.
+HEADER_PAD = 12
 
 
 class MainWindow:
@@ -39,7 +49,8 @@ class MainWindow:
         self.root.geometry("1024x768")
         self.root.minsize(960, 660)
 
-        self.fonts = apply_theme(self.root)
+        self.theme_name = resolve_theme(self._load_saved_theme())
+        self.fonts = apply_theme(self.root, theme=self.theme_name)
 
         self.broker: Any | None = None
         self.camera = Camera(
@@ -60,6 +71,22 @@ class MainWindow:
             borderwidth=0,
         )
         self.header_canvas.pack(side=tk.TOP, fill=tk.X)
+        # Theme picker, parked in the top-right of the title bar. It rides on
+        # the canvas as a window item so it floats over the gradient;
+        # `_repaint_header` keeps it pinned to the right edge on resize.
+        self.theme_var = tk.StringVar(value=self.theme_name)
+        self.theme_combo = ttk.Combobox(
+            self.header_canvas,
+            textvariable=self.theme_var,
+            values=theme_names(),
+            state="readonly",
+            style="Header.TCombobox",
+            width=max(len(name) for name in theme_names()) + 1,
+        )
+        self.theme_combo.bind("<<ComboboxSelected>>", self._on_theme_selected)
+        self._theme_window = self.header_canvas.create_window(
+            0, HEADER_HEIGHT // 2, anchor=tk.E, window=self.theme_combo,
+        )
         self.header_canvas.bind("<Configure>", self._repaint_header)
 
         # Status bar (must exist before tabs that call set_status).
@@ -93,6 +120,8 @@ class MainWindow:
         # Pack serial first so it ends up rightmost; camera sits to its left.
         # Each indicator is a [dot][text] pair grouped in a sub-frame so the
         # dot stays glued to its label when the bar resizes.
+        self._serial_connected = False
+        self._camera_connected = False
         self.serial_dot = self._build_status_indicator(status_bar, self.serial_status_var)
         self.camera_dot = self._build_status_indicator(status_bar, self.camera_status_var)
 
@@ -386,21 +415,39 @@ class MainWindow:
 
     def _set_camera_indicator(self, message: str, *, connected: bool) -> None:
         self.camera_status_var.set(message)
+        self._camera_connected = connected
         self.camera_dot.config(
             foreground=PALETTE["success" if connected else "error"],
         )
 
     def _set_serial_indicator(self, message: str, *, connected: bool) -> None:
         self.serial_status_var.set(message)
+        self._serial_connected = connected
         self.serial_dot.config(
             foreground=PALETTE["success" if connected else "error"],
         )
 
+    def _refresh_status_indicators(self) -> None:
+        """Re-apply the dot colors from the live palette (after a theme switch).
+
+        The generic re-colouring pass can't tell a red dot from any other red,
+        so the source of truth — connected or not — repaints them here.
+        """
+        for dot, connected in (
+            (self.camera_dot, self._camera_connected),
+            (self.serial_dot, self._serial_connected),
+        ):
+            dot.config(
+                background=PALETTE["bg_window"],
+                foreground=PALETTE["success" if connected else "error"],
+            )
+
     # ----- header gradient ----------------------------------------------------
 
     def _repaint_header(self, _event=None) -> None:
-        """Paint the gradient header and overlay the app title."""
+        """Paint the gradient header, overlay the app title, pin the theme picker."""
         canvas = self.header_canvas
+        canvas.configure(bg=PALETTE["bg_window"])
         paint_gradient(
             canvas,
             color_a=PALETTE["bg_gradient_a"],
@@ -408,6 +455,7 @@ class MainWindow:
             direction="horizontal",
         )
         canvas.delete("title")
+        self._place_theme_picker()
         title_id = canvas.create_text(
             18, HEADER_HEIGHT // 2,
             anchor=tk.W,
@@ -427,6 +475,70 @@ class MainWindow:
             font=self.fonts["small"],
             tags="title",
         )
+
+    def _place_theme_picker(self) -> None:
+        """Right-align the theme dropdown and label it, after a paint or resize."""
+        canvas = self.header_canvas
+        combo = getattr(self, "theme_combo", None)
+        if combo is None:
+            return
+        width = canvas.winfo_width()
+        canvas.coords(self._theme_window, width - HEADER_PAD, HEADER_HEIGHT // 2)
+        canvas.tag_raise(self._theme_window)
+        canvas.create_text(
+            width - HEADER_PAD - combo.winfo_reqwidth() - 8,
+            HEADER_HEIGHT // 2,
+            anchor=tk.E,
+            text="Theme",
+            fill=PALETTE["text_muted"],
+            font=self.fonts["small"],
+            tags="title",
+        )
+
+    # ----- theme --------------------------------------------------------------
+
+    def _load_saved_theme(self) -> str | None:
+        """Theme name persisted from a previous session, if any."""
+        if self.db is None:
+            return None
+        try:
+            from ..repository import SettingsRepo
+
+            return SettingsRepo(self.db).get(SETTING_THEME)
+        except Exception:
+            return None
+
+    def _on_theme_selected(self, _event=None) -> None:
+        self.set_theme(self.theme_var.get())
+        # The dropdown keeps focus (and its highlight) after a pick; hand it
+        # back so the title bar settles.
+        self.root.focus_set()
+
+    def set_theme(self, name: str) -> None:
+        """Switch palettes live and remember the choice."""
+        resolved = resolve_theme(name)
+        previous = dict(PALETTE)
+        self.theme_name = resolved
+        self.theme_var.set(resolved)
+        self.fonts = apply_theme(self.root, theme=resolved)
+        # ttk widgets follow the restyled theme on their own; the classic Tk
+        # widgets (and any open dialog's) need their baked-in colors remapped.
+        retheme_widgets(self.root, previous)
+        self._repaint_header()
+        self._refresh_status_indicators()
+        self._save_theme(resolved)
+        self.set_status(f"Theme: {resolved}.")
+
+    def _save_theme(self, name: str) -> None:
+        if self.db is None:
+            return
+        try:
+            from ..repository import SettingsRepo
+
+            SettingsRepo(self.db).set(SETTING_THEME, name)
+        except Exception:
+            # A theme that can't be persisted still applies for this session.
+            pass
 
     # ----- camera -------------------------------------------------------------
 

--- a/sorter/ui/app.py
+++ b/sorter/ui/app.py
@@ -25,7 +25,9 @@ from .theme import (
     PALETTE,
     SETTING_THEME,
     apply_theme,
+    halftone_ink,
     paint_gradient,
+    paint_halftone,
     resolve_theme,
     retheme_widgets,
     theme_names,
@@ -454,6 +456,9 @@ class MainWindow:
             color_b=PALETTE["bg_gradient_b"],
             direction="horizontal",
         )
+        # Themes that ask for it get a halftone screen over the gradient;
+        # for the rest this clears the field and costs nothing.
+        paint_halftone(canvas, color=halftone_ink())
         canvas.delete("title")
         self._place_theme_picker()
         title_id = canvas.create_text(

--- a/sorter/ui/app.py
+++ b/sorter/ui/app.py
@@ -99,6 +99,7 @@ class MainWindow:
         )
         self.theme_new_button = ttk.Button(
             self.header_canvas, text="\u2699", width=2,
+            style="HeaderIcon.TButton", takefocus=False,
             command=self.open_theme_editor,
         )
         self._theme_new_window = self.header_canvas.create_window(

--- a/sorter/ui/app.py
+++ b/sorter/ui/app.py
@@ -23,9 +23,11 @@ from .tab_serial import SerialTab
 from .tab_train import TrainTab
 from .theme import (
     PALETTE,
+    SETTING_CUSTOM_THEMES,
     SETTING_THEME,
     apply_theme,
     halftone_ink,
+    load_custom_themes,
     paint_gradient,
     paint_halftone,
     resolve_theme,
@@ -56,7 +58,8 @@ class MainWindow:
         self.root.geometry("1024x768")
         self.root.minsize(960, 660)
 
-        self.theme_name = resolve_theme(self._load_saved_theme())
+        load_custom_themes(self._load_setting(SETTING_CUSTOM_THEMES))
+        self.theme_name = resolve_theme(self._load_setting(SETTING_THEME))
         self.fonts = apply_theme(self.root, theme=self.theme_name)
 
         self.broker: Any | None = None
@@ -93,6 +96,12 @@ class MainWindow:
         self.theme_combo.bind("<<ComboboxSelected>>", self._on_theme_selected)
         self._theme_window = self.header_canvas.create_window(
             0, HEADER_HEIGHT // 2, anchor=tk.E, window=self.theme_combo,
+        )
+        self.theme_new_button = ttk.Button(
+            self.header_canvas, text="+", width=2, command=self.open_theme_editor,
+        )
+        self._theme_new_window = self.header_canvas.create_window(
+            0, HEADER_HEIGHT // 2, anchor=tk.E, window=self.theme_new_button,
         )
         self.header_canvas.bind("<Configure>", self._repaint_header)
 
@@ -507,16 +516,19 @@ class MainWindow:
         )
 
     def _place_theme_picker(self) -> None:
-        """Right-align the theme dropdown and label it, after a paint or resize."""
+        """Lay out [Theme] [dropdown] [+] against the right edge of the bar."""
         canvas = self.header_canvas
         combo = getattr(self, "theme_combo", None)
         if combo is None:
             return
-        width = canvas.winfo_width()
-        canvas.coords(self._theme_window, width - HEADER_PAD, HEADER_HEIGHT // 2)
+        right = canvas.winfo_width() - HEADER_PAD
+        canvas.coords(self._theme_new_window, right, HEADER_HEIGHT // 2)
+        right -= self.theme_new_button.winfo_reqwidth() + 4
+        canvas.coords(self._theme_window, right, HEADER_HEIGHT // 2)
         canvas.tag_raise(self._theme_window)
+        canvas.tag_raise(self._theme_new_window)
         canvas.create_text(
-            width - HEADER_PAD - combo.winfo_reqwidth() - 8,
+            right - combo.winfo_reqwidth() - 8,
             HEADER_HEIGHT // 2,
             anchor=tk.E,
             text="Theme",
@@ -570,14 +582,14 @@ class MainWindow:
 
     # ----- theme --------------------------------------------------------------
 
-    def _load_saved_theme(self) -> str | None:
-        """Theme name persisted from a previous session, if any."""
+    def _load_setting(self, key: str):
+        """Read a settings row, or None if there's no DB / it can't be read."""
         if self.db is None:
             return None
         try:
             from ..repository import SettingsRepo
 
-            return SettingsRepo(self.db).get(SETTING_THEME)
+            return SettingsRepo(self.db).get(key)
         except Exception:
             return None
 
@@ -600,19 +612,36 @@ class MainWindow:
         self._repaint_header()
         self._layout_page(force=True)
         self._refresh_status_indicators()
-        self._save_theme(resolved)
-        self.set_status(f"Theme: {resolved}.")
+        self._save_setting(SETTING_THEME, resolved)
 
-    def _save_theme(self, name: str) -> None:
+    def _save_setting(self, key: str, value) -> None:
         if self.db is None:
             return
         try:
             from ..repository import SettingsRepo
 
-            SettingsRepo(self.db).set(SETTING_THEME, name)
+            SettingsRepo(self.db).set(key, value)
         except Exception:
-            # A theme that can't be persisted still applies for this session.
+            # A preference that can't be persisted still applies this session.
             pass
+
+    def open_theme_editor(self) -> None:
+        """Create a new theme from the active one, or edit a saved one."""
+        from .dialog_theme_editor import ThemeEditorDialog
+
+        ThemeEditorDialog(self.root, app=self)
+
+    def refresh_theme_picker(self) -> None:
+        """Re-read the theme list into the dropdown (after an edit or import)."""
+        self.theme_combo.configure(values=theme_names())
+        self.theme_var.set(self.theme_name)
+        self._place_theme_picker()
+
+    def save_custom_themes(self) -> None:
+        """Persist every user-made theme (the editor calls this after a change)."""
+        from .theme import custom_themes_payload
+
+        self._save_setting(SETTING_CUSTOM_THEMES, custom_themes_payload())
 
     # ----- camera -------------------------------------------------------------
 

--- a/sorter/ui/dialog_theme_editor.py
+++ b/sorter/ui/dialog_theme_editor.py
@@ -1,9 +1,13 @@
 """Theme editor — build your own palette from one of the shipped themes.
 
-Opened by the ``+`` beside the title-bar theme picker. It starts as a copy of
-the active theme, so a user only has to change the handful of colours they
-care about; everything else keeps working because a theme is always a *full*
+Opened by the gear beside the title-bar theme picker. It starts from the
+active theme, so a user only has to change the handful of colours they care
+about; everything else keeps working because a theme is always a *full*
 palette (see ``theme.normalize_palette``).
+
+On a saved theme, **Save & apply** writes back to it — renaming included.
+**Create new…** always makes a separate theme, so a built-in is never the
+thing being written to.
 
 Saved themes live in the ``ui.custom_themes`` setting and are registered into
 ``theme.THEMES`` at startup, which is all it takes for them to appear in the
@@ -23,6 +27,7 @@ from .theme import (
     CUSTOM_THEME_VERSION,
     HALFTONE_INK,
     INK_OUTLINE,
+    MAX_THEME_NAME,
     PALETTE,
     THEMES,
     current_theme,
@@ -33,6 +38,7 @@ from .theme import (
     paint_gradient,
     paint_halftone,
     register_custom_theme,
+    rename_custom_theme,
     unique_theme_name,
     unregister_custom_theme,
 )
@@ -123,13 +129,17 @@ class ThemeEditorDialog(tk.Toplevel):
 
         self.title("Edit Theme" if self.editing else "New Theme")
         self.transient(parent)
-        self.resizable(False, False)
+        self.resizable(True, True)
+        self.minsize(LIST_W + PREVIEW_W + 70, 420)
         self.configure(bg=PALETTE["bg_surface"])
 
         # Working copy — nothing here touches the live palette until Save.
         self.values: dict[str, str] = dict(THEMES[self.base])
+        # A new theme gets a short, free name rather than "<base> copy" —
+        # names are capped for the picker's sake, and the header line below
+        # already says which theme this started from.
         self.name_var = tk.StringVar(
-            value=self.base if self.editing else unique_theme_name(f"{self.base} copy")
+            value=self.base if self.editing else unique_theme_name("My theme")
         )
         self.outline_var = tk.BooleanVar(value=bool(INK_OUTLINE.get(self.base)))
         self.halftone_var = tk.BooleanVar(value=bool(HALFTONE_INK.get(self.base)))
@@ -157,7 +167,11 @@ class ThemeEditorDialog(tk.Toplevel):
         row = ttk.Frame(parent)
         row.pack(fill=tk.X)
         ttk.Label(row, text="Name", style="Subtitle.TLabel").pack(side=tk.LEFT)
-        entry = ttk.Entry(row, textvariable=self.name_var, width=26)
+        entry = ttk.Entry(
+            row, textvariable=self.name_var, width=MAX_THEME_NAME + 2,
+            validate="key",
+            validatecommand=(self.register(_within_limit), "%P"),
+        )
         entry.pack(side=tk.LEFT, padx=(8, 16))
         entry.focus_set()
 
@@ -176,8 +190,11 @@ class ThemeEditorDialog(tk.Toplevel):
         ttk.Label(
             parent,
             text=(
-                f"Starting from “{self.base}”. Saving under a new name adds a "
-                "theme; keeping the name replaces it."
+                f"Editing “{self.base}” — Save & apply writes back to it, "
+                "including a rename."
+                if self.editing else
+                f"Starting from the built-in “{self.base}”, which can't be "
+                "changed. Save & apply keeps this as a new theme."
             ),
             style="Subtle.TLabel",
         ).pack(anchor=tk.W, pady=(6, 0))
@@ -246,6 +263,8 @@ class ThemeEditorDialog(tk.Toplevel):
         ttk.Button(
             bar, text="Save & apply", style="Accent.TButton", command=self._save,
         ).pack(side=tk.RIGHT)
+        ttk.Button(bar, text="Create new…", command=self._create_new)\
+            .pack(side=tk.RIGHT, padx=(0, 8))
 
     # ----- editing ------------------------------------------------------------
 
@@ -402,6 +421,11 @@ class ThemeEditorDialog(tk.Toplevel):
 
     # ----- save / delete ------------------------------------------------------
 
+    def _payload_named(self, name: str) -> dict:
+        payload = self._payload()
+        payload["name"] = name
+        return payload
+
     def _payload(self) -> dict:
         return {
             "version": CUSTOM_THEME_VERSION,
@@ -413,24 +437,71 @@ class ThemeEditorDialog(tk.Toplevel):
         }
 
     def _save(self) -> None:
-        payload = self._payload()
-        name = payload["name"]
+        """Write the edits back to the theme being edited, or create it.
+
+        On a built-in there is nothing to write back to, so this creates a
+        theme under the name in the box (that's what the box is prefilled
+        with). On a saved theme it updates it in place — including a rename,
+        which keeps the theme rather than leaving the old name behind.
+        """
+        name = self.name_var.get().strip()
+        if not self._name_is_usable(name):
+            return
+        if self.editing and name != self.base:
+            try:
+                rename_custom_theme(self.base, name)
+            except ValueError as exc:
+                messagebox.showwarning("Can't rename", str(exc), parent=self)
+                return
+            self.base = name
+        elif not self.editing and name in THEMES and not messagebox.askyesno(
+            "Replace theme", f"Replace the saved theme “{name}”?", parent=self,
+        ):
+            return
+        self._register_and_apply(self._payload_named(name))
+        self.destroy()
+
+    def _create_new(self) -> None:
+        """Save these colours as a separate theme, under a name of its own."""
+        name = self._prompt_name()
+        if name is None:
+            return
+        name = name.strip()
+        if not self._name_is_usable(name) or (
+            name in THEMES and not messagebox.askyesno(
+                "Replace theme", f"Replace the saved theme “{name}”?", parent=self,
+            )
+        ):
+            return
+        self._register_and_apply(self._payload_named(name))
+        self.destroy()
+
+    def _name_is_usable(self, name: str) -> bool:
+        """Complain (and return False) if `name` can't be a theme."""
         if not name:
             messagebox.showwarning("Name needed", "Give the theme a name.", parent=self)
-            return
+            return False
+        if len(name) > MAX_THEME_NAME:
+            messagebox.showwarning(
+                "Name too long",
+                f"Theme names are at most {MAX_THEME_NAME} characters.",
+                parent=self,
+            )
+            return False
         if name in BUILTIN_THEMES:
             messagebox.showwarning(
                 "Built-in theme",
                 f"“{name}” is a built-in theme. Pick a different name.",
                 parent=self,
             )
-            return
-        if name != self.base and name in THEMES and not messagebox.askyesno(
-            "Replace theme", f"Replace the saved theme “{name}”?", parent=self,
-        ):
-            return
-        self._register_and_apply(payload)
-        self.destroy()
+            return False
+        return True
+
+    def _prompt_name(self) -> str | None:
+        """Ask for a name for a new theme. None if the user backs out."""
+        return _NameDialog(
+            self, initial=unique_theme_name(self.name_var.get() or self.base),
+        ).result
 
     def _register_and_apply(self, payload: dict) -> None:
         register_custom_theme(
@@ -519,6 +590,56 @@ class ThemeEditorDialog(tk.Toplevel):
             "outline": payload.get("outline", 0),
             "palette": normalize_palette(payload.get("palette")),
         })
+
+
+def _within_limit(proposed: str) -> bool:
+    """Entry validator: keep theme names inside the picker's width."""
+    return len(proposed) <= MAX_THEME_NAME
+
+
+class _NameDialog(tk.Toplevel):
+    """Ask for a new theme's name. `result` is None if the user backs out."""
+
+    def __init__(self, parent: tk.Misc, *, initial: str) -> None:
+        super().__init__(parent)
+        self.result: str | None = None
+        self.title("New Theme")
+        self.transient(parent)
+        self.resizable(False, False)
+
+        body = ttk.Frame(self, padding=(14, 12, 14, 8))
+        body.pack(fill=tk.BOTH, expand=True)
+        ttk.Label(body, text="Name for the new theme", style="Muted.TLabel")\
+            .pack(anchor=tk.W)
+        self._var = tk.StringVar(value=initial)
+        entry = ttk.Entry(
+            body, textvariable=self._var, width=MAX_THEME_NAME + 4,
+            validate="key", validatecommand=(self.register(_within_limit), "%P"),
+        )
+        entry.pack(fill=tk.X, pady=(3, 0))
+        entry.selection_range(0, tk.END)
+        entry.focus_set()
+        ttk.Label(
+            body, text=f"Up to {MAX_THEME_NAME} characters.", style="Subtle.TLabel",
+        ).pack(anchor=tk.W, pady=(4, 0))
+
+        buttons = ttk.Frame(self, padding=(14, 0, 14, 12))
+        buttons.pack(fill=tk.X)
+        ttk.Button(buttons, text="Cancel", command=self.destroy)\
+            .pack(side=tk.RIGHT, padx=(8, 0))
+        ttk.Button(
+            buttons, text="Create", style="Accent.TButton", command=self._accept,
+        ).pack(side=tk.RIGHT)
+
+        entry.bind("<Return>", lambda _e: self._accept())
+        self.bind("<Escape>", lambda _e: self.destroy())
+        # Modal: the caller reads `result` as soon as this returns.
+        self.grab_set()
+        self.wait_window(self)
+
+    def _accept(self) -> None:
+        self.result = self._var.get()
+        self.destroy()
 
 
 def _describe_bad_theme(payload) -> str | None:

--- a/sorter/ui/dialog_theme_editor.py
+++ b/sorter/ui/dialog_theme_editor.py
@@ -1,0 +1,539 @@
+"""Theme editor — build your own palette from one of the shipped themes.
+
+Opened by the ``+`` beside the title-bar theme picker. It starts as a copy of
+the active theme, so a user only has to change the handful of colours they
+care about; everything else keeps working because a theme is always a *full*
+palette (see ``theme.normalize_palette``).
+
+Saved themes live in the ``ui.custom_themes`` setting and are registered into
+``theme.THEMES`` at startup, which is all it takes for them to appear in the
+picker — nothing downstream knows a palette was made by a user. The same
+payload is what Export writes and Import reads, so a theme travels as one
+small JSON file.
+"""
+from __future__ import annotations
+
+import json
+import tkinter as tk
+from pathlib import Path
+from tkinter import colorchooser, filedialog, messagebox, ttk
+
+from .theme import (
+    BUILTIN_THEMES,
+    CUSTOM_THEME_VERSION,
+    HALFTONE_INK,
+    INK_OUTLINE,
+    PALETTE,
+    THEMES,
+    current_theme,
+    custom_theme_payload,
+    editable_roles,
+    is_custom_theme,
+    normalize_palette,
+    paint_gradient,
+    paint_halftone,
+    register_custom_theme,
+    unique_theme_name,
+    unregister_custom_theme,
+)
+from .widgets import ScrollableFrame
+
+
+# Role → the words a user thinks in. Grouped the way the UI reads: surfaces
+# first, then the ink on them, then the things that mean something.
+_GROUPS: list[tuple[str, list[tuple[str, str]]]] = [
+    ("Surfaces", [
+        ("bg_window", "Window"),
+        ("bg_surface", "Panel"),
+        ("bg_card", "Card"),
+        ("bg_card_hover", "Card — hover"),
+        ("bg_card_sel", "Card — selected"),
+        ("bg_input", "Input field"),
+        ("bg_gradient_a", "Title bar — left"),
+        ("bg_gradient_b", "Title bar — right"),
+    ]),
+    ("Lines", [
+        ("border", "Border"),
+        ("border_focus", "Focus ring"),
+    ]),
+    ("Text", [
+        ("text", "Text"),
+        ("text_highlight", "Text — emphasis"),
+        ("text_muted", "Text — muted"),
+        ("text_subtle", "Text — subtle"),
+        ("text_inverse", "Text on a colour"),
+    ]),
+    ("Accent", [
+        ("accent", "Accent"),
+        ("accent_hover", "Accent — hover"),
+        ("accent_press", "Accent — pressed"),
+        ("accent_dim", "Secondary button"),
+    ]),
+    ("Primary button", [
+        ("action", "Primary"),
+        ("action_hover", "Primary — hover"),
+        ("action_press", "Primary — pressed"),
+    ]),
+    ("Update button", [
+        ("update", "Update"),
+        ("update_hover", "Update — hover"),
+        ("update_press", "Update — pressed"),
+    ]),
+    ("Stop / delete button", [
+        ("danger", "Danger"),
+        ("danger_hover", "Danger — hover"),
+        ("danger_press", "Danger — pressed"),
+    ]),
+    ("Status", [
+        ("warning", "Warning text"),
+        ("success_dim", "Success fill"),
+    ]),
+]
+
+_FILE_TYPES = [("Case Sorter theme", "*.json"), ("All files", "*.*")]
+
+PREVIEW_W = 300
+PREVIEW_H = 330
+# The colour list scrolls; this is how much of it is on screen at once.
+LIST_W = 360
+LIST_H = 470
+
+
+def _grouped_roles() -> list[tuple[str, list[tuple[str, str]]]]:
+    """The groups above, plus any palette role they forgot to mention.
+
+    A new key in the palette should show up in the editor even if whoever
+    added it didn't come here — better an ugly "Other" row than a colour the
+    user can't reach.
+    """
+    listed = {role for _, rows in _GROUPS for role, _ in rows}
+    extra = [(role, role.replace("_", " ").capitalize())
+             for role in editable_roles() if role not in listed]
+    return _GROUPS + ([("Other", extra)] if extra else [])
+
+
+class ThemeEditorDialog(tk.Toplevel):
+    """Create or edit a user theme, with a live preview of the result."""
+
+    def __init__(self, parent: tk.Misc, *, app) -> None:
+        super().__init__(parent)
+        self.app = app
+        self.base = current_theme()
+        self.editing = is_custom_theme(self.base)
+
+        self.title("Edit Theme" if self.editing else "New Theme")
+        self.transient(parent)
+        self.resizable(False, False)
+        self.configure(bg=PALETTE["bg_surface"])
+
+        # Working copy — nothing here touches the live palette until Save.
+        self.values: dict[str, str] = dict(THEMES[self.base])
+        self.name_var = tk.StringVar(
+            value=self.base if self.editing else unique_theme_name(f"{self.base} copy")
+        )
+        self.outline_var = tk.BooleanVar(value=bool(INK_OUTLINE.get(self.base)))
+        self.halftone_var = tk.BooleanVar(value=bool(HALFTONE_INK.get(self.base)))
+        self.halftone_ink = HALFTONE_INK.get(self.base) or self.values["border"]
+        self._swatches: dict[str, tk.Label] = {}
+        self._hex_vars: dict[str, tk.StringVar] = {}
+
+        wrap = ttk.Frame(self, padding=(12, 10, 12, 8))
+        wrap.pack(fill=tk.BOTH, expand=True)
+        self._build_header(wrap)
+
+        columns = ttk.Frame(wrap)
+        columns.pack(fill=tk.BOTH, expand=True, pady=(8, 0))
+        self._build_color_list(columns)
+        self._build_preview(columns)
+
+        self._build_buttons(ttk.Frame(self, padding=(12, 0, 12, 12)))
+        self.name_var.trace_add("write", lambda *_a: self._render_preview())
+        self.bind("<Escape>", lambda _e: self.destroy())
+        self._render_preview()
+
+    # ----- construction -------------------------------------------------------
+
+    def _build_header(self, parent: tk.Misc) -> None:
+        row = ttk.Frame(parent)
+        row.pack(fill=tk.X)
+        ttk.Label(row, text="Name", style="Subtitle.TLabel").pack(side=tk.LEFT)
+        entry = ttk.Entry(row, textvariable=self.name_var, width=26)
+        entry.pack(side=tk.LEFT, padx=(8, 16))
+        entry.focus_set()
+
+        ttk.Checkbutton(
+            row, text="Comic ink outlines", variable=self.outline_var,
+            command=self._render_preview,
+        ).pack(side=tk.LEFT)
+        ttk.Checkbutton(
+            row, text="Halftone dots", variable=self.halftone_var,
+            command=self._render_preview,
+        ).pack(side=tk.LEFT, padx=(12, 4))
+        self._halftone_swatch = self._swatch(row, self.halftone_ink)
+        self._halftone_swatch.pack(side=tk.LEFT)
+        self._halftone_swatch.bind("<Button-1>", lambda _e: self._pick_halftone())
+
+        ttk.Label(
+            parent,
+            text=(
+                f"Starting from “{self.base}”. Saving under a new name adds a "
+                "theme; keeping the name replaces it."
+            ),
+            style="Subtle.TLabel",
+        ).pack(anchor=tk.W, pady=(6, 0))
+
+    def _build_color_list(self, parent: tk.Misc) -> None:
+        holder = ScrollableFrame(parent, viewport=(LIST_W, LIST_H))
+        holder.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        body = holder.body
+
+        for title, rows in _grouped_roles():
+            ttk.Label(body, text=title, style="Header.TLabel")\
+                .pack(anchor=tk.W, pady=(8, 2))
+            grid = ttk.Frame(body)
+            grid.pack(fill=tk.X)
+            for i, (role, label) in enumerate(rows):
+                self._build_color_row(grid, role, label, i)
+
+    def _build_color_row(self, parent: tk.Misc, role: str, label: str, row: int) -> None:
+        swatch = self._swatch(parent, self.values[role])
+        swatch.grid(row=row, column=0, sticky="w", pady=1)
+        swatch.bind("<Button-1>", lambda _e, r=role: self._pick(r))
+        self._swatches[role] = swatch
+
+        ttk.Label(parent, text=label).grid(row=row, column=1, sticky="w", padx=8)
+        parent.columnconfigure(1, minsize=150)
+
+        var = tk.StringVar(value=self.values[role])
+        var.trace_add("write", lambda *_a, r=role: self._on_hex_typed(r))
+        self._hex_vars[role] = var
+        ttk.Entry(parent, textvariable=var, width=9)\
+            .grid(row=row, column=2, sticky="w", padx=(8, 0))
+
+    def _swatch(self, parent: tk.Misc, color: str) -> tk.Label:
+        return tk.Label(
+            parent, background=color, width=4, cursor="hand2",
+            relief="flat", borderwidth=0, highlightthickness=1,
+            highlightbackground=PALETTE["border"],
+        )
+
+    def _build_preview(self, parent: tk.Misc) -> None:
+        side = ttk.Frame(parent)
+        side.pack(side=tk.LEFT, fill=tk.Y, anchor=tk.N, padx=(12, 0))
+        ttk.Label(side, text="Preview", style="Subtitle.TLabel").pack(anchor=tk.W)
+        self.preview = tk.Canvas(
+            side, width=PREVIEW_W, height=PREVIEW_H,
+            highlightthickness=1, highlightbackground=PALETTE["border"],
+            borderwidth=0,
+        )
+        self.preview.pack(pady=(3, 0))
+        # The gradient helper measures the canvas, so the first useful paint
+        # can only happen once Tk has laid it out.
+        self.preview.bind("<Configure>", lambda _e: self._render_preview())
+
+    def _build_buttons(self, bar: ttk.Frame) -> None:
+        bar.pack(fill=tk.X)
+        if self.editing:
+            ttk.Button(
+                bar, text="Delete", style="Danger.TButton", command=self._delete,
+            ).pack(side=tk.LEFT)
+        ttk.Button(bar, text="Import…", command=self._import)\
+            .pack(side=tk.LEFT, padx=(12 if self.editing else 0, 6))
+        ttk.Button(bar, text="Export…", command=self._export).pack(side=tk.LEFT)
+
+        ttk.Button(bar, text="Cancel", command=self.destroy)\
+            .pack(side=tk.RIGHT, padx=(8, 0))
+        ttk.Button(
+            bar, text="Save & apply", style="Accent.TButton", command=self._save,
+        ).pack(side=tk.RIGHT)
+
+    # ----- editing ------------------------------------------------------------
+
+    def _pick(self, role: str) -> None:
+        chosen = colorchooser.askcolor(
+            color=self.values[role], parent=self, title=f"Colour — {role}",
+        )
+        if chosen and chosen[1]:
+            self._set_color(role, chosen[1])
+
+    def _pick_halftone(self) -> None:
+        chosen = colorchooser.askcolor(
+            color=self.halftone_ink, parent=self, title="Colour — halftone dots",
+        )
+        if chosen and chosen[1]:
+            self.halftone_ink = chosen[1].lower()
+            self._halftone_swatch.configure(background=self.halftone_ink)
+            self.halftone_var.set(True)
+            self._render_preview()
+
+    def _set_color(self, role: str, color: str) -> None:
+        color = color.lower()
+        self.values[role] = color
+        self._swatches[role].configure(background=color)
+        if self._hex_vars[role].get().lower() != color:
+            self._hex_vars[role].set(color)
+        self._render_preview()
+
+    def _on_hex_typed(self, role: str) -> None:
+        """Accept a hand-typed colour once it's complete, ignore it until then."""
+        text = self._hex_vars[role].get().strip()
+        if not text.startswith("#"):
+            text = "#" + text
+        if len(text) != 7:
+            return
+        try:
+            int(text[1:], 16)
+        except ValueError:
+            return
+        if text.lower() != self.values[role]:
+            self._set_color(role, text)
+
+    # ----- preview ------------------------------------------------------------
+
+    def _render_preview(self) -> None:
+        """Draw a miniature of the app from the working palette.
+
+        Canvas shapes rather than real widgets: the preview has to show a
+        palette that isn't loaded, and ttk styles are global.
+        """
+        if not hasattr(self, "preview"):
+            return
+        c, v = self.preview, self.values
+        c.delete("all")
+        c.configure(background=v["bg_window"])
+        ink = v["border"] if self.outline_var.get() else ""
+        outline_w = 2 if self.outline_var.get() else 1
+
+        # Title bar, with the halftone screening in from the right.
+        c.create_rectangle(0, 0, PREVIEW_W, 34, fill=v["bg_gradient_a"], outline="")
+        paint_gradient(
+            c, color_a=v["bg_gradient_a"], color_b=v["bg_gradient_b"],
+            direction="horizontal",
+        )
+        c.create_rectangle(0, 34, PREVIEW_W, PREVIEW_H, fill=v["bg_window"], outline="")
+        if self.halftone_var.get():
+            paint_halftone(
+                c, color=self.halftone_ink, box=(0, 0, PREVIEW_W, 34),
+                fade_from="right", fade_span=PREVIEW_W * 0.55, spacing=6, radius=1.7,
+            )
+        c.create_text(
+            10, 17, anchor=tk.W, text="AI Case Sorter",
+            fill=v["text"], font=("TkDefaultFont", 11, "bold"),
+        )
+
+        # Panel with a section heading.
+        c.create_rectangle(
+            8, 44, PREVIEW_W - 8, PREVIEW_H - 40,
+            fill=v["bg_surface"], outline=ink, width=outline_w,
+        )
+        c.create_text(
+            18, 58, anchor=tk.W, text="Slots",
+            fill=v["accent"], font=("TkDefaultFont", 9, "bold"),
+        )
+
+        # A plain card and a selected one.
+        for x0, fill, title in (
+            (18, v["bg_card"], "Slot #1"),
+            (160, v["bg_card_sel"], "Slot #2"),
+        ):
+            c.create_rectangle(
+                x0, 70, x0 + 122, 128, fill=fill, outline=ink, width=outline_w,
+            )
+            c.create_text(
+                x0 + 10, 84, anchor=tk.W, text=title,
+                fill=v["text"], font=("TkDefaultFont", 9, "bold"),
+            )
+            c.create_text(
+                x0 + 10, 102, anchor=tk.W, text="(no headstamps)",
+                fill=v["text_muted"], font=("TkDefaultFont", 8),
+            )
+
+        # An input field.
+        c.create_rectangle(
+            18, 140, PREVIEW_W - 18, 164,
+            fill=v["bg_input"], outline=v["border"], width=outline_w,
+        )
+        c.create_text(
+            26, 152, anchor=tk.W, text="Confidence floor",
+            fill=v["text_subtle"], font=("TkDefaultFont", 8),
+        )
+
+        # The three coloured buttons and the secondary one.
+        buttons = (
+            (v["action"], "Start"),
+            (v["update"], "Update"),
+            (v["danger"], "Stop"),
+        )
+        x = 18
+        for fill, label in buttons:
+            c.create_rectangle(
+                x, 176, x + 84, 202, fill=fill, outline=ink, width=outline_w,
+            )
+            c.create_text(
+                x + 42, 189, text=label, fill=v["text_inverse"],
+                font=("TkDefaultFont", 8, "bold"),
+            )
+            x += 89
+        c.create_rectangle(
+            18, 210, 102, 236, fill=v["accent_dim"], outline=ink, width=outline_w,
+        )
+        c.create_text(
+            60, 223, text="Secondary", fill=v["text"], font=("TkDefaultFont", 8),
+        )
+
+        # Status text and the two connection dots.
+        c.create_text(
+            116, 223, anchor=tk.W, text="Warning",
+            fill=v["warning"], font=("TkDefaultFont", 8),
+        )
+        c.create_text(
+            18, 252, anchor=tk.W, text="●  connected",
+            fill=v["action"], font=("TkDefaultFont", 8),
+        )
+        c.create_text(
+            18, 268, anchor=tk.W, text="●  disconnected",
+            fill=v["danger"], font=("TkDefaultFont", 8),
+        )
+        c.create_text(
+            18, PREVIEW_H - 22, anchor=tk.W,
+            text=self.name_var.get() or "Untitled",
+            fill=v["text_muted"], font=("TkDefaultFont", 8),
+        )
+
+    # ----- save / delete ------------------------------------------------------
+
+    def _payload(self) -> dict:
+        return {
+            "version": CUSTOM_THEME_VERSION,
+            "name": self.name_var.get().strip(),
+            "based_on": self.base,
+            "halftone": self.halftone_ink if self.halftone_var.get() else None,
+            "outline": 2 if self.outline_var.get() else 0,
+            "palette": normalize_palette(self.values),
+        }
+
+    def _save(self) -> None:
+        payload = self._payload()
+        name = payload["name"]
+        if not name:
+            messagebox.showwarning("Name needed", "Give the theme a name.", parent=self)
+            return
+        if name in BUILTIN_THEMES:
+            messagebox.showwarning(
+                "Built-in theme",
+                f"“{name}” is a built-in theme. Pick a different name.",
+                parent=self,
+            )
+            return
+        if name != self.base and name in THEMES and not messagebox.askyesno(
+            "Replace theme", f"Replace the saved theme “{name}”?", parent=self,
+        ):
+            return
+        self._register_and_apply(payload)
+        self.destroy()
+
+    def _register_and_apply(self, payload: dict) -> None:
+        register_custom_theme(
+            payload["name"], payload["palette"],
+            halftone=payload.get("halftone"),
+            outline=payload.get("outline", 0),
+            base=payload.get("based_on"),
+        )
+        self.app.save_custom_themes()
+        self.app.set_theme(payload["name"])
+        self.app.refresh_theme_picker()
+
+    def _delete(self) -> None:
+        if messagebox.askyesno(
+            "Delete theme", f"Delete the theme “{self.base}”?", parent=self,
+        ):
+            self._delete_confirmed()
+
+    def _delete_confirmed(self) -> None:
+        # Fall back to whatever this theme was made from; that may itself have
+        # been deleted since, in which case `set_theme` resolves to the default.
+        fallback = self.app.theme_name
+        if fallback == self.base:
+            fallback = custom_theme_payload(self.base).get("based_on") or ""
+        unregister_custom_theme(self.base)
+        self.app.save_custom_themes()
+        self.app.set_theme(fallback)
+        self.app.refresh_theme_picker()
+        self.destroy()
+
+    # ----- files --------------------------------------------------------------
+
+    def _export(self) -> None:
+        if not self.name_var.get().strip():
+            messagebox.showwarning(
+                "Name needed", "Give the theme a name before exporting.", parent=self,
+            )
+            return
+        path = filedialog.asksaveasfilename(
+            parent=self, title="Export theme", defaultextension=".json",
+            initialfile=f"{self.name_var.get().strip()}.json", filetypes=_FILE_TYPES,
+        )
+        if not path:
+            return
+        try:
+            self._write_theme_file(Path(path))
+        except OSError as exc:
+            messagebox.showerror("Export failed", str(exc), parent=self)
+            return
+        messagebox.showinfo("Theme exported", f"Saved to {path}", parent=self)
+
+    def _write_theme_file(self, path: Path) -> dict:
+        """Write the theme as it stands in the editor — unsaved edits included."""
+        payload = self._payload()
+        path.write_text(json.dumps(payload, indent=2), encoding="utf-8")
+        return payload
+
+    def _import(self) -> None:
+        path = filedialog.askopenfilename(
+            parent=self, title="Import theme", filetypes=_FILE_TYPES,
+        )
+        if not path:
+            return
+        try:
+            self._read_theme_file(Path(path))
+        except (OSError, ValueError) as exc:
+            messagebox.showerror("Import failed", str(exc), parent=self)
+            return
+        self.destroy()
+
+    def _read_theme_file(self, path: Path) -> None:
+        """Register and apply the theme in `path`; raises ValueError if it isn't one.
+
+        An imported theme never replaces an existing one — it comes in under a
+        free name, so importing the file you exported leaves you with both.
+        """
+        payload = json.loads(path.read_text(encoding="utf-8"))
+        problem = _describe_bad_theme(payload)
+        if problem:
+            raise ValueError(problem)
+        self._register_and_apply({
+            "version": CUSTOM_THEME_VERSION,
+            "name": unique_theme_name(str(payload.get("name") or path.stem)),
+            "based_on": payload.get("based_on"),
+            "halftone": payload.get("halftone"),
+            "outline": payload.get("outline", 0),
+            "palette": normalize_palette(payload.get("palette")),
+        })
+
+
+def _describe_bad_theme(payload) -> str | None:
+    """Why this file can't be a theme, or None if it can."""
+    if not isinstance(payload, dict):
+        return "That file doesn't contain a theme."
+    if not isinstance(payload.get("palette"), dict):
+        return "That file has no theme colours in it."
+    try:
+        version = int(payload.get("version", CUSTOM_THEME_VERSION))
+    except (TypeError, ValueError):
+        return "That theme file's version isn't readable."
+    if version > CUSTOM_THEME_VERSION:
+        return (
+            "That theme was made by a newer version of the app. "
+            "Update, then import it again."
+        )
+    return None

--- a/sorter/ui/tab_community.py
+++ b/sorter/ui/tab_community.py
@@ -79,11 +79,11 @@ class CommunityModelCard(ttk.Frame):
         ).pack(side=tk.TOP, anchor="w")
 
         # Info grid (3 columns × 3 rows)
-        grid = ttk.Frame(self, style="Card.TFrame")
+        grid = ttk.Frame(self, style="CardRow.TFrame")
         grid.pack(side=tk.TOP, fill=tk.X, pady=(8, 6))
 
         def _cell(row: int, col: int, label: str, value: str) -> None:
-            f = ttk.Frame(grid, style="Card.TFrame")
+            f = ttk.Frame(grid, style="CardRow.TFrame")
             f.grid(row=row, column=col, sticky="w", padx=(0, 32), pady=2)
             ttk.Label(f, text=f"{label}:", style="CardSubtle.TLabel").pack(side=tk.LEFT)
             ttk.Label(f, text=value, style="CardMuted.TLabel").pack(side=tk.LEFT, padx=(6, 0))
@@ -105,9 +105,9 @@ class CommunityModelCard(ttk.Frame):
             ).pack(side=tk.TOP, anchor="w", pady=(2, 8), fill=tk.X)
 
         # Action button (right-aligned)
-        action_row = ttk.Frame(self, style="Card.TFrame")
+        action_row = ttk.Frame(self, style="CardRow.TFrame")
         action_row.pack(side=tk.TOP, fill=tk.X)
-        ttk.Frame(action_row, style="Card.TFrame").pack(side=tk.LEFT, fill=tk.X, expand=True)
+        ttk.Frame(action_row, style="CardRow.TFrame").pack(side=tk.LEFT, fill=tk.X, expand=True)
         if installed_state == "installed":
             btn = ttk.Button(action_row, text="Already Installed",
                              state=tk.DISABLED)

--- a/sorter/ui/tab_models.py
+++ b/sorter/ui/tab_models.py
@@ -38,7 +38,7 @@ from ..repository import (
 from .dialog_model_editor import ModelEditorDialog
 from .dialog_model_evaluator import ModelEvaluatorDialog
 from .dialog_model_images import ModelImagesDialog
-from .theme import PALETTE
+from .theme import PALETTE, row_style
 
 
 # Characters disallowed in headstamp / parent names — they would collide with
@@ -81,10 +81,10 @@ class ModelRowCard(ttk.Frame):
         self._on_select = on_select
 
         # Left column — title, subtitle, info grid.
-        left = ttk.Frame(self, style="Card.TFrame")
+        left = ttk.Frame(self, style="CardRow.TFrame")
         left.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
 
-        title_row = ttk.Frame(left, style="Card.TFrame")
+        title_row = ttk.Frame(left, style="CardRow.TFrame")
         title_row.pack(side=tk.TOP, fill=tk.X)
         self._title_lbl = ttk.Label(
             title_row, text=title, style="CardTitle.TLabel",
@@ -103,18 +103,18 @@ class ModelRowCard(ttk.Frame):
             self._subtitle_lbl.pack(side=tk.TOP, anchor="w", pady=(2, 6))
 
         if info_pairs:
-            grid = ttk.Frame(left, style="Card.TFrame")
+            grid = ttk.Frame(left, style="CardRow.TFrame")
             grid.pack(side=tk.TOP, fill=tk.X, pady=(0, 2))
             for i, (label, value) in enumerate(info_pairs):
                 col = i % 3
                 row = i // 3
-                cell = ttk.Frame(grid, style="Card.TFrame")
+                cell = ttk.Frame(grid, style="CardRow.TFrame")
                 cell.grid(row=row, column=col, sticky="w", padx=(0, 18), pady=1)
                 ttk.Label(cell, text=f"{label}:", style="CardSubtle.TLabel").pack(side=tk.LEFT)
                 ttk.Label(cell, text=value, style="CardMuted.TLabel").pack(side=tk.LEFT, padx=(4, 0))
 
         # Right column — action buttons.
-        right = ttk.Frame(self, style="Card.TFrame")
+        right = ttk.Frame(self, style="CardRow.TFrame")
         right.pack(side=tk.RIGHT)
         for label, cmd in actions:
             style = "Accent.TButton" if label == primary_action else (
@@ -148,7 +148,7 @@ class ModelRowCard(ttk.Frame):
         def _walk(w: tk.Misc) -> None:
             for child in w.winfo_children():
                 if isinstance(child, ttk.Frame):
-                    child.configure(style=frame_style)
+                    child.configure(style=row_style(frame_style))
                     _walk(child)
                 elif isinstance(child, ttk.Label):
                     # Don't restyle the accent active dot.

--- a/sorter/ui/tab_run.py
+++ b/sorter/ui/tab_run.py
@@ -33,13 +33,7 @@ from typing import Callable
 from ..events import EventBus
 from ..feedback import FeedbackService, debug_log, is_feedback_model
 from ..repository import ModelRepo
-from .theme import (
-    PALETTE,
-    halftone_ink,
-    paint_halftone,
-    register_halftone,
-    row_style,
-)
+from .theme import PALETTE, row_style
 from .widgets import ImagePanel
 
 
@@ -60,10 +54,6 @@ _STORE_IMAGES_LABELS = {
     "all": "All Images",
 }
 _STORE_IMAGES_BY_LABEL = {label: mode for mode, label in _STORE_IMAGES_LABELS.items()}
-
-# How far the slot-details backdrop screen reaches, in pixels from the top of
-# the panel's canvas (see SlotDetailsPanel._screen_backdrop).
-_BACKDROP_SCREEN_DEPTH = 260
 
 
 # ----- Flow-layout container --------------------------------------------------
@@ -406,12 +396,10 @@ class SlotDetailsPanel(ttk.LabelFrame):
             "<Configure>",
             lambda _e: self._canvas.configure(scrollregion=self._canvas.bbox("all")),
         )
-        self._canvas.bind("<Configure>", self._on_canvas_configure)
-        # The panel's empty lower half is one of the few places in the app
-        # where a backdrop is actually visible, so themes that print a
-        # halftone get to screen it (see theme.HALFTONE_INK).
-        self._screened_width = -1
-        register_halftone(self._canvas, self._screen_backdrop)
+        self._canvas.bind(
+            "<Configure>",
+            lambda e: self._canvas.itemconfigure(self._inner_id, width=e.width),
+        )
 
         # Per-label counters: counters[slot][label] = int (label = predicted
         # headstamp name). A parent cell sums its children's counters.
@@ -420,31 +408,6 @@ class SlotDetailsPanel(ttk.LabelFrame):
         self._cells_by_source: dict[str, list[HeadstampCell]] = defaultdict(list)
         # Parent names whose group is collapsed (grouped mode only).
         self._collapsed: set[str] = set()
-
-    # ----- backdrop -----------------------------------------------------------
-
-    def _on_canvas_configure(self, event: tk.Event) -> None:
-        self._canvas.itemconfigure(self._inner_id, width=event.width)
-        # A drag-resize fires this continuously; the screen only depends on
-        # the width, so repaint the (few thousand) dots when that changes.
-        if event.width != self._screened_width:
-            self._screened_width = event.width
-            self._screen_backdrop()
-
-    def _screen_backdrop(self) -> None:
-        """Fade a dot screen down the panel's backdrop, if themed for it.
-
-        Only what the checkbox grid doesn't cover shows — the grid is an
-        embedded window, and Tk always draws those over the canvas's own
-        items. The band is anchored to the top and measured in pixels rather
-        than a fraction of the canvas: this canvas is as tall as the whole
-        (scrollable) tab, so a proportional fade would land off-screen.
-        """
-        paint_halftone(
-            self._canvas, color=halftone_ink(), fade_from="top",
-            box=(0, 0, self._canvas.winfo_width(), _BACKDROP_SCREEN_DEPTH),
-            fade_span=_BACKDROP_SCREEN_DEPTH, spacing=10, radius=2.4,
-        )
 
     # ----- render -------------------------------------------------------------
 

--- a/sorter/ui/tab_run.py
+++ b/sorter/ui/tab_run.py
@@ -33,7 +33,13 @@ from typing import Callable
 from ..events import EventBus
 from ..feedback import FeedbackService, debug_log, is_feedback_model
 from ..repository import ModelRepo
-from .theme import PALETTE
+from .theme import (
+    PALETTE,
+    halftone_ink,
+    paint_halftone,
+    register_halftone,
+    row_style,
+)
 from .widgets import ImagePanel
 
 
@@ -54,6 +60,10 @@ _STORE_IMAGES_LABELS = {
     "all": "All Images",
 }
 _STORE_IMAGES_BY_LABEL = {label: mode for mode, label in _STORE_IMAGES_LABELS.items()}
+
+# How far the slot-details backdrop screen reaches, in pixels from the top of
+# the panel's canvas (see SlotDetailsPanel._screen_backdrop).
+_BACKDROP_SCREEN_DEPTH = 260
 
 
 # ----- Flow-layout container --------------------------------------------------
@@ -162,7 +172,7 @@ class SlotCard(ttk.Frame):
         )
         self.headstamps_label.pack(anchor=tk.W, pady=(6, 8))
 
-        count_row = ttk.Frame(self, style="Card.TFrame")
+        count_row = ttk.Frame(self, style="CardRow.TFrame")
         count_row.pack(fill=tk.X)
         self.count_caption = ttk.Label(
             count_row, text="Count",
@@ -178,7 +188,7 @@ class SlotCard(ttk.Frame):
         # Live batch-reset (package mode only, never the catch-all). Lets the
         # operator dump a full bin and zero its counter while other slots keep
         # filling. Hidden until set_package_mode(True) is called.
-        self._reset_row = ttk.Frame(self, style="Card.TFrame")
+        self._reset_row = ttk.Frame(self, style="CardRow.TFrame")
         self._reset_btn = ttk.Button(
             self._reset_row, text="⟲ Reset count",
             command=self._reset_clicked, width=16,
@@ -266,11 +276,12 @@ class SlotCard(ttk.Frame):
         self.headstamps_label.configure(style=muted_style)
         self.count_label.configure(style=title_style)
         self.count_caption.configure(style=subtle_style)
-        # The "count" row frame also needs to track the card background.
+        # The "count" row frame also needs to track the card background —
+        # in its flat variant, so only the card itself carries an outline.
         for child in self.winfo_children():
             if isinstance(child, ttk.Frame):
                 try:
-                    child.configure(style=frame_style)
+                    child.configure(style=row_style(frame_style))
                 except tk.TclError:
                     pass
 
@@ -395,10 +406,12 @@ class SlotDetailsPanel(ttk.LabelFrame):
             "<Configure>",
             lambda _e: self._canvas.configure(scrollregion=self._canvas.bbox("all")),
         )
-        self._canvas.bind(
-            "<Configure>",
-            lambda e: self._canvas.itemconfigure(self._inner_id, width=e.width),
-        )
+        self._canvas.bind("<Configure>", self._on_canvas_configure)
+        # The panel's empty lower half is one of the few places in the app
+        # where a backdrop is actually visible, so themes that print a
+        # halftone get to screen it (see theme.HALFTONE_INK).
+        self._screened_width = -1
+        register_halftone(self._canvas, self._screen_backdrop)
 
         # Per-label counters: counters[slot][label] = int (label = predicted
         # headstamp name). A parent cell sums its children's counters.
@@ -407,6 +420,31 @@ class SlotDetailsPanel(ttk.LabelFrame):
         self._cells_by_source: dict[str, list[HeadstampCell]] = defaultdict(list)
         # Parent names whose group is collapsed (grouped mode only).
         self._collapsed: set[str] = set()
+
+    # ----- backdrop -----------------------------------------------------------
+
+    def _on_canvas_configure(self, event: tk.Event) -> None:
+        self._canvas.itemconfigure(self._inner_id, width=event.width)
+        # A drag-resize fires this continuously; the screen only depends on
+        # the width, so repaint the (few thousand) dots when that changes.
+        if event.width != self._screened_width:
+            self._screened_width = event.width
+            self._screen_backdrop()
+
+    def _screen_backdrop(self) -> None:
+        """Fade a dot screen down the panel's backdrop, if themed for it.
+
+        Only what the checkbox grid doesn't cover shows — the grid is an
+        embedded window, and Tk always draws those over the canvas's own
+        items. The band is anchored to the top and measured in pixels rather
+        than a fraction of the canvas: this canvas is as tall as the whole
+        (scrollable) tab, so a proportional fade would land off-screen.
+        """
+        paint_halftone(
+            self._canvas, color=halftone_ink(), fade_from="top",
+            box=(0, 0, self._canvas.winfo_width(), _BACKDROP_SCREEN_DEPTH),
+            fade_span=_BACKDROP_SCREEN_DEPTH, spacing=10, radius=2.4,
+        )
 
     # ----- render -------------------------------------------------------------
 

--- a/sorter/ui/theme.py
+++ b/sorter/ui/theme.py
@@ -269,6 +269,52 @@ _GOTHIC = {
     "error":         "#e5484d",
 }
 
+# Comic-book ink: black panel gutters, a cobalt title bar, gold and orange
+# on top. The one theme where **gold, not green, is "go"** — an anime/comic
+# palette has no green in it, and `success` tracks `action` by rule, so the
+# connected indicator is gold here and the disconnected one stays red. Gold
+# against red separates further than green against red for the most common
+# form of colour blindness, and both dots sit beside their labels anyway.
+_COMIC = {
+    "bg_window":     "#0e1117",
+    "bg_gradient_a": "#1b56b8",   # cobalt left — the comic panel's sky
+    "bg_gradient_b": "#090c11",
+    "bg_surface":    "#151a23",
+    "bg_card":       "#1e2531",
+    "bg_card_hover": "#29323f",
+    "bg_card_sel":   "#26406d",   # selection lifts toward the cobalt
+    "bg_input":      "#070a0e",
+
+    "border":        "#2c3644",
+    "border_focus":  "#ffd257",
+
+    "text":          "#eef2f8",
+    "text_highlight": "#ffffff",
+    "text_muted":    "#a5b1c1",
+    "text_subtle":   "#6f7c8d",
+    "text_inverse":  "#0b0e13",
+
+    "accent":        "#f2b01e",
+    "accent_hover":  "#ffc74d",
+    "accent_press":  "#cc9014",
+    "accent_dim":    "#232c39",
+
+    "action":        "#ffc219",
+    "action_hover":  "#ffd451",
+    "action_press":  "#e0a300",
+    "update":        "#2f7fe0",
+    "update_hover":  "#559bf0",
+    "update_press":  "#1f63b8",
+    "danger":        "#e5342a",
+    "danger_hover":  "#f4574d",
+    "danger_press":  "#c02318",
+
+    "success":       "#ffc219",
+    "success_dim":   "#3a2f08",
+    "warning":       "#ff8a1f",
+    "error":         "#e5342a",
+}
+
 # Display name → palette. Insertion order drives the picker's order.
 THEMES: dict[str, dict[str, str]] = {
     "Dark": _DARK,
@@ -276,9 +322,24 @@ THEMES: dict[str, dict[str, str]] = {
     "Sepia": _SEPIA,
     "Midnight Blue": _MIDNIGHT_BLUE,
     "Gothic": _GOTHIC,
+    "Comic Book": _COMIC,
 }
 
 DEFAULT_THEME = "Dark"
+
+# Themes whose title bar gets a ben-day dot field printed over the gradient,
+# and the ink to print it in. A theme that isn't listed here gets a plain
+# gradient — the dots are a comic-book device, not a default. Pick an ink
+# close to the gradient's dark end so the field fades out as the background
+# darkens under it.
+HALFTONE_INK = {
+    "Comic Book": "#123a86",
+}
+
+
+def halftone_ink() -> str | None:
+    """Dot colour for the current theme's title bar, or None for no dots."""
+    return HALFTONE_INK.get(_current_theme)
 
 # The live palette. Modules do `from .theme import PALETTE` and index it at
 # call time, so switching themes **mutates this dict in place** — rebinding
@@ -1079,6 +1140,48 @@ def paint_gradient(
                 tags="gradient",
             )
     canvas.tag_lower("gradient")
+
+
+def paint_halftone(
+    canvas: tk.Canvas,
+    *,
+    color: str | None,
+    spacing: int = 7,
+    radius: float = 2.0,
+    fade_end: float = 0.8,
+) -> None:
+    """Print a ben-day dot field across the canvas, replacing any prior one.
+
+    The dots shrink from full size at the left edge to nothing by `fade_end`
+    (a fraction of the width), which is how a comic screens a flat colour into
+    the ink beside it. Rows are offset by half a step so the field reads as a
+    proper halftone screen rather than a grid.
+
+    `color=None` just clears the field, so a caller can hand it whatever
+    ``halftone_ink()`` returns without branching.
+    """
+    canvas.delete("halftone")
+    if color is None:
+        return
+    canvas.update_idletasks()
+    width = canvas.winfo_width()
+    height = canvas.winfo_height()
+    if width < 2 or height < 2:
+        return
+
+    span = max(1.0, width * fade_end)
+    for row in range(int(height / spacing) + 2):
+        y = row * spacing + spacing / 2
+        offset = spacing / 2 if row % 2 else 0.0
+        for col in range(int(width / spacing) + 2):
+            x = col * spacing + offset
+            r = radius * (1.0 - x / span)
+            if r < 0.6:
+                break  # everything further right is smaller still
+            canvas.create_oval(
+                x - r, y - r, x + r, y + r,
+                fill=color, outline="", tags="halftone",
+            )
 
 
 def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:

--- a/sorter/ui/theme.py
+++ b/sorter/ui/theme.py
@@ -224,38 +224,41 @@ _MIDNIGHT_BLUE = {
     "error":         "#ef4444",
 }
 
-# Near-black with a violet cast; the "update" blue becomes violet so the
-# one cool accent belongs to the palette. Green/red keep their meaning.
+# Black and blood red. The one theme whose accent carries hue: section
+# titles, selection fills and the focus ring are crimson, and the surfaces
+# are near-black with just enough red in them to belong. Green still means
+# go and the danger red stays a step brighter than the accent, so a Stop or
+# a Delete button is still the loudest thing on screen.
 _GOTHIC = {
-    "bg_window":     "#0d0a10",
-    "bg_gradient_a": "#35233f",
-    "bg_gradient_b": "#0a070d",
-    "bg_surface":    "#16111b",
-    "bg_card":       "#211829",
-    "bg_card_hover": "#2c2036",
-    "bg_card_sel":   "#402f4d",
-    "bg_input":      "#0a070e",
+    "bg_window":     "#0c0708",
+    "bg_gradient_a": "#4a1116",
+    "bg_gradient_b": "#080405",
+    "bg_surface":    "#150e10",
+    "bg_card":       "#1f1416",
+    "bg_card_hover": "#2b1a1d",
+    "bg_card_sel":   "#46181e",
+    "bg_input":      "#070303",
 
-    "border":        "#3a2b45",
-    "border_focus":  "#b08bd0",
+    "border":        "#3a2226",
+    "border_focus":  "#c0464e",
 
-    "text":          "#ded3e6",
+    "text":          "#e0d6d7",
     "text_highlight": "#ffffff",
-    "text_muted":    "#a394ae",
-    "text_subtle":   "#766a80",
-    "text_inverse":  "#0c0910",
+    "text_muted":    "#a89597",
+    "text_subtle":   "#7a686a",
+    "text_inverse":  "#0b0607",
 
-    "accent":        "#c9a7e0",
-    "accent_hover":  "#ddc4ee",
-    "accent_press":  "#a684bd",
-    "accent_dim":    "#2b2034",
+    "accent":        "#d13c45",
+    "accent_hover":  "#e85860",
+    "accent_press":  "#a52a31",
+    "accent_dim":    "#2a1518",
 
     "action":        "#3fb950",
     "action_hover":  "#56d364",
     "action_press":  "#2ea043",
-    "update":        "#a78bfa",
-    "update_hover":  "#c4b5fd",
-    "update_press":  "#8b5cf6",
+    "update":        "#5b82c4",
+    "update_hover":  "#7ba0dd",
+    "update_press":  "#45689f",
     "danger":        "#e5484d",
     "danger_hover":  "#ef6b6f",
     "danger_press":  "#c93c41",

--- a/sorter/ui/theme.py
+++ b/sorter/ui/theme.py
@@ -317,7 +317,7 @@ _COMIC = {
 }
 
 # Display name → palette. Insertion order drives the picker's order.
-THEMES: dict[str, dict[str, str]] = {
+BUILTIN_THEMES: dict[str, dict[str, str]] = {
     "Dark": _DARK,
     "Light": _LIGHT,
     "Sepia": _SEPIA,
@@ -326,7 +326,18 @@ THEMES: dict[str, dict[str, str]] = {
     "Comic Book": _COMIC,
 }
 
+# The live registry: the built-ins above plus whatever the user has saved in
+# the theme editor, appended in load order. Mutated in place by
+# `register_custom_theme` (the module is imported all over the UI).
+THEMES: dict[str, dict[str, str]] = dict(BUILTIN_THEMES)
+
 DEFAULT_THEME = "Dark"
+
+# Settings key holding the user's saved themes: {name: payload}, where the
+# payload is what `custom_theme_payload` returns.
+SETTING_CUSTOM_THEMES = "ui.custom_themes"
+# Bumped if the payload shape ever changes; import refuses anything newer.
+CUSTOM_THEME_VERSION = 1
 
 # Themes whose title bar gets a ben-day dot field printed over the gradient,
 # and the ink to print it in. A theme that isn't listed here gets a plain
@@ -393,6 +404,162 @@ def set_palette(name: str | None) -> dict[str, str]:
     PALETTE.clear()
     PALETTE.update(THEMES[_current_theme])
     return previous
+
+
+# ----- user-made themes -------------------------------------------------------
+#
+# The editor (ui/dialog_theme_editor.py) builds these from an existing theme,
+# and the app registers whatever the settings store holds at startup. They are
+# ordinary entries in THEMES from then on — nothing downstream knows or cares
+# that a palette was made by a user.
+
+# Roles the editor never asks about because they mirror another one. Keeping
+# them derived is what lets `retheme_widgets` resolve a colour to one role.
+DERIVED_ROLES = {"success": "action", "error": "danger"}
+
+_custom_themes: dict[str, dict] = {}
+
+
+def is_custom_theme(name: str) -> bool:
+    return name in _custom_themes
+
+
+def custom_theme_names() -> list[str]:
+    return list(_custom_themes)
+
+
+def editable_roles() -> list[str]:
+    """Palette roles a user can set; the rest are derived from these."""
+    return [key for key in _DARK if key not in DERIVED_ROLES]
+
+
+def normalize_palette(
+    values: "dict | None", base: dict[str, str] | None = None
+) -> dict[str, str]:
+    """Coerce arbitrary input into a full, well-formed palette.
+
+    Unknown keys are dropped, missing ones come from `base` (the default theme
+    if not given), non-colours are ignored, and the derived roles are forced
+    back into step with the ones they mirror. An imported file can therefore be
+    partial or slightly wrong without the app ever seeing a broken palette.
+    """
+    palette = dict(base or _DARK)
+    for key, value in (values or {}).items():
+        if key in palette and isinstance(value, str) and _is_hex_color(value):
+            palette[key] = value.lower()
+    for derived, source in DERIVED_ROLES.items():
+        palette[derived] = palette[source]
+    return palette
+
+
+def _is_hex_color(value: str) -> bool:
+    if not isinstance(value, str) or len(value) != 7 or not value.startswith("#"):
+        return False
+    try:
+        int(value[1:], 16)
+    except ValueError:
+        return False
+    return True
+
+
+def unique_theme_name(name: str) -> str:
+    """A name that doesn't collide with an existing theme (adds " (2)", …)."""
+    stem = (name or "").strip() or "My theme"
+    candidate, n = stem, 2
+    existing = {known.casefold() for known in THEMES}
+    while candidate.casefold() in existing:
+        candidate = f"{stem} ({n})"
+        n += 1
+    return candidate
+
+
+def register_custom_theme(
+    name: str,
+    palette: dict[str, str],
+    *,
+    halftone: str | None = None,
+    outline: int = 0,
+    base: str | None = None,
+) -> str:
+    """Add (or replace) a user-made theme. Returns the name it registered under."""
+    name = (name or "").strip()
+    if not name:
+        raise ValueError("A theme needs a name.")
+    if name in BUILTIN_THEMES:
+        raise ValueError(f"{name!r} is a built-in theme — pick another name.")
+    THEMES[name] = normalize_palette(palette)
+    _custom_themes[name] = {
+        "version": CUSTOM_THEME_VERSION,
+        "based_on": base,
+        "halftone": halftone if (halftone and _is_hex_color(halftone)) else None,
+        "outline": max(0, min(4, int(outline or 0))),
+    }
+    if _custom_themes[name]["halftone"]:
+        HALFTONE_INK[name] = _custom_themes[name]["halftone"]
+    else:
+        HALFTONE_INK.pop(name, None)
+    if _custom_themes[name]["outline"]:
+        INK_OUTLINE[name] = _custom_themes[name]["outline"]
+    else:
+        INK_OUTLINE.pop(name, None)
+    return name
+
+
+def unregister_custom_theme(name: str) -> None:
+    """Forget a user-made theme. Built-ins are left alone."""
+    if name not in _custom_themes:
+        return
+    _custom_themes.pop(name, None)
+    THEMES.pop(name, None)
+    HALFTONE_INK.pop(name, None)
+    INK_OUTLINE.pop(name, None)
+
+
+def custom_theme_payload(name: str) -> dict:
+    """The storable / exportable form of a user-made theme."""
+    meta = _custom_themes[name]
+    return {
+        "version": CUSTOM_THEME_VERSION,
+        "name": name,
+        "based_on": meta.get("based_on"),
+        "halftone": meta.get("halftone"),
+        "outline": meta.get("outline", 0),
+        "palette": dict(THEMES[name]),
+    }
+
+
+def custom_themes_payload() -> dict[str, dict]:
+    """Every user-made theme, keyed by name — what the app persists."""
+    return {name: custom_theme_payload(name) for name in _custom_themes}
+
+
+def load_custom_themes(stored: "dict | None") -> list[str]:
+    """Replace the registered custom themes with `stored`. Returns their names.
+
+    Anything unreadable is skipped rather than raising: a corrupt settings row
+    must not stop the app from starting.
+    """
+    for name in list(_custom_themes):
+        unregister_custom_theme(name)
+    loaded: list[str] = []
+    if not isinstance(stored, dict):
+        return loaded
+    for key, payload in stored.items():
+        if not isinstance(payload, dict):
+            continue
+        try:
+            loaded.append(
+                register_custom_theme(
+                    payload.get("name") or key,
+                    normalize_palette(payload.get("palette")),
+                    halftone=payload.get("halftone"),
+                    outline=payload.get("outline", 0),
+                    base=payload.get("based_on"),
+                )
+            )
+        except (ValueError, TypeError):
+            continue
+    return loaded
 
 
 def row_style(card_style: str) -> str:

--- a/sorter/ui/theme.py
+++ b/sorter/ui/theme.py
@@ -27,10 +27,14 @@ Exported helpers:
   Tk widgets that baked their colors in at construction time.
 * ``paint_gradient(canvas, ...)`` — paint a vertical/horizontal linear
   gradient across the canvas. Used for the title bar.
+* ``paint_halftone(canvas, ...)`` — print a ben-day dot screen over part of
+  a canvas, for the themes that ask for one (``HALFTONE_INK``). Register the
+  paint with ``register_halftone`` so it survives a theme switch.
 """
 from __future__ import annotations
 
 import tkinter as tk
+from collections.abc import Callable
 from tkinter import font as tkfont
 from tkinter import ttk
 
@@ -269,50 +273,49 @@ _GOTHIC = {
     "error":         "#e5484d",
 }
 
-# Comic-book ink: black panel gutters, a cobalt title bar, gold and orange
-# on top. The one theme where **gold, not green, is "go"** — an anime/comic
-# palette has no green in it, and `success` tracks `action` by rule, so the
-# connected indicator is gold here and the disconnected one stays red. Gold
-# against red separates further than green against red for the most common
-# form of colour blindness, and both dots sit beside their labels anyway.
+# A comic page: yellow newsprint, white panels, black ink outlines, and the
+# two comic inks — red for headings and stops, blue for go. The one theme
+# where **blue, not green, means go**: a comic palette has no green in it,
+# and `success` tracks `action` by rule, so the connected indicator is blue
+# here while the disconnected one stays red.
 _COMIC = {
-    "bg_window":     "#0e1117",
-    "bg_gradient_a": "#1b56b8",   # cobalt left — the comic panel's sky
-    "bg_gradient_b": "#090c11",
-    "bg_surface":    "#151a23",
-    "bg_card":       "#1e2531",
-    "bg_card_hover": "#29323f",
-    "bg_card_sel":   "#26406d",   # selection lifts toward the cobalt
-    "bg_input":      "#070a0e",
+    "bg_window":     "#f2b800",   # the page's darker edge, behind the tabs
+    "bg_gradient_a": "#ffe14d",   # title bar left — bright newsprint yellow
+    "bg_gradient_b": "#ffb61f",
+    "bg_surface":    "#ffd21f",   # the page itself
+    "bg_card":       "#ffffff",   # white panels sit on it
+    "bg_card_hover": "#eef4ff",
+    "bg_card_sel":   "#9ec5ff",   # selection goes comic blue
+    "bg_input":      "#fffdf2",
 
-    "border":        "#2c3644",
-    "border_focus":  "#ffd257",
+    "border":        "#111318",   # ink — every outline in this theme
+    "border_focus":  "#2352cc",
 
-    "text":          "#eef2f8",
-    "text_highlight": "#ffffff",
-    "text_muted":    "#a5b1c1",
-    "text_subtle":   "#6f7c8d",
-    "text_inverse":  "#0b0e13",
+    "text":          "#14161c",
+    "text_highlight": "#000000",
+    "text_muted":    "#4b4740",
+    "text_subtle":   "#7d7566",
+    "text_inverse":  "#fefefe",   # white, but not the panels' white
 
-    "accent":        "#f2b01e",
-    "accent_hover":  "#ffc74d",
-    "accent_press":  "#cc9014",
-    "accent_dim":    "#232c39",
+    "accent":        "#cf1b1b",   # headings, selection fills, the caret
+    "accent_hover":  "#ea2a2a",
+    "accent_press":  "#a41313",
+    "accent_dim":    "#ffe58f",
 
-    "action":        "#ffc219",
-    "action_hover":  "#ffd451",
-    "action_press":  "#e0a300",
-    "update":        "#2f7fe0",
-    "update_hover":  "#559bf0",
-    "update_press":  "#1f63b8",
-    "danger":        "#e5342a",
-    "danger_hover":  "#f4574d",
-    "danger_press":  "#c02318",
+    "action":        "#1a4fc4",
+    "action_hover":  "#2f66e0",
+    "action_press":  "#123a96",
+    "update":        "#1f2530",
+    "update_hover":  "#333c4d",
+    "update_press":  "#12171f",
+    "danger":        "#e8302a",
+    "danger_hover":  "#f65046",
+    "danger_press":  "#bf1f1a",
 
-    "success":       "#ffc219",
-    "success_dim":   "#3a2f08",
-    "warning":       "#ff8a1f",
-    "error":         "#e5342a",
+    "success":       "#1a4fc4",
+    "success_dim":   "#cfe0ff",
+    "warning":       "#e07a00",
+    "error":         "#e8302a",
 }
 
 # Display name → palette. Insertion order drives the picker's order.
@@ -333,13 +336,25 @@ DEFAULT_THEME = "Dark"
 # close to the gradient's dark end so the field fades out as the background
 # darkens under it.
 HALFTONE_INK = {
-    "Comic Book": "#123a86",
+    "Comic Book": "#1b1e24",
+}
+
+# Themes drawn with comic-book ink outlines: how many pixels of border to put
+# around panels, cards, buttons and fields. 0 (the default) keeps the flat,
+# borderless look the other themes are built on.
+INK_OUTLINE = {
+    "Comic Book": 2,
 }
 
 
 def halftone_ink() -> str | None:
-    """Dot colour for the current theme's title bar, or None for no dots."""
+    """Dot colour for the current theme's backdrops, or None for no dots."""
     return HALFTONE_INK.get(_current_theme)
+
+
+def ink_outline() -> int:
+    """Border width for the current theme's panels and controls (0 = flat)."""
+    return INK_OUTLINE.get(_current_theme, 0)
 
 # The live palette. Modules do `from .theme import PALETTE` and index it at
 # call time, so switching themes **mutates this dict in place** — rebinding
@@ -380,6 +395,11 @@ def set_palette(name: str | None) -> dict[str, str]:
     PALETTE.clear()
     PALETTE.update(THEMES[_current_theme])
     return previous
+
+
+def row_style(card_style: str) -> str:
+    """The flat, outline-free variant of a card frame style."""
+    return card_style.replace(".TFrame", "Row.TFrame")
 
 
 def _pick_font(
@@ -438,15 +458,19 @@ def _colored_button(
     """Configure a solid-fill action button (the app's only colored controls).
 
     clam draws a button's edge from bordercolor/darkcolor/lightcolor, so all
-    three track the fill or the button reads as outlined.
+    three track the fill or the button reads as outlined — except in an
+    ink-outline theme, where an outline is exactly what we want.
     """
+    ink = ink_outline()
+    edge = PALETTE["border"] if ink else rest
     style.configure(
         name,
         background=rest,
         foreground=PALETTE["text_inverse"],
-        bordercolor=rest,
-        darkcolor=rest,
-        lightcolor=rest,
+        bordercolor=edge,
+        darkcolor=edge,
+        lightcolor=edge,
+        borderwidth=ink,
         focuscolor=PALETTE["text_inverse"],
         font=fonts["bold"],
     )
@@ -455,12 +479,13 @@ def _colored_button(
         ("active", hover),
         ("disabled", PALETTE["bg_surface"]),
     ]
+    edges = [("!disabled", edge)] if ink else fill
     style.map(
         name,
         background=fill,
-        bordercolor=fill,
-        darkcolor=fill,
-        lightcolor=fill,
+        bordercolor=edges,
+        darkcolor=edges,
+        lightcolor=edges,
         foreground=[("disabled", PALETTE["text_subtle"])],
     )
 
@@ -507,14 +532,36 @@ def apply_theme(root: tk.Tk, theme: str | None = None) -> dict[str, tuple]:
     bg = PALETTE["bg_surface"]
     text = PALETTE["text"]
     accent = PALETTE["accent"]
+    # Comic-book themes outline everything in ink; the rest stay borderless.
+    ink = ink_outline()
+    ink_edge = PALETTE["border"]
+
+    def _outlined(name: str, fill: str) -> None:
+        """A surface that carries an ink outline in the themes that use one."""
+        style.configure(
+            name,
+            background=fill,
+            bordercolor=ink_edge if ink else fill,
+            darkcolor=ink_edge if ink else fill,
+            lightcolor=ink_edge if ink else fill,
+            borderwidth=ink,
+            relief="solid" if ink else "flat",
+        )
 
     # ----- Frames ------------------------------------------------------------
     style.configure("TFrame", background=bg)
     style.configure("Window.TFrame", background=PALETTE["bg_window"])
-    style.configure("Card.TFrame", background=PALETTE["bg_card"])
-    style.configure("CardHover.TFrame", background=PALETTE["bg_card_hover"])
-    style.configure("CardSel.TFrame", background=PALETTE["bg_card_sel"])
     style.configure("StatusBar.TFrame", background=PALETTE["bg_window"])
+    # A card is outlined; the rows *inside* it share its fill but never its
+    # outline, or every layout row in a card would draw its own box. Cards
+    # restyle their children through `row_style` to keep the two in step.
+    for card, fill in (
+        ("Card.TFrame", PALETTE["bg_card"]),
+        ("CardHover.TFrame", PALETTE["bg_card_hover"]),
+        ("CardSel.TFrame", PALETTE["bg_card_sel"]),
+    ):
+        _outlined(card, fill)
+        style.configure(row_style(card), background=fill)
 
     # ----- Labels ------------------------------------------------------------
     style.configure(
@@ -637,15 +684,7 @@ def apply_theme(root: tk.Tk, theme: str | None = None) -> dict[str, tuple]:
     # ----- LabelFrame --------------------------------------------------------
     # Borderless — the colored label and bg-surface contrast against the
     # window already separate sections visually, no outline needed.
-    style.configure(
-        "TLabelframe",
-        background=bg,
-        bordercolor=bg,
-        darkcolor=bg,
-        lightcolor=bg,
-        borderwidth=0,
-        relief="flat",
-    )
+    _outlined("TLabelframe", bg)
     style.configure(
         "TLabelframe.Label",
         background=bg,
@@ -677,15 +716,20 @@ def apply_theme(root: tk.Tk, theme: str | None = None) -> dict[str, tuple]:
         "TNotebook.Tab",
         background=PALETTE["bg_card"],
         foreground=PALETTE["text_muted"],
-        bordercolor=PALETTE["bg_card"],
-        darkcolor=PALETTE["bg_card"],
-        lightcolor=PALETTE["bg_card"],
+        bordercolor=ink_edge if ink else PALETTE["bg_card"],
+        darkcolor=ink_edge if ink else PALETTE["bg_card"],
+        lightcolor=ink_edge if ink else PALETTE["bg_card"],
         padding=(16, 8),
-        borderwidth=0,
+        borderwidth=ink,
         font=fonts["bold"],
     )
     # Selected tab is visually elevated: extra padding, blue-tinted bg,
-    # bumped font. Hovered tab gets a subtle lift.
+    # bumped font. Hovered tab gets a subtle lift. Under an ink outline the
+    # edge stays ink whatever the fill does.
+    _tab_edges = [("selected", ink_edge), ("active", ink_edge)] if ink else [
+        ("selected", PALETTE["bg_card_sel"]),
+        ("active", PALETTE["bg_card_hover"]),
+    ]
     style.map(
         "TNotebook.Tab",
         background=[
@@ -696,18 +740,9 @@ def apply_theme(root: tk.Tk, theme: str | None = None) -> dict[str, tuple]:
             ("selected", PALETTE["text"]),
             ("active", PALETTE["text"]),
         ],
-        bordercolor=[
-            ("selected", PALETTE["bg_card_sel"]),
-            ("active", PALETTE["bg_card_hover"]),
-        ],
-        lightcolor=[
-            ("selected", PALETTE["bg_card_sel"]),
-            ("active", PALETTE["bg_card_hover"]),
-        ],
-        darkcolor=[
-            ("selected", PALETTE["bg_card_sel"]),
-            ("active", PALETTE["bg_card_hover"]),
-        ],
+        bordercolor=_tab_edges,
+        lightcolor=_tab_edges,
+        darkcolor=_tab_edges,
         padding=[
             ("selected", (22, 12)),
         ],
@@ -727,13 +762,15 @@ def apply_theme(root: tk.Tk, theme: str | None = None) -> dict[str, tuple]:
         "TButton",
         background=PALETTE["accent_dim"],
         foreground=text,
-        bordercolor=PALETTE["accent_dim"],
-        darkcolor=PALETTE["accent_dim"],
-        lightcolor=PALETTE["accent_dim"],
+        bordercolor=ink_edge if ink else PALETTE["accent_dim"],
+        darkcolor=ink_edge if ink else PALETTE["accent_dim"],
+        lightcolor=ink_edge if ink else PALETTE["accent_dim"],
         focuscolor=PALETTE["border_focus"],
-        borderwidth=0,
-        relief="flat",
-        padding=(14, 7),
+        borderwidth=ink,
+        relief="solid" if ink else "flat",
+        # The outline eats into the button, so give the padding back — button
+        # rows elsewhere are packed to fit and would otherwise clip.
+        padding=(14 - 2 * ink, 7 - ink),
         font=fonts["body"],
     )
     _button_fill = [
@@ -741,12 +778,13 @@ def apply_theme(root: tk.Tk, theme: str | None = None) -> dict[str, tuple]:
         ("active", PALETTE["bg_card_hover"]),
         ("disabled", PALETTE["bg_surface"]),
     ]
+    _button_edge = [("!disabled", ink_edge)] if ink else _button_fill
     style.map(
         "TButton",
         background=_button_fill,
-        bordercolor=_button_fill,
-        darkcolor=_button_fill,
-        lightcolor=_button_fill,
+        bordercolor=_button_edge,
+        darkcolor=_button_edge,
+        lightcolor=_button_edge,
         foreground=[
             ("disabled", PALETTE["text_subtle"]),
             ("active", PALETTE["text_highlight"]),
@@ -788,6 +826,7 @@ def apply_theme(root: tk.Tk, theme: str | None = None) -> dict[str, tuple]:
             bordercolor=PALETTE["border"],
             darkcolor=PALETTE["border"],
             lightcolor=PALETTE["border"],
+            borderwidth=ink or 1,
             insertcolor=accent,
             arrowcolor=PALETTE["text_muted"],
             padding=4,
@@ -1146,42 +1185,101 @@ def paint_halftone(
     canvas: tk.Canvas,
     *,
     color: str | None,
+    box: tuple[float, float, float, float] | None = None,
+    fade_from: str = "left",
+    fade_span: float | None = None,
     spacing: int = 7,
     radius: float = 2.0,
-    fade_end: float = 0.8,
+    clear: bool = True,
+    tag: str = "halftone",
 ) -> None:
-    """Print a ben-day dot field across the canvas, replacing any prior one.
+    """Print a ben-day dot field over `box`, replacing any prior field.
 
-    The dots shrink from full size at the left edge to nothing by `fade_end`
-    (a fraction of the width), which is how a comic screens a flat colour into
-    the ink beside it. Rows are offset by half a step so the field reads as a
-    proper halftone screen rather than a grid.
+    The dots start full size along the `fade_from` edge and shrink to nothing
+    `fade_span` pixels in, which is how a comic screens a flat colour away
+    into the paper beside it. Rows are offset by half a step so the field
+    reads as a halftone screen rather than a grid. `fade_span` defaults to
+    80% of the box across the fade's axis.
+
+    `box` defaults to the whole canvas. `clear=False` adds a band to the field
+    already painted under `tag` instead of replacing it — that's how a caller
+    screens several edges of one canvas in a single pass.
 
     `color=None` just clears the field, so a caller can hand it whatever
     ``halftone_ink()`` returns without branching.
     """
-    canvas.delete("halftone")
+    if clear:
+        canvas.delete(tag)
     if color is None:
         return
-    canvas.update_idletasks()
-    width = canvas.winfo_width()
-    height = canvas.winfo_height()
+    # Deliberately no update_idletasks() here: this runs from <Configure>
+    # handlers and during widget construction, where re-entering the event
+    # loop would fire half-built widgets' callbacks.
+    if box is None:
+        box = (0, 0, canvas.winfo_width(), canvas.winfo_height())
+    x0, y0, x1, y1 = box
+    width, height = x1 - x0, y1 - y0
     if width < 2 or height < 2:
         return
 
-    span = max(1.0, width * fade_end)
+    horizontal = fade_from in ("left", "right")
+    if fade_span is None:
+        fade_span = (width if horizontal else height) * 0.8
+    span = max(1.0, fade_span)
+
     for row in range(int(height / spacing) + 2):
-        y = row * spacing + spacing / 2
+        y = y0 + row * spacing + spacing / 2
+        if y - radius > y1:
+            break
         offset = spacing / 2 if row % 2 else 0.0
         for col in range(int(width / spacing) + 2):
-            x = col * spacing + offset
-            r = radius * (1.0 - x / span)
+            x = x0 + col * spacing + offset
+            if x - radius > x1:
+                break
+            if fade_from == "left":
+                depth = x - x0
+            elif fade_from == "right":
+                depth = x1 - x
+            elif fade_from == "top":
+                depth = y - y0
+            else:
+                depth = y1 - y
+            r = radius * (1.0 - depth / span)
             if r < 0.6:
-                break  # everything further right is smaller still
+                if horizontal and fade_from == "left":
+                    break  # everything further in is smaller still
+                continue
             canvas.create_oval(
                 x - r, y - r, x + r, y + r,
-                fill=color, outline="", tags="halftone",
+                fill=color, outline="", tags=tag,
             )
+
+
+def register_halftone(canvas: tk.Canvas, repaint: "Callable[[], None]") -> None:
+    """Have `repaint` re-run whenever the theme changes.
+
+    A canvas that screens part of itself paints with sizes and fade edges only
+    it knows, so a theme switch can't repaint it generically. Registering the
+    callback here means a new backdrop anywhere in the app starts following
+    theme changes without app.py having to learn about it.
+    """
+    canvas._halftone_repaint = repaint  # type: ignore[attr-defined]
+
+
+def repaint_halftone_fields(widget: tk.Misc) -> None:
+    """Re-run every halftone registered under `widget` (after a theme switch)."""
+    repaint = getattr(widget, "_halftone_repaint", None)
+    if callable(repaint):
+        try:
+            repaint()
+        except tk.TclError:
+            pass
+    try:
+        children = widget.winfo_children()
+    except tk.TclError:
+        return
+    for child in children:
+        repaint_halftone_fields(child)
 
 
 def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:

--- a/sorter/ui/theme.py
+++ b/sorter/ui/theme.py
@@ -28,13 +28,11 @@ Exported helpers:
 * ``paint_gradient(canvas, ...)`` — paint a vertical/horizontal linear
   gradient across the canvas. Used for the title bar.
 * ``paint_halftone(canvas, ...)`` — print a ben-day dot screen over part of
-  a canvas, for the themes that ask for one (``HALFTONE_INK``). Register the
-  paint with ``register_halftone`` so it survives a theme switch.
+  a canvas, for the themes that ask for one (``HALFTONE_INK``).
 """
 from __future__ import annotations
 
 import tkinter as tk
-from collections.abc import Callable
 from tkinter import font as tkfont
 from tkinter import ttk
 
@@ -1253,33 +1251,6 @@ def paint_halftone(
                 x - r, y - r, x + r, y + r,
                 fill=color, outline="", tags=tag,
             )
-
-
-def register_halftone(canvas: tk.Canvas, repaint: "Callable[[], None]") -> None:
-    """Have `repaint` re-run whenever the theme changes.
-
-    A canvas that screens part of itself paints with sizes and fade edges only
-    it knows, so a theme switch can't repaint it generically. Registering the
-    callback here means a new backdrop anywhere in the app starts following
-    theme changes without app.py having to learn about it.
-    """
-    canvas._halftone_repaint = repaint  # type: ignore[attr-defined]
-
-
-def repaint_halftone_fields(widget: tk.Misc) -> None:
-    """Re-run every halftone registered under `widget` (after a theme switch)."""
-    repaint = getattr(widget, "_halftone_repaint", None)
-    if callable(repaint):
-        try:
-            repaint()
-        except tk.TclError:
-            pass
-    try:
-        children = widget.winfo_children()
-    except tk.TclError:
-        return
-    for child in children:
-        repaint_halftone_fields(child)
 
 
 def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:

--- a/sorter/ui/theme.py
+++ b/sorter/ui/theme.py
@@ -338,6 +338,9 @@ DEFAULT_THEME = "Dark"
 SETTING_CUSTOM_THEMES = "ui.custom_themes"
 # Bumped if the payload shape ever changes; import refuses anything newer.
 CUSTOM_THEME_VERSION = 1
+# Theme names ride in the title-bar dropdown, which is sized to the longest of
+# them — so they stay short enough not to crowd the title out.
+MAX_THEME_NAME = 12
 
 # Themes whose title bar gets a ben-day dot field printed over the gradient,
 # and the ink to print it in. A theme that isn't listed here gets a plain
@@ -463,12 +466,13 @@ def _is_hex_color(value: str) -> bool:
 
 
 def unique_theme_name(name: str) -> str:
-    """A name that doesn't collide with an existing theme (adds " (2)", …)."""
-    stem = (name or "").strip() or "My theme"
+    """A free theme name within the length limit (adds " (2)", … as needed)."""
+    stem = (name or "").strip()[:MAX_THEME_NAME].strip() or "My theme"
     candidate, n = stem, 2
     existing = {known.casefold() for known in THEMES}
     while candidate.casefold() in existing:
-        candidate = f"{stem} ({n})"
+        suffix = f" ({n})"
+        candidate = f"{stem[:MAX_THEME_NAME - len(suffix)].strip()}{suffix}"
         n += 1
     return candidate
 
@@ -485,6 +489,8 @@ def register_custom_theme(
     name = (name or "").strip()
     if not name:
         raise ValueError("A theme needs a name.")
+    if len(name) > MAX_THEME_NAME:
+        raise ValueError(f"Theme names are at most {MAX_THEME_NAME} characters.")
     if name in BUILTIN_THEMES:
         raise ValueError(f"{name!r} is a built-in theme — pick another name.")
     THEMES[name] = normalize_palette(palette)
@@ -503,6 +509,29 @@ def register_custom_theme(
     else:
         INK_OUTLINE.pop(name, None)
     return name
+
+
+def rename_custom_theme(old: str, new: str) -> str:
+    """Rename a user-made theme in place. Returns the new name.
+
+    A rename is not "save a copy and delete the original": the theme keeps its
+    position in the picker and its options, and only the key changes.
+    """
+    if old not in _custom_themes:
+        raise ValueError(f"{old!r} isn't a theme you can rename.")
+    new = (new or "").strip()
+    if new == old:
+        return old
+    meta = _custom_themes[old]
+    palette = dict(THEMES[old])
+    # Register first: a bad new name must leave the original untouched.
+    register_custom_theme(
+        new, palette,
+        halftone=meta.get("halftone"), outline=meta.get("outline", 0),
+        base=meta.get("based_on"),
+    )
+    unregister_custom_theme(old)
+    return new
 
 
 def unregister_custom_theme(name: str) -> None:

--- a/sorter/ui/theme.py
+++ b/sorter/ui/theme.py
@@ -1075,6 +1075,36 @@ def apply_theme(root: tk.Tk, theme: str | None = None) -> dict[str, tuple]:
         arrowcolor=[("active", accent)],
     )
 
+    # The gear beside it is an icon, not a control to be noticed: no fill, no
+    # border, no focus ring, and it sits on the gradient's dark end so it
+    # reads as part of the title bar rather than a button parked on it.
+    _header_bg = PALETTE["bg_gradient_b"]
+    style.configure(
+        "HeaderIcon.TButton",
+        background=_header_bg,
+        foreground=PALETTE["text_muted"],
+        bordercolor=_header_bg,
+        darkcolor=_header_bg,
+        lightcolor=_header_bg,
+        focuscolor=_header_bg,
+        borderwidth=0,
+        relief="flat",
+        padding=(3, 0),
+        font=fonts["body"],
+    )
+    _icon_bg = [("pressed", _header_bg), ("active", _header_bg)]
+    style.map(
+        "HeaderIcon.TButton",
+        background=_icon_bg,
+        bordercolor=_icon_bg,
+        darkcolor=_icon_bg,
+        lightcolor=_icon_bg,
+        foreground=[
+            ("pressed", PALETTE["accent_press"]),
+            ("active", PALETTE["text_highlight"]),
+        ],
+    )
+
     # Combobox dropdown list (uses the option database).
     root.option_add("*TCombobox*Listbox.background", PALETTE["bg_card"])
     root.option_add("*TCombobox*Listbox.foreground", text)

--- a/sorter/ui/theme.py
+++ b/sorter/ui/theme.py
@@ -1,20 +1,30 @@
-"""Modern dark theme for the OSS Client UI.
+"""Themes for the OSS Client UI.
 
 Centralises colors, fonts, and ttk styles so the rest of the app can stay
-focused on layout. The chrome — window, panels, cards, inputs, borders,
-text — is **neutral grayscale**: a flat luminance ladder that gives the UI
-depth without bevels, relief, or a hue of its own. Color is reserved for
-things that mean something: action buttons (green = go / primary,
-red = stop / destructive) and status text (success / warning / error).
-Keeping the surfaces colorless means a green Start or a red Stop is the
-only saturated thing on screen, so it reads instantly.
+focused on layout. Every color lives in one of the palettes below; the
+rest of the app reads the *live* ``PALETTE`` dict, which always holds the
+selected theme's values.
 
-Two helpers are exported:
+**The role of each key is fixed; only its color changes per theme.** The
+original theme (``"Dark"``) keeps its chrome — window, panels, cards,
+inputs, borders, text — **neutral grayscale**: a flat luminance ladder
+that gives the UI depth without bevels, relief, or a hue of its own,
+reserving color for things that mean something (action buttons, status
+text). The alternative themes tint the chrome, but they keep that
+discipline internally: their surfaces stay a single low-saturation family
+so the action buttons remain the most saturated thing on screen.
 
-* ``apply_theme(root)`` — call once after the root is created. Applies
-  ttk styles, sets default fonts on the legacy Tk widgets (Listbox / Text
-  / Canvas), and returns the resolved fonts dict for callers that need to
-  match.
+Adding a theme means copying ``_DARK`` and re-colouring it — every theme
+must define exactly the same keys (``tests/test_theme.py`` enforces it).
+
+Exported helpers:
+
+* ``apply_theme(root, theme=...)`` — call once after the root is created,
+  and again on every theme switch. Selects the palette, applies ttk styles,
+  sets defaults for the legacy Tk widgets (Listbox / Text / Canvas), and
+  returns the resolved fonts dict for callers that need to match.
+* ``retheme_widgets(root, previous)`` — after a switch, repaint the classic
+  Tk widgets that baked their colors in at construction time.
 * ``paint_gradient(canvas, ...)`` — paint a vertical/horizontal linear
   gradient across the canvas. Used for the title bar.
 """
@@ -25,17 +35,21 @@ from tkinter import font as tkfont
 from tkinter import ttk
 
 
-# Color palette — single source of truth.
+# Settings key holding the user's chosen theme name (see repository.SettingsRepo).
+SETTING_THEME = "ui.theme"
+
+
+# The original theme, and the reference for every other palette's key set.
 #
 # Everything above the "Action colors" block is neutral gray (R == G == B):
 # surfaces, borders, text, and the selection/focus tints. Only the action
 # and status entries carry hue. If you add a color here, ask which of the
 # two groups it belongs to — a new tinted surface breaks the contrast the
 # colored buttons rely on.
-PALETTE = {
+_DARK = {
     # Backgrounds — neutral gray, darkest to lightest.
     "bg_window":     "#131313",   # app background / gradient bottom
-    "bg_gradient_a": "#2e2e2e",   # title bar left
+    "bg_gradient_a": "#2f2f2f",   # title bar left
     "bg_gradient_b": "#0c0c0c",   # title bar right
     "bg_surface":    "#1c1c1c",   # panels — one step up from the window
     "bg_card":       "#272727",   # raised surfaces (slot cards, monitor log)
@@ -52,7 +66,7 @@ PALETTE = {
     "text_highlight": "#ffffff",  # emphasised values (Accent.TLabel)
     "text_muted":    "#9a9a9a",
     "text_subtle":   "#6f6f6f",
-    "text_inverse":  "#131313",   # for text on light/action backgrounds
+    "text_inverse":  "#121212",   # for text on light/action backgrounds
 
     # Neutral "accent" — section titles, focus, indicators, selection fills.
     # Kept gray on purpose: emphasis here comes from brightness so that the
@@ -75,12 +89,233 @@ PALETTE = {
     "danger_hover":  "#f87171",
     "danger_press":  "#dc2626",
 
-    # Status colors — text and small indicators.
+    # Status colors — text and small indicators. `success` tracks `action`
+    # and `error` tracks `danger` in every theme: they are the same idea
+    # rendered as text instead of a button.
     "success":       "#22c55e",
     "success_dim":   "#14331f",   # muted green fill — e.g. applied auto-suggestions
     "warning":       "#f59e0b",
     "error":         "#ef4444",
 }
+
+# Daylight theme: the gray ladder inverted, so "lifted" reads as *darker*
+# rather than brighter. The action colors are the darker 700-weight shades
+# because they now sit against white and carry light text.
+_LIGHT = {
+    "bg_window":     "#eaeaea",
+    "bg_gradient_a": "#fbfbfb",
+    "bg_gradient_b": "#d4d4d4",
+    "bg_surface":    "#f4f4f4",
+    "bg_card":       "#ffffff",
+    "bg_card_hover": "#ededed",
+    "bg_card_sel":   "#d8d8d8",
+    "bg_input":      "#fdfdfd",
+
+    "border":        "#c2c2c2",
+    "border_focus":  "#5b5b5b",
+
+    "text":          "#1c1c1c",
+    "text_highlight": "#000000",
+    "text_muted":    "#565656",
+    "text_subtle":   "#868686",
+    "text_inverse":  "#fafafa",
+
+    "accent":        "#3d3d3d",
+    "accent_hover":  "#292929",
+    "accent_press":  "#101010",
+    "accent_dim":    "#e2e2e2",
+
+    "action":        "#15803d",
+    "action_hover":  "#16a34a",
+    "action_press":  "#0f5f2e",
+    "update":        "#1d4ed8",
+    "update_hover":  "#2563eb",
+    "update_press":  "#1e40af",
+    "danger":        "#b91c1c",
+    "danger_hover":  "#dc2626",
+    "danger_press":  "#991b1b",
+
+    "success":       "#15803d",
+    "success_dim":   "#d5f0de",
+    "warning":       "#b45309",
+    "error":         "#b91c1c",
+}
+
+# Warm paper — the light theme's twin for people who find pure white harsh.
+_SEPIA = {
+    "bg_window":     "#e8dfcf",
+    "bg_gradient_a": "#f6efe0",
+    "bg_gradient_b": "#d3c6ae",
+    "bg_surface":    "#f2ebdc",
+    "bg_card":       "#fdf8ee",
+    "bg_card_hover": "#eee5d3",
+    "bg_card_sel":   "#dccfb6",
+    "bg_input":      "#fffdf7",
+
+    "border":        "#c3b498",
+    "border_focus":  "#6b5b43",
+
+    "text":          "#3a2f22",
+    "text_highlight": "#1c150c",
+    "text_muted":    "#6d5f4c",
+    "text_subtle":   "#948673",
+    "text_inverse":  "#fdf9f0",
+
+    "accent":        "#5b4a34",
+    "accent_hover":  "#453727",
+    "accent_press":  "#2e2419",
+    "accent_dim":    "#e0d6c1",
+
+    "action":        "#46733a",
+    "action_hover":  "#558a45",
+    "action_press":  "#35592c",
+    "update":        "#2f6690",
+    "update_hover":  "#3d7fb0",
+    "update_press":  "#255273",
+    "danger":        "#a33232",
+    "danger_hover":  "#c04040",
+    "danger_press":  "#872828",
+
+    "success":       "#46733a",
+    "success_dim":   "#dbe8cf",
+    "warning":       "#9a6b12",
+    "error":         "#a33232",
+}
+
+# Deep navy chrome. The surfaces carry the hue, so the accent is pulled
+# almost to white to keep selection fills legible.
+_MIDNIGHT_BLUE = {
+    "bg_window":     "#0b1220",
+    "bg_gradient_a": "#1b2a4a",
+    "bg_gradient_b": "#060b16",
+    "bg_surface":    "#121c2e",
+    "bg_card":       "#1a2740",
+    "bg_card_hover": "#22334f",
+    "bg_card_sel":   "#31456a",
+    "bg_input":      "#070d18",
+
+    "border":        "#2c3b57",
+    "border_focus":  "#7ea2d8",
+
+    "text":          "#d6e2f5",
+    "text_highlight": "#ffffff",
+    "text_muted":    "#93a6c4",
+    "text_subtle":   "#6a7c99",
+    "text_inverse":  "#0a1120",
+
+    "accent":        "#cfe0fb",
+    "accent_hover":  "#e8f1ff",
+    "accent_press":  "#a9c4ea",
+    "accent_dim":    "#22314d",
+
+    "action":        "#22c55e",
+    "action_hover":  "#4ade80",
+    "action_press":  "#16a34a",
+    "update":        "#60a5fa",
+    "update_hover":  "#93c5fd",
+    "update_press":  "#3b82f6",
+    "danger":        "#ef4444",
+    "danger_hover":  "#f87171",
+    "danger_press":  "#dc2626",
+
+    "success":       "#22c55e",
+    "success_dim":   "#123a2a",
+    "warning":       "#fbbf24",
+    "error":         "#ef4444",
+}
+
+# Near-black with a violet cast; the "update" blue becomes violet so the
+# one cool accent belongs to the palette. Green/red keep their meaning.
+_GOTHIC = {
+    "bg_window":     "#0d0a10",
+    "bg_gradient_a": "#35233f",
+    "bg_gradient_b": "#0a070d",
+    "bg_surface":    "#16111b",
+    "bg_card":       "#211829",
+    "bg_card_hover": "#2c2036",
+    "bg_card_sel":   "#402f4d",
+    "bg_input":      "#0a070e",
+
+    "border":        "#3a2b45",
+    "border_focus":  "#b08bd0",
+
+    "text":          "#ded3e6",
+    "text_highlight": "#ffffff",
+    "text_muted":    "#a394ae",
+    "text_subtle":   "#766a80",
+    "text_inverse":  "#0c0910",
+
+    "accent":        "#c9a7e0",
+    "accent_hover":  "#ddc4ee",
+    "accent_press":  "#a684bd",
+    "accent_dim":    "#2b2034",
+
+    "action":        "#3fb950",
+    "action_hover":  "#56d364",
+    "action_press":  "#2ea043",
+    "update":        "#a78bfa",
+    "update_hover":  "#c4b5fd",
+    "update_press":  "#8b5cf6",
+    "danger":        "#e5484d",
+    "danger_hover":  "#ef6b6f",
+    "danger_press":  "#c93c41",
+
+    "success":       "#3fb950",
+    "success_dim":   "#1b2a1e",
+    "warning":       "#d29922",
+    "error":         "#e5484d",
+}
+
+# Display name → palette. Insertion order drives the picker's order.
+THEMES: dict[str, dict[str, str]] = {
+    "Dark": _DARK,
+    "Light": _LIGHT,
+    "Sepia": _SEPIA,
+    "Midnight Blue": _MIDNIGHT_BLUE,
+    "Gothic": _GOTHIC,
+}
+
+DEFAULT_THEME = "Dark"
+
+# The live palette. Modules do `from .theme import PALETTE` and index it at
+# call time, so switching themes **mutates this dict in place** — rebinding
+# the name here would leave every importer holding the old colors.
+PALETTE: dict[str, str] = dict(THEMES[DEFAULT_THEME])
+
+_current_theme = DEFAULT_THEME
+
+
+def theme_names() -> list[str]:
+    """Selectable theme names, in display order."""
+    return list(THEMES)
+
+
+def current_theme() -> str:
+    """Name of the palette currently loaded into ``PALETTE``."""
+    return _current_theme
+
+
+def resolve_theme(name: str | None) -> str:
+    """Map a stored/user-supplied name onto a real theme, case-insensitively."""
+    if name:
+        for known in THEMES:
+            if known.casefold() == str(name).casefold():
+                return known
+    return DEFAULT_THEME
+
+
+def set_palette(name: str | None) -> dict[str, str]:
+    """Load a theme into ``PALETTE`` in place; returns the palette it replaced.
+
+    The returned snapshot is what ``retheme_widgets`` needs to recognise the
+    colors already baked into existing classic Tk widgets.
+    """
+    global _current_theme
+    previous = dict(PALETTE)
+    _current_theme = resolve_theme(name)
+    PALETTE.clear()
+    PALETTE.update(THEMES[_current_theme])
+    return previous
 
 
 def _pick_font(
@@ -166,8 +401,16 @@ def _colored_button(
     )
 
 
-def apply_theme(root: tk.Tk) -> dict[str, tuple]:
-    """Apply the modern dark theme to the given root. Returns the fonts dict."""
+def apply_theme(root: tk.Tk, theme: str | None = None) -> dict[str, tuple]:
+    """Apply a theme to the given root. Returns the fonts dict.
+
+    Passing ``theme`` selects that palette first (unknown names fall back to
+    the default). Safe to call repeatedly: ttk styles are reconfigured in
+    place, so every ttk widget already on screen picks the new colors up.
+    Classic Tk widgets don't — see ``retheme_widgets``.
+    """
+    if theme is not None:
+        set_palette(theme)
     fonts = get_fonts(root)
 
     root.configure(bg=PALETTE["bg_window"])
@@ -500,6 +743,41 @@ def apply_theme(root: tk.Tk) -> dict[str, tuple]:
             arrowcolor=[("active", accent)],
         )
 
+    # Title-bar theme picker. Sits on the gradient rather than a panel, so it
+    # borrows the card color to read as a control without drawing a border.
+    _header_fill = PALETTE["bg_card"]
+    style.configure(
+        "Header.TCombobox",
+        fieldbackground=_header_fill,
+        background=_header_fill,
+        foreground=text,
+        bordercolor=_header_fill,
+        darkcolor=_header_fill,
+        lightcolor=_header_fill,
+        arrowcolor=PALETTE["text_muted"],
+        # Readonly comboboxes render their text through the selection colors;
+        # matching them to the fill keeps the closed control from showing a
+        # highlight bar whenever it holds focus.
+        selectbackground=_header_fill,
+        selectforeground=text,
+        padding=(6, 2),
+    )
+    style.map(
+        "Header.TCombobox",
+        fieldbackground=[
+            ("readonly", _header_fill),
+            ("active", PALETTE["bg_card_hover"]),
+        ],
+        background=[("active", PALETTE["bg_card_hover"])],
+        foreground=[("readonly", text)],
+        selectbackground=[("readonly", _header_fill)],
+        selectforeground=[("readonly", text)],
+        bordercolor=[("focus", _header_fill)],
+        lightcolor=[("focus", _header_fill)],
+        darkcolor=[("focus", _header_fill)],
+        arrowcolor=[("active", accent)],
+    )
+
     # Combobox dropdown list (uses the option database).
     root.option_add("*TCombobox*Listbox.background", PALETTE["bg_card"])
     root.option_add("*TCombobox*Listbox.foreground", text)
@@ -673,6 +951,82 @@ def apply_theme(root: tk.Tk) -> dict[str, tuple]:
     )
 
     return fonts
+
+
+# Color options carried by the classic Tk widgets we build (Label, Frame,
+# Canvas, Text, Listbox, Menu). ttk widgets don't accept these — their colors
+# come from the styles above — so a TclError on cget just means "skip".
+_WIDGET_COLOR_OPTIONS = (
+    "background",
+    "foreground",
+    "activebackground",
+    "activeforeground",
+    "disabledforeground",
+    "highlightbackground",
+    "highlightcolor",
+    "insertbackground",
+    "selectbackground",
+    "selectforeground",
+    "selectcolor",
+    "troughcolor",
+    "readonlybackground",
+)
+
+
+def _reverse_map(previous: dict[str, str]) -> dict[str, str]:
+    """Map each color of the outgoing palette to its counterpart in ``PALETTE``.
+
+    Keys are visited in palette order, so when two roles share a color (e.g.
+    ``success`` mirrors ``action``) the first one wins — which is why the
+    palettes keep those pairs identical in every theme.
+    """
+    mapping: dict[str, str] = {}
+    for key, old in previous.items():
+        new = PALETTE.get(key)
+        if new is None:
+            continue
+        mapping.setdefault(old.lower(), new)
+    return mapping
+
+
+def retheme_widgets(widget: tk.Misc, previous: dict[str, str]) -> None:
+    """Re-colour classic Tk widgets after a theme switch.
+
+    ttk widgets follow their style and update themselves; a ``tk.Label`` or
+    ``tk.Canvas`` built with ``bg=PALETTE["bg_card"]`` keeps the literal color
+    it was given. Rather than ask every module to register a callback, this
+    walks the widget tree (including open Toplevels) and translates any color
+    that came from the outgoing palette into the same role's new color.
+    Anything the app set to a color of its own — the monitor's snake borders,
+    for instance — isn't in the map and is left alone.
+    """
+    mapping = _reverse_map(previous)
+    if not mapping:
+        return
+    _retheme_tree(widget, mapping)
+
+
+def _retheme_tree(widget: tk.Misc, mapping: dict[str, str]) -> None:
+    updates: dict[str, str] = {}
+    for option in _WIDGET_COLOR_OPTIONS:
+        try:
+            value = str(widget.cget(option))
+        except (tk.TclError, TypeError, AttributeError):
+            continue
+        new = mapping.get(value.lower())
+        if new is not None and new.lower() != value.lower():
+            updates[option] = new
+    if updates:
+        try:
+            widget.configure(**updates)
+        except tk.TclError:
+            pass
+    try:
+        children = widget.winfo_children()
+    except tk.TclError:
+        return
+    for child in children:
+        _retheme_tree(child, mapping)
 
 
 def paint_gradient(

--- a/sorter/ui/widgets.py
+++ b/sorter/ui/widgets.py
@@ -50,7 +50,9 @@ class NumericField(ttk.Frame):
 class ScrollableFrame(ttk.Frame):
     """ttk.Frame whose content is a vertically scrollable inner frame.
 
-    Add the actual tab content to ``self.body``. The body is sized to match
+    Add the actual tab content to ``self.body``. Pass ``viewport=(w, h)``
+    to fix how much of it is visible at once; without it the frame is as big
+    as its content and scrolling only kicks in when the window is too small. The body is sized to match
     the canvas width (so ``fill=X`` children get the right size) and grows
     to at least the canvas height (so ``expand=True`` children still fill
     available space). When the content's natural height exceeds the
@@ -58,7 +60,13 @@ class ScrollableFrame(ttk.Frame):
     displays reach controls that would otherwise be clipped.
     """
 
-    def __init__(self, parent: tk.Misc, **kwargs: Any) -> None:
+    def __init__(
+        self,
+        parent: tk.Misc,
+        *,
+        viewport: tuple[int, int] | None = None,
+        **kwargs: Any,
+    ) -> None:
         super().__init__(parent, **kwargs)
         self._canvas = tk.Canvas(
             self,
@@ -66,6 +74,11 @@ class ScrollableFrame(ttk.Frame):
             bg=PALETTE["bg_surface"],
             borderwidth=0,
         )
+        if viewport is not None:
+            # Size the *canvas*, not the frame: sizing the frame and turning
+            # off propagation would let the canvas (packed to expand) eat the
+            # scrollbar's width.
+            self._canvas.configure(width=viewport[0], height=viewport[1])
         self._scrollbar = ttk.Scrollbar(
             self, orient=tk.VERTICAL, command=self._canvas.yview,
         )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Make `sorter` importable when running pytest from the repo root."""
 from __future__ import annotations
 
+import gc
 import sys
 from pathlib import Path
 
@@ -26,3 +27,33 @@ _DEV_ENV_VARS = (
 def _clear_dev_env(monkeypatch):
     for name in _DEV_ENV_VARS:
         monkeypatch.delenv(name, raising=False)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _freeze_import_garbage():
+    """Move everything the imports built into gc's permanent generation.
+
+    The per-test collection below then only has to walk objects the tests
+    themselves created, which keeps it off the suite's runtime.
+    """
+    gc.collect()
+    gc.freeze()
+    yield
+    gc.unfreeze()
+
+
+@pytest.fixture(autouse=True)
+def _collect_between_tests():
+    """Finalize each test's garbage on the main thread, before the next one.
+
+    Tk widgets and StringVars reference each other, so they only die in the
+    cyclic collector — and left alone that runs on whichever thread happens to
+    allocate next. Several tests start worker threads, and a `Variable.__del__`
+    that lands on one calls into Tcl from the wrong thread: it hangs there
+    waiting on the interpreter lock, or aborts the process outright. Which
+    tests collide is a matter of allocation timing, so adding an unrelated UI
+    test can surface it anywhere — collecting here keeps Tk garbage from
+    outliving the test that made it.
+    """
+    yield
+    gc.collect()

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -1,0 +1,321 @@
+"""Theme palettes, the live PALETTE switch, and the title-bar picker.
+
+The palette invariants run anywhere tkinter imports; the widget tests need a
+real display (xvfb in practice), matching the other UI tests.
+"""
+from __future__ import annotations
+
+import gc
+import re
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tkinter")
+
+import tkinter as tk  # noqa: E402
+from tkinter import ttk  # noqa: E402
+
+from sorter.ui import theme  # noqa: E402
+from sorter.ui.theme import (  # noqa: E402
+    DEFAULT_THEME,
+    PALETTE,
+    THEMES,
+    apply_theme,
+    current_theme,
+    resolve_theme,
+    retheme_widgets,
+    set_palette,
+    theme_names,
+)
+
+_HEX = re.compile(r"^#[0-9a-f]{6}$")
+
+# Roles that intentionally share a color inside a theme: the status text is
+# the button color rendered as text. `retheme_widgets` resolves a color to
+# the first matching role, so any *other* duplicate would make an existing
+# widget's re-colour ambiguous.
+_ALIASES = (("success", "action"), ("error", "danger"))
+
+
+@pytest.fixture(autouse=True)
+def _restore_default_theme():
+    """Keep a test's theme switch from leaking into the next test."""
+    original = current_theme()
+    yield
+    set_palette(original)
+
+
+@pytest.fixture(scope="module")
+def _tk_root():
+    # One root for the module: churning dozens of independent Tk roots through
+    # a single process is fragile (see the note in tests/test_monitor.py).
+    try:
+        r = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no Tk display: {exc}")
+    r.withdraw()
+    yield r
+    # Let the widgets die while the interpreter is still up (see the
+    # collection fixture in conftest.py).
+    gc.collect()
+    r.destroy()
+
+
+@pytest.fixture
+def root(_tk_root):
+    yield _tk_root
+    for child in _tk_root.winfo_children():
+        child.destroy()
+
+
+# ----- palette invariants -----------------------------------------------------
+
+
+def test_default_theme_is_offered() -> None:
+    assert DEFAULT_THEME in THEMES
+    assert theme_names()[0] == DEFAULT_THEME
+    assert len(THEMES) >= 4
+
+
+@pytest.mark.parametrize("name", list(THEMES))
+def test_every_theme_defines_the_same_roles(name: str) -> None:
+    assert set(THEMES[name]) == set(THEMES[DEFAULT_THEME]), (
+        f"{name} does not define the same palette keys as {DEFAULT_THEME}"
+    )
+
+
+@pytest.mark.parametrize("name", list(THEMES))
+def test_colors_are_six_digit_hex(name: str) -> None:
+    bad = {k: v for k, v in THEMES[name].items() if not _HEX.match(v.lower())}
+    assert not bad, f"{name} has non-hex colors: {bad}"
+
+
+@pytest.mark.parametrize("name", list(THEMES))
+def test_status_colors_track_their_buttons(name: str) -> None:
+    palette = THEMES[name]
+    for status, button in _ALIASES:
+        assert palette[status] == palette[button], (
+            f"{name}: {status} must equal {button} so a re-themed widget "
+            "can't pick the wrong role"
+        )
+
+
+@pytest.mark.parametrize("name", list(THEMES))
+def test_roles_are_otherwise_uniquely_coloured(name: str) -> None:
+    aliased = {status for status, _ in _ALIASES}
+    seen: dict[str, str] = {}
+    for key, color in THEMES[name].items():
+        if key in aliased:
+            continue
+        assert color not in seen, (
+            f"{name}: {key} and {seen[color]} share {color}; give them "
+            "distinct values so re-theming resolves the role unambiguously"
+        )
+        seen[color] = key
+
+
+# ----- selecting a palette ----------------------------------------------------
+
+
+def test_set_palette_mutates_the_shared_dict_in_place() -> None:
+    # Modules do `from .theme import PALETTE` — rebinding would strand them.
+    before = theme.PALETTE
+    set_palette("Light")
+
+    assert theme.PALETTE is before is PALETTE
+    assert PALETTE["bg_window"] == THEMES["Light"]["bg_window"]
+    assert current_theme() == "Light"
+
+
+def test_set_palette_returns_the_outgoing_palette() -> None:
+    set_palette("Dark")
+    previous = set_palette("Gothic")
+
+    assert previous == THEMES["Dark"]
+    assert PALETTE == THEMES["Gothic"]
+
+
+def test_unknown_theme_falls_back_to_the_default() -> None:
+    set_palette("Chartreuse")
+
+    assert current_theme() == DEFAULT_THEME
+    assert PALETTE == THEMES[DEFAULT_THEME]
+
+
+def test_resolve_theme_is_case_insensitive_and_null_safe() -> None:
+    assert resolve_theme("midnight blue") == "Midnight Blue"
+    assert resolve_theme(None) == DEFAULT_THEME
+    assert resolve_theme("") == DEFAULT_THEME
+
+
+def test_apply_theme_selects_the_palette(root) -> None:
+    apply_theme(root, theme="Sepia")
+
+    assert current_theme() == "Sepia"
+    assert PALETTE["bg_card"] == THEMES["Sepia"]["bg_card"]
+    assert ttk.Style(root).lookup("TFrame", "background") == THEMES["Sepia"]["bg_surface"]
+
+
+# ----- re-colouring live widgets ----------------------------------------------
+
+
+def test_retheme_walks_the_tree_and_translates_roles(root) -> None:
+    set_palette("Dark")
+    frame = tk.Frame(root, bg=PALETTE["bg_surface"])
+    label = tk.Label(
+        frame, text="hi", bg=PALETTE["bg_card"], fg=PALETTE["text_muted"],
+    )
+    label.pack()
+
+    previous = set_palette("Light")
+    retheme_widgets(root, previous)
+
+    assert frame.cget("bg") == THEMES["Light"]["bg_surface"]
+    assert label.cget("bg") == THEMES["Light"]["bg_card"]
+    assert label.cget("fg") == THEMES["Light"]["text_muted"]
+
+
+def test_retheme_leaves_non_palette_colors_alone(root) -> None:
+    set_palette("Dark")
+    # The monitor's "snake" borders are its own colors, not palette roles.
+    label = tk.Label(root, bg="#ff00ff", fg=PALETTE["text"])
+
+    previous = set_palette("Gothic")
+    retheme_widgets(root, previous)
+
+    assert label.cget("bg") == "#ff00ff"
+    assert label.cget("fg") == THEMES["Gothic"]["text"]
+
+
+def test_retheme_skips_ttk_widgets_without_error(root) -> None:
+    set_palette("Dark")
+    button = ttk.Button(root, text="ok")
+    entry = ttk.Entry(root)
+
+    previous = set_palette("Light")
+    retheme_widgets(root, previous)
+
+    # No exception, and the style (not an instance override) drives the color.
+    assert button.cget("style") == ""
+    assert entry.winfo_exists()
+
+
+# ----- the title-bar picker ---------------------------------------------------
+
+
+@pytest.fixture(autouse=True)
+def _data_root(monkeypatch, tmp_path: Path):
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+
+
+def _stub_window(root, db=None):
+    """MainWindow's theme methods over stub state.
+
+    Constructing a real MainWindow opens the camera and probes serial ports,
+    which no test should do; borrowing the methods (as test_updater_ui does)
+    exercises the shipped implementations rather than a copy of them.
+    """
+    pytest.importorskip("cv2")
+    from sorter.ui.app import HEADER_HEIGHT, MainWindow
+
+    class _StubWindow:
+        _load_saved_theme = MainWindow._load_saved_theme
+        _save_theme = MainWindow._save_theme
+        _on_theme_selected = MainWindow._on_theme_selected
+        _place_theme_picker = MainWindow._place_theme_picker
+        _refresh_status_indicators = MainWindow._refresh_status_indicators
+        _repaint_header = MainWindow._repaint_header
+        set_theme = MainWindow.set_theme
+
+        def __init__(self) -> None:
+            self.root = root
+            self.db = db
+            self.status = ""
+            self.fonts = apply_theme(root, theme=self._load_saved_theme())
+            self.theme_name = current_theme()
+            self.theme_var = tk.StringVar(value=self.theme_name)
+            self.header_canvas = tk.Canvas(root, height=HEADER_HEIGHT)
+            self.header_canvas.pack(fill=tk.X)
+            self.theme_combo = ttk.Combobox(
+                self.header_canvas, textvariable=self.theme_var,
+                values=theme_names(), state="readonly", style="Header.TCombobox",
+            )
+            self._theme_window = self.header_canvas.create_window(
+                0, HEADER_HEIGHT // 2, anchor=tk.E, window=self.theme_combo,
+            )
+            self._camera_connected = False
+            self._serial_connected = True
+            self.camera_dot = tk.Label(
+                root, text="●", bg=PALETTE["bg_window"], fg=PALETTE["error"],
+            )
+            self.serial_dot = tk.Label(
+                root, text="●", bg=PALETTE["bg_window"], fg=PALETTE["success"],
+            )
+
+        def set_status(self, message: str) -> None:
+            self.status = message
+
+    return _StubWindow()
+
+
+def test_picker_offers_every_theme(root) -> None:
+    win = _stub_window(root)
+
+    assert list(win.theme_combo.cget("values")) == theme_names()
+    assert win.theme_var.get() == DEFAULT_THEME
+
+
+def test_selecting_a_theme_applies_it(root) -> None:
+    win = _stub_window(root)
+    panel = tk.Frame(root, bg=PALETTE["bg_card"])
+
+    win.theme_var.set("Midnight Blue")
+    win._on_theme_selected()
+
+    assert current_theme() == "Midnight Blue"
+    assert win.theme_name == "Midnight Blue"
+    assert panel.cget("bg") == THEMES["Midnight Blue"]["bg_card"]
+    assert ttk.Style(root).lookup("TFrame", "background") == (
+        THEMES["Midnight Blue"]["bg_surface"]
+    )
+
+
+def test_status_dots_keep_their_meaning_across_a_switch(root) -> None:
+    win = _stub_window(root)
+
+    win.set_theme("Light")
+
+    assert win.camera_dot.cget("fg") == THEMES["Light"]["error"]      # disconnected
+    assert win.serial_dot.cget("fg") == THEMES["Light"]["success"]    # connected
+    assert win.camera_dot.cget("bg") == THEMES["Light"]["bg_window"]
+
+
+def test_theme_choice_round_trips_through_settings(root) -> None:
+    pytest.importorskip("cv2")
+    from sorter.db import Database
+    from sorter.repository import SettingsRepo
+    from sorter.ui.theme import SETTING_THEME
+
+    db = Database()
+    db.ensure_initialized()
+    try:
+        win = _stub_window(root, db)
+        win.set_theme("Gothic")
+        assert SettingsRepo(db).get(SETTING_THEME) == "Gothic"
+
+        # A later launch starts on the stored theme.
+        set_palette(DEFAULT_THEME)
+        restored = _stub_window(root, db)
+        assert restored.theme_name == "Gothic"
+        assert current_theme() == "Gothic"
+    finally:
+        db.close()
+
+
+def test_theme_applies_even_without_a_database(root) -> None:
+    win = _stub_window(root, db=None)
+
+    win.set_theme("Sepia")
+
+    assert current_theme() == "Sepia"

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -20,14 +20,19 @@ from sorter.ui import theme  # noqa: E402
 from sorter.ui.theme import (  # noqa: E402
     DEFAULT_THEME,
     HALFTONE_INK,
+    INK_OUTLINE,
     PALETTE,
     THEMES,
     apply_theme,
     current_theme,
     halftone_ink,
+    ink_outline,
     paint_halftone,
+    register_halftone,
+    repaint_halftone_fields,
     resolve_theme,
     retheme_widgets,
+    row_style,
     set_palette,
     theme_names,
 )
@@ -246,13 +251,13 @@ def test_painting_dots_replaces_the_previous_field(painted_canvas) -> None:
 def test_dots_shrink_toward_the_fade_and_stop(painted_canvas) -> None:
     canvas = painted_canvas
 
-    paint_halftone(canvas, color="#123a86", fade_end=0.5)
+    paint_halftone(canvas, color="#123a86", fade_span=200)
     widths = {}
     for item in canvas.find_withtag("halftone"):
         x1, _y1, x2, _y2 = canvas.coords(item)
         widths[round(x1)] = x2 - x1
 
-    assert max(widths) < 400 * 0.5      # nothing past the fade
+    assert max(widths) < 200            # nothing past the fade
     left, right = min(widths), max(widths)
     assert widths[left] > widths[right]  # the screen thins out rightwards
 
@@ -264,6 +269,70 @@ def test_no_ink_means_no_dots(painted_canvas) -> None:
     paint_halftone(canvas, color=None)
 
     assert canvas.find_withtag("halftone") == ()
+
+
+def test_registered_backdrops_repaint_on_a_theme_switch(painted_canvas) -> None:
+    calls = []
+    register_halftone(painted_canvas, lambda: calls.append(current_theme()))
+
+    set_palette("Comic Book")
+    repaint_halftone_fields(painted_canvas.master)
+
+    assert calls == ["Comic Book"]
+
+
+def test_a_failed_repaint_does_not_stop_the_walk(root) -> None:
+    # A dialog can be torn down between the switch and the walk.
+    dead = tk.Canvas(root)
+    register_halftone(dead, lambda: (_ for _ in ()).throw(tk.TclError("gone")))
+    survivor = tk.Canvas(root)
+    calls = []
+    register_halftone(survivor, lambda: calls.append(1))
+
+    repaint_halftone_fields(root)
+
+    assert calls == [1]
+
+
+# ----- ink outlines -----------------------------------------------------------
+
+
+def test_ink_outline_is_opt_in_per_theme() -> None:
+    assert set(INK_OUTLINE) <= set(THEMES)
+
+    set_palette("Comic Book")
+    assert ink_outline() == INK_OUTLINE["Comic Book"] > 0
+
+    set_palette("Dark")
+    assert ink_outline() == 0
+
+
+def test_outlined_theme_draws_cards_in_ink(root) -> None:
+    apply_theme(root, theme="Comic Book")
+    style = ttk.Style(root)
+
+    assert int(style.lookup("Card.TFrame", "borderwidth")) == INK_OUTLINE["Comic Book"]
+    assert style.lookup("Card.TFrame", "bordercolor") == THEMES["Comic Book"]["border"]
+
+
+def test_flat_theme_keeps_its_borderless_cards(root) -> None:
+    apply_theme(root, theme="Dark")
+    style = ttk.Style(root)
+
+    assert int(style.lookup("Card.TFrame", "borderwidth") or 0) == 0
+
+
+@pytest.mark.parametrize("card", ["Card.TFrame", "CardHover.TFrame", "CardSel.TFrame"])
+def test_card_rows_share_the_fill_but_never_the_outline(root, card: str) -> None:
+    # Layout rows inside a card are restyled to the row variant, so only the
+    # card itself draws a box.
+    apply_theme(root, theme="Comic Book")
+    style = ttk.Style(root)
+    row = row_style(card)
+
+    assert row != card
+    assert style.lookup(row, "background") == style.lookup(card, "background")
+    assert int(style.lookup(row, "borderwidth") or 0) == 0
 
 
 # ----- the title-bar picker ---------------------------------------------------
@@ -285,6 +354,7 @@ def _stub_window(root, db=None):
     from sorter.ui.app import HEADER_HEIGHT, MainWindow
 
     class _StubWindow:
+        _layout_page = MainWindow._layout_page
         _load_saved_theme = MainWindow._load_saved_theme
         _save_theme = MainWindow._save_theme
         _on_theme_selected = MainWindow._on_theme_selected
@@ -302,6 +372,12 @@ def _stub_window(root, db=None):
             self.theme_var = tk.StringVar(value=self.theme_name)
             self.header_canvas = tk.Canvas(root, height=HEADER_HEIGHT)
             self.header_canvas.pack(fill=tk.X)
+            self.page = tk.Canvas(root, height=120)
+            self.page.pack(fill=tk.BOTH, expand=True)
+            self._notebook_window = self.page.create_window(
+                0, 0, window=ttk.Frame(self.page), anchor=tk.NW,
+            )
+            self._page_size = (0, 0)
             self.theme_combo = ttk.Combobox(
                 self.header_canvas, textvariable=self.theme_var,
                 values=theme_names(), state="readonly", style="Header.TCombobox",

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -28,8 +28,6 @@ from sorter.ui.theme import (  # noqa: E402
     halftone_ink,
     ink_outline,
     paint_halftone,
-    register_halftone,
-    repaint_halftone_fields,
     resolve_theme,
     retheme_widgets,
     row_style,
@@ -269,29 +267,6 @@ def test_no_ink_means_no_dots(painted_canvas) -> None:
     paint_halftone(canvas, color=None)
 
     assert canvas.find_withtag("halftone") == ()
-
-
-def test_registered_backdrops_repaint_on_a_theme_switch(painted_canvas) -> None:
-    calls = []
-    register_halftone(painted_canvas, lambda: calls.append(current_theme()))
-
-    set_palette("Comic Book")
-    repaint_halftone_fields(painted_canvas.master)
-
-    assert calls == ["Comic Book"]
-
-
-def test_a_failed_repaint_does_not_stop_the_walk(root) -> None:
-    # A dialog can be torn down between the switch and the walk.
-    dead = tk.Canvas(root)
-    register_halftone(dead, lambda: (_ for _ in ()).throw(tk.TclError("gone")))
-    survivor = tk.Canvas(root)
-    calls = []
-    register_halftone(survivor, lambda: calls.append(1))
-
-    repaint_halftone_fields(root)
-
-    assert calls == [1]
 
 
 # ----- ink outlines -----------------------------------------------------------

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -19,6 +19,7 @@ from tkinter import ttk  # noqa: E402
 from sorter.ui import theme  # noqa: E402
 from sorter.ui.theme import (  # noqa: E402
     DEFAULT_THEME,
+    SETTING_THEME,
     HALFTONE_INK,
     INK_OUTLINE,
     PALETTE,
@@ -330,8 +331,8 @@ def _stub_window(root, db=None):
 
     class _StubWindow:
         _layout_page = MainWindow._layout_page
-        _load_saved_theme = MainWindow._load_saved_theme
-        _save_theme = MainWindow._save_theme
+        _load_setting = MainWindow._load_setting
+        _save_setting = MainWindow._save_setting
         _on_theme_selected = MainWindow._on_theme_selected
         _place_theme_picker = MainWindow._place_theme_picker
         _refresh_status_indicators = MainWindow._refresh_status_indicators
@@ -342,7 +343,7 @@ def _stub_window(root, db=None):
             self.root = root
             self.db = db
             self.status = ""
-            self.fonts = apply_theme(root, theme=self._load_saved_theme())
+            self.fonts = apply_theme(root, theme=self._load_setting(SETTING_THEME))
             self.theme_name = current_theme()
             self.theme_var = tk.StringVar(value=self.theme_name)
             self.header_canvas = tk.Canvas(root, height=HEADER_HEIGHT)
@@ -359,6 +360,10 @@ def _stub_window(root, db=None):
             )
             self._theme_window = self.header_canvas.create_window(
                 0, HEADER_HEIGHT // 2, anchor=tk.E, window=self.theme_combo,
+            )
+            self.theme_new_button = ttk.Button(self.header_canvas, text="+", width=2)
+            self._theme_new_window = self.header_canvas.create_window(
+                0, HEADER_HEIGHT // 2, anchor=tk.E, window=self.theme_new_button,
             )
             self._camera_connected = False
             self._serial_connected = True
@@ -411,7 +416,6 @@ def test_theme_choice_round_trips_through_settings(root) -> None:
     pytest.importorskip("cv2")
     from sorter.db import Database
     from sorter.repository import SettingsRepo
-    from sorter.ui.theme import SETTING_THEME
 
     db = Database()
     db.ensure_initialized()

--- a/tests/test_theme.py
+++ b/tests/test_theme.py
@@ -19,10 +19,13 @@ from tkinter import ttk  # noqa: E402
 from sorter.ui import theme  # noqa: E402
 from sorter.ui.theme import (  # noqa: E402
     DEFAULT_THEME,
+    HALFTONE_INK,
     PALETTE,
     THEMES,
     apply_theme,
     current_theme,
+    halftone_ink,
+    paint_halftone,
     resolve_theme,
     retheme_widgets,
     set_palette,
@@ -199,6 +202,68 @@ def test_retheme_skips_ttk_widgets_without_error(root) -> None:
     # No exception, and the style (not an instance override) drives the color.
     assert button.cget("style") == ""
     assert entry.winfo_exists()
+
+
+# ----- the halftone field -----------------------------------------------------
+
+
+@pytest.fixture
+def painted_canvas(root):
+    """A canvas with a real, mapped size.
+
+    The paint helpers bail out on a widget Tk hasn't laid out yet (it reports
+    a width of 1), which is why the window has to come up for these.
+    """
+    root.deiconify()
+    canvas = tk.Canvas(root, width=400, height=36, highlightthickness=0)
+    canvas.pack()
+    root.update()
+    yield canvas
+    root.withdraw()
+
+
+def test_halftone_is_opt_in_per_theme() -> None:
+    assert set(HALFTONE_INK) <= set(THEMES)
+
+    set_palette("Comic Book")
+    assert halftone_ink() == HALFTONE_INK["Comic Book"]
+
+    set_palette("Dark")
+    assert halftone_ink() is None
+
+
+def test_painting_dots_replaces_the_previous_field(painted_canvas) -> None:
+    canvas = painted_canvas
+
+    paint_halftone(canvas, color="#123a86")
+    first = canvas.find_withtag("halftone")
+    assert len(first) > 20
+
+    paint_halftone(canvas, color="#123a86")
+    assert len(canvas.find_withtag("halftone")) == len(first)
+
+
+def test_dots_shrink_toward_the_fade_and_stop(painted_canvas) -> None:
+    canvas = painted_canvas
+
+    paint_halftone(canvas, color="#123a86", fade_end=0.5)
+    widths = {}
+    for item in canvas.find_withtag("halftone"):
+        x1, _y1, x2, _y2 = canvas.coords(item)
+        widths[round(x1)] = x2 - x1
+
+    assert max(widths) < 400 * 0.5      # nothing past the fade
+    left, right = min(widths), max(widths)
+    assert widths[left] > widths[right]  # the screen thins out rightwards
+
+
+def test_no_ink_means_no_dots(painted_canvas) -> None:
+    canvas = painted_canvas
+    paint_halftone(canvas, color="#123a86")
+
+    paint_halftone(canvas, color=None)
+
+    assert canvas.find_withtag("halftone") == ()
 
 
 # ----- the title-bar picker ---------------------------------------------------

--- a/tests/test_theme_editor.py
+++ b/tests/test_theme_editor.py
@@ -22,6 +22,7 @@ from sorter.ui.theme import (  # noqa: E402
     DEFAULT_THEME,
     HALFTONE_INK,
     INK_OUTLINE,
+    MAX_THEME_NAME,
     THEMES,
     custom_theme_payload,
     custom_themes_payload,
@@ -30,6 +31,7 @@ from sorter.ui.theme import (  # noqa: E402
     load_custom_themes,
     normalize_palette,
     register_custom_theme,
+    rename_custom_theme,
     resolve_theme,
     set_palette,
     theme_names,
@@ -129,6 +131,47 @@ def test_a_deleted_theme_falls_back_to_the_default_when_selected() -> None:
     set_palette("Doomed")
 
     assert theme.current_theme() == DEFAULT_THEME
+
+
+def test_renaming_moves_a_theme_rather_than_copying_it() -> None:
+    register_custom_theme(
+        "Mine", _palette(action="#123456"), halftone="#101010", outline=2,
+        base="Gothic",
+    )
+
+    rename_custom_theme("Mine", "Yours")
+
+    assert "Mine" not in theme_names()
+    assert THEMES["Yours"]["action"] == "#123456"
+    assert HALFTONE_INK["Yours"] == "#101010"        # options came along
+    assert "Mine" not in HALFTONE_INK
+    assert custom_theme_payload("Yours")["based_on"] == "Gothic"
+
+
+def test_a_rejected_rename_leaves_the_original_alone() -> None:
+    register_custom_theme("Mine", _palette(action="#123456"))
+
+    with pytest.raises(ValueError):
+        rename_custom_theme("Mine", "Dark")             # a built-in
+    with pytest.raises(ValueError):
+        rename_custom_theme("Mine", "x" * (MAX_THEME_NAME + 1))
+    with pytest.raises(ValueError):
+        rename_custom_theme("Sepia", "Mine")            # not renameable
+
+    assert THEMES["Mine"]["action"] == "#123456"
+    assert THEMES["Dark"] == BUILTIN_THEMES["Dark"]
+
+
+def test_names_are_capped_to_fit_the_picker() -> None:
+    long_name = "A very long theme name"
+
+    assert len(unique_theme_name(long_name)) <= MAX_THEME_NAME
+    with pytest.raises(ValueError):
+        register_custom_theme(long_name, _palette())
+
+    register_custom_theme(unique_theme_name(long_name), _palette())
+    # …and a collision-avoiding suffix still fits.
+    assert len(unique_theme_name(long_name)) <= MAX_THEME_NAME
 
 
 def test_unique_theme_name_avoids_collisions() -> None:
@@ -271,7 +314,7 @@ def test_editor_starts_as_a_copy_of_the_active_theme(root) -> None:
 
     assert dlg.base == "Gothic"
     assert dlg.editing is False
-    assert dlg.name_var.get() == "Gothic copy"
+    assert dlg.name_var.get() == "My theme"
     assert dlg.values == THEMES["Gothic"]
 
 
@@ -338,6 +381,66 @@ def test_editing_a_custom_theme_offers_delete(root) -> None:
     assert "Mine" not in theme_names()
     assert app.theme_name == "Sepia"         # falls back to what it was made from
     assert app.saved == {}
+
+
+def test_renaming_in_the_editor_updates_the_theme_in_place(root) -> None:
+    register_custom_theme("Mine", _palette(action="#123456"), base="Sepia")
+    set_palette("Mine")
+    app = _StubApp()
+    dlg = _editor(root, app)
+
+    dlg.name_var.set("Renamed")
+    dlg._save()
+
+    assert "Mine" not in theme_names()
+    assert THEMES["Renamed"]["action"] == "#123456"
+    assert app.theme_name == "Renamed"
+    assert list(app.saved or {}) == ["Renamed"]
+
+
+def test_create_new_keeps_the_theme_it_started_from(root, monkeypatch) -> None:
+    register_custom_theme("Mine", _palette(action="#123456"), base="Sepia")
+    set_palette("Mine")
+    app = _StubApp()
+    dlg = _editor(root, app)
+    monkeypatch.setattr(type(dlg), "_prompt_name", lambda _self: "Second")
+
+    dlg._set_color("action", "#abcdef")
+    dlg._create_new()
+
+    assert THEMES["Mine"]["action"] == "#123456"      # untouched
+    assert THEMES["Second"]["action"] == "#abcdef"
+    assert app.theme_name == "Second"
+
+
+def test_create_new_backing_out_changes_nothing(root, monkeypatch) -> None:
+    app = _StubApp()
+    dlg = _editor(root, app)
+    monkeypatch.setattr(type(dlg), "_prompt_name", lambda _self: None)
+
+    dlg._create_new()
+
+    assert app.saved is None
+    assert custom_themes_payload() == {}
+
+
+def test_editor_refuses_an_over_long_name(root, monkeypatch) -> None:
+    from sorter.ui import dialog_theme_editor as mod
+
+    warned: list[str] = []
+    monkeypatch.setattr(
+        mod.messagebox, "showwarning", lambda *a, **k: warned.append(a[0]),
+    )
+    app = _StubApp()
+    dlg = _editor(root, app)
+    # The entry blocks typing past the limit; the check is the backstop.
+    assert mod._within_limit("x" * MAX_THEME_NAME) is True
+    assert mod._within_limit("x" * (MAX_THEME_NAME + 1)) is False
+
+    dlg.name_var.set("x" * (MAX_THEME_NAME + 1))
+    dlg._save()
+
+    assert warned and app.saved is None
 
 
 def test_typed_hex_updates_the_working_palette(root) -> None:

--- a/tests/test_theme_editor.py
+++ b/tests/test_theme_editor.py
@@ -1,0 +1,392 @@
+"""User-made themes: the registry, and the editor dialog that writes them.
+
+The registry half only needs tkinter to import; the dialog half needs a real
+display (xvfb in practice), matching the other UI tests.
+"""
+from __future__ import annotations
+
+import gc
+import json
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tkinter")
+
+import tkinter as tk  # noqa: E402
+
+from sorter.ui import theme  # noqa: E402
+from sorter.ui.theme import (  # noqa: E402
+    BUILTIN_THEMES,
+    CUSTOM_THEME_VERSION,
+    DEFAULT_THEME,
+    HALFTONE_INK,
+    INK_OUTLINE,
+    THEMES,
+    custom_theme_payload,
+    custom_themes_payload,
+    editable_roles,
+    is_custom_theme,
+    load_custom_themes,
+    normalize_palette,
+    register_custom_theme,
+    resolve_theme,
+    set_palette,
+    theme_names,
+    unique_theme_name,
+    unregister_custom_theme,
+)
+
+
+def _palette(**overrides: str) -> dict[str, str]:
+    return normalize_palette(overrides, BUILTIN_THEMES["Dark"])
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry():
+    """Custom themes are module state — no test may leak one into the next."""
+    original = custom_themes_payload()
+    started_on = theme.current_theme()
+    yield
+    load_custom_themes(original)
+    set_palette(started_on)
+
+
+# ----- the registry -----------------------------------------------------------
+
+
+def test_a_registered_theme_becomes_selectable() -> None:
+    register_custom_theme("Mine", _palette(action="#123456"))
+
+    assert is_custom_theme("Mine")
+    assert "Mine" in theme_names()
+    assert THEMES["Mine"]["action"] == "#123456"
+    assert resolve_theme("mine") == "Mine"
+
+    set_palette("Mine")
+    assert theme.PALETTE["action"] == "#123456"
+
+
+def test_registering_carries_the_halftone_and_outline_options() -> None:
+    register_custom_theme(
+        "Inky", _palette(), halftone="#101010", outline=2, base="Comic Book",
+    )
+    set_palette("Inky")
+
+    assert HALFTONE_INK["Inky"] == "#101010"
+    assert INK_OUTLINE["Inky"] == 2
+    assert theme.halftone_ink() == "#101010"
+    assert theme.ink_outline() == 2
+
+
+def test_options_left_off_are_not_registered() -> None:
+    register_custom_theme("Plain", _palette(), halftone=None, outline=0)
+    set_palette("Plain")
+
+    assert "Plain" not in HALFTONE_INK
+    assert "Plain" not in INK_OUTLINE
+    assert theme.halftone_ink() is None
+    assert theme.ink_outline() == 0
+
+
+def test_saving_over_a_theme_replaces_it() -> None:
+    register_custom_theme("Mine", _palette(action="#111111"))
+    register_custom_theme("Mine", _palette(action="#222222"), halftone="#333333")
+
+    assert theme_names().count("Mine") == 1
+    assert THEMES["Mine"]["action"] == "#222222"
+    assert HALFTONE_INK["Mine"] == "#333333"
+
+
+def test_built_in_names_are_protected() -> None:
+    with pytest.raises(ValueError):
+        register_custom_theme("Dark", _palette())
+    with pytest.raises(ValueError):
+        register_custom_theme("   ", _palette())
+
+    assert THEMES["Dark"] == BUILTIN_THEMES["Dark"]
+
+
+def test_unregistering_removes_every_trace() -> None:
+    register_custom_theme("Gone", _palette(), halftone="#101010", outline=2)
+
+    unregister_custom_theme("Gone")
+
+    assert "Gone" not in theme_names()
+    assert "Gone" not in HALFTONE_INK
+    assert "Gone" not in INK_OUTLINE
+    assert not is_custom_theme("Gone")
+    # A built-in handed to the same call is left alone.
+    unregister_custom_theme("Dark")
+    assert "Dark" in theme_names()
+
+
+def test_a_deleted_theme_falls_back_to_the_default_when_selected() -> None:
+    register_custom_theme("Doomed", _palette())
+    set_palette("Doomed")
+
+    unregister_custom_theme("Doomed")
+    set_palette("Doomed")
+
+    assert theme.current_theme() == DEFAULT_THEME
+
+
+def test_unique_theme_name_avoids_collisions() -> None:
+    assert unique_theme_name("Dark") != "Dark"
+    register_custom_theme("Mine", _palette())
+    assert unique_theme_name("Mine") == "Mine (2)"
+    assert unique_theme_name("") == "My theme"
+
+
+# ----- normalizing what a user (or a file) supplies ---------------------------
+
+
+def test_normalize_fills_gaps_and_drops_junk() -> None:
+    palette = normalize_palette(
+        {"action": "#ABCDEF", "nonsense": "#000000", "text": 42, "border": "red"},
+        BUILTIN_THEMES["Light"],
+    )
+
+    assert set(palette) == set(BUILTIN_THEMES["Dark"])
+    assert palette["action"] == "#abcdef"            # accepted, lowercased
+    assert "nonsense" not in palette                 # unknown role dropped
+    assert palette["text"] == BUILTIN_THEMES["Light"]["text"]      # wrong type
+    assert palette["border"] == BUILTIN_THEMES["Light"]["border"]  # not a hex
+
+
+def test_normalize_keeps_the_derived_roles_in_step() -> None:
+    palette = normalize_palette({"action": "#0f0f0f", "success": "#ff0000"})
+
+    # `retheme_widgets` resolves a colour to one role, so these must not drift.
+    assert palette["success"] == palette["action"] == "#0f0f0f"
+    assert palette["error"] == palette["danger"]
+
+
+def test_editable_roles_exclude_the_derived_ones() -> None:
+    roles = editable_roles()
+
+    assert "success" not in roles and "error" not in roles
+    assert set(roles) | set(theme.DERIVED_ROLES) == set(BUILTIN_THEMES["Dark"])
+
+
+# ----- persistence ------------------------------------------------------------
+
+
+def test_themes_round_trip_through_the_settings_payload() -> None:
+    register_custom_theme(
+        "Mine", _palette(action="#123456"), halftone="#101010", outline=2,
+        base="Gothic",
+    )
+    stored = custom_themes_payload()
+
+    load_custom_themes(json.loads(json.dumps(stored)))  # survives a JSON trip
+
+    assert custom_theme_payload("Mine") == stored["Mine"]
+    assert THEMES["Mine"]["action"] == "#123456"
+    assert HALFTONE_INK["Mine"] == "#101010"
+    assert stored["Mine"]["based_on"] == "Gothic"
+
+
+def test_loading_replaces_the_previous_set() -> None:
+    register_custom_theme("Old", _palette())
+
+    load_custom_themes({"New": {"name": "New", "palette": _palette()}})
+
+    assert "Old" not in theme_names()
+    assert "New" in theme_names()
+
+
+def test_a_corrupt_settings_row_never_stops_startup() -> None:
+    loaded = load_custom_themes({
+        "Fine": {"name": "Fine", "palette": _palette(action="#010203")},
+        "NotADict": "nonsense",
+        "NoPalette": {"name": "NoPalette"},
+        "Builtin": {"name": "Dark", "palette": _palette()},
+    })
+
+    assert loaded == ["Fine", "NoPalette"]      # the readable ones
+    assert THEMES["Fine"]["action"] == "#010203"
+    assert THEMES["NoPalette"] == BUILTIN_THEMES["Dark"]   # gaps filled in
+    assert THEMES["Dark"] == BUILTIN_THEMES["Dark"]        # untouched
+
+    assert load_custom_themes(None) == []
+    assert load_custom_themes("junk") == []
+
+
+# ----- the editor dialog ------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def _tk_root():
+    try:
+        r = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no Tk display: {exc}")
+    r.withdraw()
+    yield r
+    gc.collect()
+    r.destroy()
+
+
+@pytest.fixture
+def root(_tk_root):
+    from sorter.ui.theme import apply_theme
+
+    apply_theme(_tk_root, theme=DEFAULT_THEME)
+    yield _tk_root
+    for child in _tk_root.winfo_children():
+        child.destroy()
+
+
+class _StubApp:
+    """The slice of MainWindow the editor talks to."""
+
+    def __init__(self) -> None:
+        self.theme_name = theme.current_theme()
+        self.saved: dict | None = None
+        self.refreshed = 0
+
+    def set_theme(self, name: str) -> None:
+        self.theme_name = theme.resolve_theme(name)
+        set_palette(self.theme_name)
+
+    def save_custom_themes(self) -> None:
+        self.saved = custom_themes_payload()
+
+    def refresh_theme_picker(self) -> None:
+        self.refreshed += 1
+
+
+def _editor(root, app):
+    from sorter.ui.dialog_theme_editor import ThemeEditorDialog
+
+    dlg = ThemeEditorDialog(root, app=app)
+    root.update_idletasks()
+    return dlg
+
+
+def test_editor_starts_as_a_copy_of_the_active_theme(root) -> None:
+    set_palette("Gothic")
+    dlg = _editor(root, _StubApp())
+
+    assert dlg.base == "Gothic"
+    assert dlg.editing is False
+    assert dlg.name_var.get() == "Gothic copy"
+    assert dlg.values == THEMES["Gothic"]
+
+
+def test_saving_registers_applies_and_persists(root) -> None:
+    set_palette("Dark")
+    app = _StubApp()
+    dlg = _editor(root, app)
+    dlg.name_var.set("Mine")
+    dlg._set_color("action", "#ABCDEF")
+
+    dlg._save()
+
+    assert THEMES["Mine"]["action"] == "#abcdef"
+    assert app.theme_name == "Mine"          # applied
+    assert "Mine" in (app.saved or {})       # persisted
+    assert app.refreshed == 1                # picker re-read
+    assert theme.PALETTE["action"] == "#abcdef"
+
+
+def test_saving_without_a_name_is_refused(root, monkeypatch) -> None:
+    from sorter.ui import dialog_theme_editor as mod
+
+    warned: list[str] = []
+    monkeypatch.setattr(
+        mod.messagebox, "showwarning", lambda *a, **k: warned.append(a[0]),
+    )
+    app = _StubApp()
+    dlg = _editor(root, app)
+    dlg.name_var.set("   ")
+
+    dlg._save()
+
+    assert warned and app.saved is None
+    assert dlg.winfo_exists()                # dialog stays open to be fixed
+
+
+def test_a_built_in_name_is_refused(root, monkeypatch) -> None:
+    from sorter.ui import dialog_theme_editor as mod
+
+    warned: list[str] = []
+    monkeypatch.setattr(
+        mod.messagebox, "showwarning", lambda *a, **k: warned.append(a[0]),
+    )
+    dlg = _editor(root, _StubApp())
+    dlg.name_var.set("Sepia")
+
+    dlg._save()
+
+    assert warned
+    assert THEMES["Sepia"] == BUILTIN_THEMES["Sepia"]
+
+
+def test_editing_a_custom_theme_offers_delete(root) -> None:
+    register_custom_theme("Mine", _palette(), base="Sepia")
+    set_palette("Mine")
+    app = _StubApp()
+    dlg = _editor(root, app)
+
+    assert dlg.editing is True
+    assert dlg.name_var.get() == "Mine"
+
+    dlg._delete_confirmed()
+
+    assert "Mine" not in theme_names()
+    assert app.theme_name == "Sepia"         # falls back to what it was made from
+    assert app.saved == {}
+
+
+def test_typed_hex_updates_the_working_palette(root) -> None:
+    dlg = _editor(root, _StubApp())
+
+    dlg._hex_vars["accent"].set("#ff8800")
+    assert dlg.values["accent"] == "#ff8800"
+
+    dlg._hex_vars["accent"].set("#nope!!")   # ignored, not crashed on
+    assert dlg.values["accent"] == "#ff8800"
+
+    dlg._hex_vars["accent"].set("#ff")       # incomplete: wait for the rest
+    assert dlg.values["accent"] == "#ff8800"
+
+
+def test_export_writes_a_file_import_reads_it_back(root, tmp_path: Path) -> None:
+    set_palette("Comic Book")
+    app = _StubApp()
+    dlg = _editor(root, app)
+    dlg.name_var.set("Shared")
+    dlg._set_color("danger", "#001122")
+    path = tmp_path / "shared.json"
+
+    dlg._write_theme_file(path)
+    payload = json.loads(path.read_text(encoding="utf-8"))
+
+    assert payload["name"] == "Shared"
+    assert payload["based_on"] == "Comic Book"
+    assert payload["palette"]["danger"] == "#001122"
+    assert payload["halftone"] == HALFTONE_INK["Comic Book"]
+    assert payload["outline"] == INK_OUTLINE["Comic Book"]
+
+    dlg._read_theme_file(path)
+
+    assert app.theme_name == "Shared"
+    assert THEMES["Shared"]["danger"] == "#001122"
+    # Importing it a second time keeps both rather than clobbering.
+    dlg2 = _editor(root, _StubApp())
+    dlg2._read_theme_file(path)
+    assert "Shared (2)" in theme_names()
+
+
+def test_import_rejects_files_that_are_not_themes(root, tmp_path: Path) -> None:
+    from sorter.ui.dialog_theme_editor import _describe_bad_theme
+
+    assert _describe_bad_theme([1, 2, 3])
+    assert _describe_bad_theme({"name": "x"})                      # no palette
+    assert _describe_bad_theme({"palette": {}, "version": "abc"})   # unreadable
+    assert _describe_bad_theme(
+        {"palette": {}, "version": CUSTOM_THEME_VERSION + 1}
+    )                                                              # from the future
+    assert _describe_bad_theme({"palette": {}}) is None


### PR DESCRIPTION
## Summary

Implements a complete theme system for the UI, replacing the single hardcoded dark palette with 6 built-in themes (Dark, Light, Sepia, Midnight Blue, Gothic, Comic Book) plus support for user-created custom themes. Adds a theme editor dialog accessible from the title bar, and persists theme selection and custom themes to settings.

## Key Changes

**Theme infrastructure (`sorter/ui/theme.py`)**
- Refactored single `PALETTE` dict into named theme palettes (`_DARK`, `_LIGHT`, `_SEPIA`, `_MIDNIGHT_BLUE`, `_GOTHIC`, `_COMIC`)
- Added `BUILTIN_THEMES` registry and live `THEMES` dict (built-ins + user-created)
- Implemented palette switching: `set_palette(name)` mutates the shared `PALETTE` dict in place so all importers see theme changes without rebinding
- Added `apply_theme(root, theme=...)` to select palette and apply ttk styles on startup and theme switches
- Added `retheme_widgets(root, previous)` to repaint classic Tk widgets that baked colors at construction time
- Added `paint_halftone(canvas, ...)` for optional ben-day dot screens (Comic Book theme uses this)
- Introduced theme metadata: `HALFTONE_INK` and `INK_OUTLINE` dicts for per-theme visual options
- Added custom theme registry functions: `register_custom_theme()`, `unregister_custom_theme()`, `rename_custom_theme()`, `load_custom_themes()`, `custom_theme_payload()`
- Added palette normalization and validation: `normalize_palette()`, `editable_roles()`, `is_custom_theme()`

**Theme editor dialog (`sorter/ui/dialog_theme_editor.py`)**
- New `ThemeEditorDialog` for creating/editing themes with live preview
- Color picker per role, organized into logical groups (Surfaces, Lines, Text, Accent, Buttons, Status)
- Options for comic-book ink outlines and halftone dots
- Import/Export theme as JSON file
- Delete, Create new, Save & apply buttons
- Validates theme names (max length, no built-in overwrites, collision avoidance)

**Main window integration (`sorter/ui/app.py`)**
- Added theme picker dropdown in title bar (right edge, floats over gradient)
- Added gear button next to picker to open theme editor
- Loads custom themes from settings on startup
- Persists theme selection to settings
- Calls `retheme_widgets()` on theme switch to update live widgets
- Notebook now hosted on a backdrop canvas to own the margin (allows halftone screen to print behind UI)

**Settings & persistence**
- New settings keys: `ui.theme` (selected theme name), `ui.custom_themes` (user-created themes)
- Custom theme payload includes: name, palette, based_on (source theme), version, optional halftone/outline settings
- Corrupt settings rows are skipped gracefully at startup

**Tests**
- `tests/test_theme.py`: palette invariants (all themes define same keys, valid hex colors, status colors track buttons), palette switching, widget re-theming, halftone rendering
- `tests/test_theme_editor.py`: custom theme registry (register/unregister/rename), normalization, persistence, import/export

## Notable Implementation Details

- **In-place mutation of `PALETTE`**: Modules import `PALETTE` once; switching themes mutates it in place so all importers see the change without needing to re-import. This is critical for the live update to work across the entire UI.
- **Role aliasing**: `success` always equals `action` and `error` always equals `danger` in every theme, so `retheme_widgets()` can unambiguously resolve a color back to a role when re-theming classic Tk widgets.
- **Derived roles**: Some palette keys (like `success`, `error`) are derived from others and excluded from the editor's editable list; `normalize_palette()` keeps them in sync.
- **Comic Book theme**: The only theme with hue in the

https://claude.ai/code/session_01KFx2QJMGQ7pNYRAjHwL93A