### PR TITLE
Gate PyTorch install on actual need; refuse silent HTTP fallback

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -212,13 +212,20 @@ between them from the Run tab's template dropdown.
 ### Classification
 - **`classifier.py`** — `classify_active`: routes to **local inference** when the
   active model has a valid `model_path`, else to the **HTTP API**. Passes the
-  trained `image_size` through.
+  trained `image_size` through. `active_local_model` / `uses_local_inference`
+  expose that routing decision alone, so the UI can ask "does this action need
+  PyTorch?" before starting a run — keep them in lock-step with
+  `classify_active` or the install gate (§5) drifts from reality.
 - **`local_inference.py`** — lazy-imports torch; picks the device once; caches
   loaded models by `(path, mtime)`; runs all inference through a single-threaded
   executor to keep cuDNN state warm. Detects the checkpoint's classifier layout
   and rebuilds the ConvNeXt head. Loads checkpoints with
   `torch.load(..., weights_only=True)` so a malicious `.pth` (community download
-  or imported ZIP) cannot execute code on load.
+  or imported ZIP) cannot execute code on load. Two presence checks, and the
+  difference matters: `is_installed()` is a `find_spec` probe (free, safe on the
+  UI thread) and is what the install gate uses; `is_available()` actually
+  imports torch and on first call runs the device probe + benchmark dump, which
+  would freeze the UI if called from a button handler.
 - **`api_client.py`** — stateless HTTP client (`classify`, `get_headstamps`)
   against an OpenAI-compatible server. JPEG-encodes the frame to a base64 data
   URL, renders the `{{headstamps}}` prompt placeholder, parses `choices[0]...`
@@ -257,6 +264,9 @@ between them from the Run tab's template dropdown.
   detect a compute-capability ≥ 8.0 NVIDIA GPU for the Install-PyTorch dialog.
 - **`image_store.py`** — pure pathlib helpers to list/filter/reclassify/delete
   training images by their `{headstamp}__{ticks}` filenames.
+- **`models.py` ownership helpers** — `is_foreign_model` / `is_trainable` /
+  `FOREIGN_MODEL_TYPES`: the single definition of "this model belongs to
+  someone else" (see §5, *Model ownership*).
 - **`model_io.py`** — model **ZIP** import/export compatible with the WinForms
   format (`manifest.json` + `model/<id>.pth` + `images/*`). Accepts both
   snake_case and WinForms PascalCase manifest keys. Import **rejects `..`
@@ -266,7 +276,8 @@ between them from the Run tab's template dropdown.
   headstamp slots, and sorting templates) instead of creating a duplicate, and
   keeps the local name / feedback-loop opt-in / AI config. `find_update_target`
   tells a caller which path an archive will take; `update_existing=False`
-  forces a separate copy.
+  forces a separate copy. `community_download=True` marks the install as the
+  publisher's, and an update never downgrades that (§5, *Model ownership*).
 
 ### Self-update (see §7 for the full flow)
 - **`updater.py`** — GitHub Releases check, version comparison, and download →
@@ -318,9 +329,46 @@ startup, and runs the bus drain loop. `run_worker(fn, on_done, on_error)` is the
 standard helper for offloading blocking work to a thread and marshaling the
 result back through the bus.
 
-**Tab visibility is mode-driven:** Train shows for a local active model; AI
+**Tab visibility is mode-driven:** Train shows for a local active model **that
+this user owns** (`models.is_trainable` — see *Model ownership* below); AI
 Config shows in AI Config mode; Community is mounted only while signed in. The
 `mode/changed` event re-evaluates this.
+
+### Model ownership
+A model installed from the **Community tab** is stamped `model_type =
+"CommunityManaged"` by `import_model(..., community_download=True)`, and
+`models.is_trainable()` is False for it: the local checkpoint is the
+publisher's, retraining forks it from the version they keep updating, and the
+archive usually ships without the images it was built from. `ReadOnly` (the
+legacy app's marker) is treated the same. `_merge_onto_installed` never lets
+an update downgrade ownership.
+
+**`community_model_uid` is not an ownership signal** — sharing your own model
+stamps a UID onto your local copy, so a UID means "exists in the community",
+not "isn't yours". Ownership is decided by *how the model reached this
+machine*, which is why the flag is a parameter of `import_model` rather than
+something read out of the manifest (a publisher's own copy is `Standard`, and
+that's what they export). A plain ZIP import stays owned — it's just as likely
+to be a user restoring their own model onto a new machine.
+
+### The PyTorch install gate
+PyTorch is the optional `[ml]` extra, so a fresh install has none. **The rule:
+torch is installed the first time something actually needs it, and never
+before** — an AI Config user must never be prompted. `ui/torch_gate.py` is the
+single entry point; it opens `dialog_install_torch` and re-enters the caller on
+success:
+
+```python
+if not ensure_torch(self, self._start, reason="Sorting needs PyTorch"):
+    return
+```
+
+Gated: Run tab Start + Manual feed (only when `classifier.uses_local_inference`
+is True), the evaluator, and training. The Train tab's Feed *offers* rather
+than gates — capturing and labelling images is exactly the workflow that
+doesn't need torch, so declining costs only the predicted-label convenience and
+is remembered for the session. Call it on the **main thread only** (it opens a
+modal), and never gate on `is_available()`.
 
 ### Tabs (`tab_*.py`)
 | Tab | File | Purpose |
@@ -413,6 +461,9 @@ a separate one, so a built-in is never the thing being written to),
   `NumericField`, labeled-entry/button-row helpers.
 - **`monitor.py`** — detachable history window: ring buffer of recent
   classifications with a color "snake" trailing the latest. Subscribes `run/history`.
+- **`torch_gate.py`** — `ensure_torch(parent, proceed, reason=…)`: the only
+  sanctioned way to front a local-model action with the PyTorch install dialog.
+  See *The PyTorch install gate* above.
 - **`sysutil.py`** — `open_path` (os.startfile / open / xdg-open).
 
 ---
@@ -527,7 +578,10 @@ sorter.apply_update          backup → copy over app dir → prune → clear pe
   the legacy Windows app — preserve that compatibility when editing these.
 - **PyTorch is optional and lazily imported.** Guard any torch use; surface a
   friendly "install PyTorch" path rather than letting an `ImportError` escape.
-  Don't add torch to `requirements.txt` (it's the `[ml]` extra).
+  Don't add torch to `requirements.txt` (it's the `[ml]` extra). Any **new**
+  entry point that runs a model locally must go through
+  `ui/torch_gate.ensure_torch` (§5) — a bare `LocalInferenceError` reaching the
+  user is the bug that gate exists to prevent.
 - **DB access is shared across threads** via one connection + RLock. Wrap
   multi-statement work in `db.transaction()` (reentrant via SAVEPOINT).
 - **Headstamps are read fresh, not cached** — don't reintroduce a cached

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -205,17 +205,26 @@ between them from the Run tab's template dropdown.
   → `classifier.classify_active` → `_resolve_destination(label, confidence)` →
   `broker.sort_and_move(slot)`. Handles the 5-position wheel pipeline
   (`_last_classified_slot`), the **confidence floor** (below → catch-all slot 0),
+  a `NoLocalCheckpointError` from `classify_active` (stops the run with the
+  reason; the Run tab also pre-flights this at Start so no case is fed),
   **auto-select trays**, **package/batch mode** (`_package_counts` under a lock),
   optional run-image storage, and feedback capture. Also `cycle_once()` (manual
   feed) and `test_once()` (feed+classify, no sort). Posts `run/*` and `test/*`.
 
 ### Classification
-- **`classifier.py`** — `classify_active`: routes to **local inference** when the
-  active model has a valid `model_path`, else to the **HTTP API**. Passes the
-  trained `image_size` through. `active_local_model` / `uses_local_inference`
-  expose that routing decision alone, so the UI can ask "does this action need
-  PyTorch?" before starting a run — keep them in lock-step with
-  `classify_active` or the install gate (§5) drifts from reality.
+- **`classifier.py`** — `classify_active`: **the active model alone picks the
+  backend.** A model is active → local inference; AI Config mode (no active
+  model) → HTTP. Passes the trained `image_size` through. A local model whose
+  checkpoint is missing raises `NoLocalCheckpointError` — it does **not**
+  degrade to HTTP. That fallback existed and was a trap: a renamed data folder
+  or an images-only community share left `model_path` unusable and the app
+  quietly POSTed case images to whatever the AI Config tab last pointed at,
+  surfacing only as a connection error naming a host the user wasn't knowingly
+  using. Switching backends is the user's call, on the Models tab. `active_model`
+  / `uses_local_inference` / `has_local_checkpoint` / `checkpoint_problem`
+  expose the decision alone, so the UI can ask "does this need PyTorch?" and
+  "can this model actually classify?" before starting a run — keep them in
+  lock-step with `classify_active` or the install gate (§5) drifts from reality.
 - **`local_inference.py`** — lazy-imports torch; picks the device once; caches
   loaded models by `(path, mtime)`; runs all inference through a single-threaded
   executor to keep cuDNN state warm. Detects the checkpoint's classifier layout

--- a/sorter/classifier.py
+++ b/sorter/classifier.py
@@ -4,6 +4,12 @@ Called from `RunController` so the run loop doesn't need to know which backend
 is active. Routing:
   - Active model has a `model_path` pointing to an existing file → local
   - Otherwise → HTTP via `api_client.classify`
+
+`active_local_model` / `uses_local_inference` expose that routing decision on
+its own so the UI can answer "is this action about to need PyTorch?" *before*
+starting a run, without duplicating the rule. Keep them and `classify_active`
+in lock-step — a gate that disagrees with the dispatcher either nags AI Config
+users or lets a run die mid-feed.
 """
 from __future__ import annotations
 
@@ -14,7 +20,38 @@ import numpy as np
 
 from . import api_client, local_inference
 from .db import Database
+from .models import Model
 from .repository import ModelRepo, SettingsRepo
+
+
+def model_uses_local_inference(model: Model | None) -> bool:
+    """True when `model` would be classified by local PyTorch inference."""
+    return bool(
+        model is not None
+        and model.model_path
+        and Path(model.model_path).exists()
+    )
+
+
+def active_local_model(db: Database | None) -> Model | None:
+    """The active model iff it routes to local inference, else None.
+
+    None covers every HTTP case: no database, AI Config mode (no active
+    model), and an active model whose checkpoint is missing or not yet
+    trained.
+    """
+    if db is None:
+        return None
+    active_id = SettingsRepo(db).get_active_model_id()
+    if active_id is None:
+        return None
+    model = ModelRepo(db).get(active_id)
+    return model if model_uses_local_inference(model) else None
+
+
+def uses_local_inference(db: Database | None) -> bool:
+    """True when the next `classify_active` call will need PyTorch."""
+    return active_local_model(db) is not None
 
 
 def classify_active(
@@ -28,24 +65,17 @@ def classify_active(
     Falls back to HTTP if `db` is None (used in tests that don't need
     a database).
     """
-    if db is not None:
-        active_id = SettingsRepo(db).get_active_model_id()
-        if active_id is not None:
-            model = ModelRepo(db).get(active_id)
-            if (
-                model is not None
-                and model.model_path
-                and Path(model.model_path).exists()
-            ):
-                # Pass the trained image size from the model record so
-                # imported community models (often trained at 480) get
-                # the right resolution at inference.
-                image_size = (
-                    int(model.training_config.image_size)
-                    if model.training_config else None
-                )
-                return local_inference.classify(
-                    image_bgr, model.model_path, image_size=image_size,
-                )
+    model = active_local_model(db)
+    if model is not None:
+        # Pass the trained image size from the model record so imported
+        # community models (often trained at 480) get the right resolution
+        # at inference.
+        image_size = (
+            int(model.training_config.image_size)
+            if model.training_config else None
+        )
+        return local_inference.classify(
+            image_bgr, model.model_path, image_size=image_size,
+        )
 
     return api_client.classify(image_bgr, headstamps, api_cfg)

--- a/sorter/classifier.py
+++ b/sorter/classifier.py
@@ -1,15 +1,26 @@
 """Dispatcher: pick local PyTorch inference or HTTP classify based on active model.
 
 Called from `RunController` so the run loop doesn't need to know which backend
-is active. Routing:
-  - Active model has a `model_path` pointing to an existing file → local
-  - Otherwise → HTTP via `api_client.classify`
+is active. **The active model alone decides the backend:**
+  - A model is active → local inference, always
+  - AI Config mode (no active model) → HTTP via `api_client.classify`
 
-`active_local_model` / `uses_local_inference` expose that routing decision on
-its own so the UI can answer "is this action about to need PyTorch?" *before*
-starting a run, without duplicating the rule. Keep them and `classify_active`
-in lock-step — a gate that disagrees with the dispatcher either nags AI Config
-users or lets a run die mid-feed.
+A local model whose checkpoint is missing raises `NoLocalCheckpointError`. It
+does **not** quietly become an HTTP classification. That fallback used to
+exist, and it was a trap: renaming the data folder (or an images-only
+community share) left `model_path` unusable, and the app silently started
+POSTing case images to whatever the AI Config tab last pointed at. If that
+endpoint happened to answer, the user got confident-looking labels from a
+model they never chose; when it didn't, the only symptom was a connection
+error naming a host they weren't knowingly using. Neither is something to
+infer on the user's behalf — the switch is theirs to make on the Models tab.
+Note the AI Config tab is hidden while a local model is active, so its
+endpoint isn't even reachable to configure in that state.
+
+`active_model` / `uses_local_inference` / `has_local_checkpoint` expose the
+routing decision on its own so the UI can answer "is this about to need
+PyTorch?" and "can this model actually classify?" *before* starting a run.
+Keep them in lock-step with `classify_active`.
 """
 from __future__ import annotations
 
@@ -18,14 +29,22 @@ from typing import Any
 
 import numpy as np
 
-from . import api_client, local_inference
+from . import api_client, local_inference, paths
 from .db import Database
 from .models import Model
 from .repository import ModelRepo, SettingsRepo
 
 
-def model_uses_local_inference(model: Model | None) -> bool:
-    """True when `model` would be classified by local PyTorch inference."""
+class NoLocalCheckpointError(Exception):
+    """The active model can't classify: its trained checkpoint is missing.
+
+    Raised instead of silently classifying over HTTP — see the module
+    docstring.
+    """
+
+
+def has_local_checkpoint(model: Model | None) -> bool:
+    """True when `model` has a trained checkpoint present on disk."""
     return bool(
         model is not None
         and model.model_path
@@ -33,25 +52,87 @@ def model_uses_local_inference(model: Model | None) -> bool:
     )
 
 
-def active_local_model(db: Database | None) -> Model | None:
-    """The active model iff it routes to local inference, else None.
+def active_model(db: Database | None) -> Model | None:
+    """The active model, or None for AI Config mode (classify over HTTP).
 
-    None covers every HTTP case: no database, AI Config mode (no active
-    model), and an active model whose checkpoint is missing or not yet
-    trained.
+    None also covers `db is None` (tests that don't need a database) and a
+    `default_model_id` pointing at a row that no longer exists.
     """
     if db is None:
         return None
     active_id = SettingsRepo(db).get_active_model_id()
     if active_id is None:
         return None
-    model = ModelRepo(db).get(active_id)
-    return model if model_uses_local_inference(model) else None
+    return ModelRepo(db).get(active_id)
 
 
 def uses_local_inference(db: Database | None) -> bool:
-    """True when the next `classify_active` call will need PyTorch."""
-    return active_local_model(db) is not None
+    """True when classification will run locally — i.e. will need PyTorch.
+
+    This is "a local model is active", not "a local model can currently
+    classify": a model with a missing checkpoint still routes locally, it
+    just fails loudly. Callers that need to know whether it will actually
+    work should ask `checkpoint_problem` first.
+    """
+    return active_model(db) is not None
+
+
+def checkpoint_problem(db: Database | None) -> str | None:
+    """A user-facing explanation of why the active model can't classify.
+
+    None when there's nothing wrong — AI Config mode, or a local model whose
+    checkpoint is present. The UI uses this to refuse *before* the machine
+    feeds a case; `classify_active` raises the same text as a backstop for a
+    checkpoint that disappears mid-run.
+    """
+    model = active_model(db)
+    if model is None or has_local_checkpoint(model):
+        return None
+    return _checkpoint_detail(model)
+
+
+def _checkpoint_summary(model: Model) -> str:
+    """One-line form, for `NoLocalCheckpointError` and the run status bar.
+
+    `_checkpoint_detail` is the multi-paragraph version the dialogs show;
+    the status bar renders a single line, so it needs its own wording rather
+    than a truncated one.
+    """
+    name = model.name or f"model #{model.id}"
+    if not model.model_path:
+        return (
+            f"“{name}” has no trained model file — train it or re-download it "
+            "before sorting."
+        )
+    return f"“{name}”: trained model file is missing — {model.model_path}"
+
+
+def _checkpoint_detail(model: Model) -> str:
+    name = model.name or f"model #{model.id}"
+    if not model.model_path:
+        detail = (
+            f"“{name}” has no trained model file yet.\n\n"
+            f"Expected it in:\n{paths.model_trained_dir(model.id)}"
+        )
+        hint = (
+            "Train the model on the Train tab, or — if it came from the "
+            "Community tab — re-download it, since an images-only share "
+            "carries no model file."
+        )
+    else:
+        detail = (
+            f"“{name}” points at a trained model file that isn't there:\n\n"
+            f"{model.model_path}"
+        )
+        hint = (
+            "This usually means the data folder was moved or renamed. Put it "
+            "back, re-download the model, or re-train it."
+        )
+    return (
+        f"{detail}\n\n{hint}\n\n"
+        "Sorting is stopped rather than falling back to the AI Config server "
+        "— switch to “Use AI Config” on the Models tab if that's what you want."
+    )
 
 
 def classify_active(
@@ -62,20 +143,23 @@ def classify_active(
 ) -> tuple[str, float]:
     """Classify `image_bgr` using whichever backend the active model selects.
 
-    Falls back to HTTP if `db` is None (used in tests that don't need
-    a database).
+    Raises `NoLocalCheckpointError` when a local model is active but its
+    checkpoint is missing. Uses HTTP only in AI Config mode (which includes
+    `db is None`, for tests that don't need a database).
     """
-    model = active_local_model(db)
-    if model is not None:
-        # Pass the trained image size from the model record so imported
-        # community models (often trained at 480) get the right resolution
-        # at inference.
-        image_size = (
-            int(model.training_config.image_size)
-            if model.training_config else None
-        )
-        return local_inference.classify(
-            image_bgr, model.model_path, image_size=image_size,
-        )
+    model = active_model(db)
+    if model is None:
+        return api_client.classify(image_bgr, headstamps, api_cfg)
 
-    return api_client.classify(image_bgr, headstamps, api_cfg)
+    if not has_local_checkpoint(model):
+        raise NoLocalCheckpointError(_checkpoint_summary(model))
+
+    # Pass the trained image size from the model record so imported community
+    # models (often trained at 480) get the right resolution at inference.
+    image_size = (
+        int(model.training_config.image_size)
+        if model.training_config else None
+    )
+    return local_inference.classify(
+        image_bgr, model.model_path, image_size=image_size,
+    )

--- a/sorter/local_inference.py
+++ b/sorter/local_inference.py
@@ -87,6 +87,12 @@ def _torch():
     """Lazy importer. Raises LocalInferenceError with a friendly message if missing."""
     global _torch_mod, _models_mod, _F_mod, _env_dumped
     if _torch_mod is None:
+        # torch is usually installed by the in-app dialog *while this process
+        # is running*, so the import-system's cached directory listing for
+        # site-packages predates it. Without this the first post-install
+        # import fails and the user is told to install what they just did.
+        import importlib
+        importlib.invalidate_caches()
         try:
             import torch
             from torchvision import models
@@ -501,8 +507,42 @@ def current_device_label() -> str:
     return _device_cache.type if _device_cache is not None else "n/a"
 
 
+def is_installed() -> bool:
+    """Is torch present, *without* importing it?
+
+    This is the check the install gate wants. `is_available()` fully imports
+    torch and, on the first call, probes the device and runs the environment
+    dump's synthetic benchmarks — seconds of work on a CUDA box. That is fine
+    on the inference thread, where it's paid once and the user is already
+    waiting on a classification, but it must never run on a button handler
+    just to decide whether to offer the install: it would freeze the UI every
+    time the user presses Start.
+
+    `find_spec` answers the same question for free. A torch that is present
+    but broken still gets caught downstream by `_torch()`, which raises
+    `LocalInferenceError` as it always has.
+    """
+    import importlib.util
+    # Same rationale as _torch(): a just-installed torch is invisible to a
+    # stale finder cache.
+    importlib.invalidate_caches()
+    try:
+        return (
+            importlib.util.find_spec("torch") is not None
+            and importlib.util.find_spec("torchvision") is not None
+        )
+    except (ImportError, ValueError):
+        # ImportError: a parent package is missing. ValueError: the module is
+        # in sys.modules with a None __spec__. Both mean "not usable".
+        return False
+
+
 def is_available() -> bool:
-    """Cheap check — does importing torch succeed?"""
+    """Does importing torch succeed?
+
+    Imports torch as a side effect — see `is_installed()` for the cheap
+    presence check to use from the UI thread.
+    """
     try:
         _torch()
         return True

--- a/sorter/model_io.py
+++ b/sorter/model_io.py
@@ -42,6 +42,7 @@ from .models import (
     Headstamp,
     ImageProcessingConfig,
     Model,
+    is_foreign_model,
     normalize_upload_mode,
     SUPPORTED_MODEL_MODES,
     TrainingConfig,
@@ -393,6 +394,12 @@ def _merge_onto_installed(incoming: Model, existing: Model, *, name: str) -> Mod
     incoming.id = existing.id
     incoming.name = name
     incoming.ai_model_config = existing.ai_model_config
+    # Ownership never downgrades on update. Without this, re-importing a
+    # community model from a plain ZIP (whose manifest says `Standard`, since
+    # that's what the publisher's own copy is) would quietly hand the user
+    # training rights on someone else's model.
+    if is_foreign_model(existing):
+        incoming.model_type = existing.model_type
     # Overwritten during extraction if the archive ships a checkpoint; keep
     # the installed one so an images-only archive doesn't orphan the model.
     incoming.model_path = existing.model_path
@@ -416,11 +423,19 @@ def import_model(
     images_target_dir: Path | str | None = None,
     models_target_dir: Path | str | None = None,
     update_existing: bool = True,
+    community_download: bool = False,
     progress: Callable[[int, int], None] | None = None,
 ) -> tuple[int, int]:
     """Import a model archive.
 
     Returns (cartridge_id, model_id).
+
+    Pass ``community_download=True`` when the archive came from the Community
+    tab. That marks the installed model `CommunityManaged`, which is what
+    makes it read-only for training — it belongs to whoever published it.
+    The default is False because a plain ZIP import is just as likely to be
+    the user restoring their *own* model onto a new machine, and that model
+    must stay trainable.
 
     An archive that carries a community UID already installed locally is an
     **update of that model**, not a new one: with ``update_existing`` (the
@@ -489,6 +504,13 @@ def import_model(
         model = model_from_export_dict(manifest.get("ModelInfo") or {})
         if model.model_mode not in SUPPORTED_MODEL_MODES:
             model.model_mode = "convnext_tiny"
+
+        # Ownership is decided by how the archive reached this machine, not by
+        # what its manifest claims. A publisher's own copy is `Standard` and
+        # that's what they export, so trusting the manifest would hand every
+        # downloader a trainable model.
+        if community_download:
+            model.model_type = "CommunityManaged"
 
         # Is this archive an update of something already installed?
         existing = (

--- a/sorter/models.py
+++ b/sorter/models.py
@@ -378,3 +378,33 @@ class Model:
             ),
             model_path=row["model_path"],
         )
+
+
+# `model_type` values that mean "this model belongs to someone else". A
+# download from the Community tab is stamped `CommunityManaged` by
+# `model_io.import_model(..., community_download=True)`; `ReadOnly` is the
+# legacy app's equivalent marker and is honoured the same way.
+#
+# NOTE: `community_model_uid` is deliberately NOT part of this test. Sharing
+# your own model stamps a UID onto your local copy (`dialog_share_model`), so
+# a UID means "this model exists in the community", not "this model is not
+# yours". Ownership is decided by how the model arrived on *this* machine.
+FOREIGN_MODEL_TYPES = frozenset({"CommunityManaged", "ReadOnly"})
+
+
+def is_foreign_model(model: "Model | None") -> bool:
+    """True when `model` was installed from the community rather than authored here."""
+    return bool(model is not None and model.model_type in FOREIGN_MODEL_TYPES)
+
+
+def is_trainable(model: "Model | None") -> bool:
+    """Can this model be trained (and have training images added) locally?
+
+    False for community downloads. The local checkpoint is a copy of the
+    publisher's: retraining it forks it away from the version they keep
+    updating, the archive usually ships without the training images the
+    model was built from, and the next published update would overwrite the
+    result anyway. Users who want to build on someone else's model export it
+    and import it back as their own.
+    """
+    return model is not None and not is_foreign_model(model)

--- a/sorter/ui/app.py
+++ b/sorter/ui/app.py
@@ -348,18 +348,21 @@ class MainWindow:
             pass
 
     def _apply_train_tab_visibility(self) -> None:
-        """Show the Train tab when a local model is active; hide in AI Config mode.
+        """Show the Train tab only for a local model this user owns.
 
-        Inverse of `_apply_ai_config_visibility`: AI models can't be trained
-        from this client, so the tab vanishes when the active model is the
-        AI Config sentinel.
+        Two things hide it. AI Config mode, because AI models can't be
+        trained from this client (the inverse of
+        `_apply_ai_config_visibility`). And a community download, because
+        that model belongs to its publisher — see `models.is_trainable`.
         """
         if self.db is None:
             return
-        from ..repository import SettingsRepo
+        from ..models import is_trainable
+        from ..repository import ModelRepo, SettingsRepo
         active_id = SettingsRepo(self.db).get_active_model_id()
+        active = ModelRepo(self.db).get(active_id) if active_id is not None else None
         try:
-            if active_id is None:
+            if active_id is None or not is_trainable(active):
                 self.notebook.hide(self._train_tab_container)
             else:
                 self.notebook.add(self._train_tab_container, text="Train")

--- a/sorter/ui/dialog_install_torch.py
+++ b/sorter/ui/dialog_install_torch.py
@@ -1,14 +1,18 @@
 """Modal that installs PyTorch + torchvision into the active venv.
 
-Training is gated on this so AI-Config-only users never pay the ~2 GB
-torch install cost. On open we detect a supported Nvidia GPU (compute
-capability ≥ 8.0). If one is present, the user gets to pick between
-the GPU build (CUDA 12.8 wheels) and the CPU build; otherwise only
-the CPU build is offered.
+Every local-model action is gated on this — training *and* inference — so
+AI-Config-only users never pay the ~2 GB torch install cost. Callers reach it
+through `torch_gate.ensure_torch` rather than constructing it directly; pass
+`reason` to say which action is asking, since "Training needs PyTorch" is the
+wrong headline when the user just pressed Start on the Run tab.
+
+On open we detect a supported Nvidia GPU (compute capability ≥ 8.0). If one is
+present, the user gets to pick between the GPU build (CUDA 12.8 wheels) and the
+CPU build; otherwise only the CPU build is offered.
 
 `pip install` runs in a subprocess and streams its output to the dialog's
-console. On success the calling tab's `on_success` callback fires and the
-training run proceeds; on cancel/failure the venv is left as-is.
+console. On success the caller's `on_success` callback fires and the gated
+action proceeds; on cancel/failure the venv is left as-is.
 """
 from __future__ import annotations
 
@@ -31,6 +35,10 @@ _TARGETS = ("torch==2.9.1", "torchvision==0.24.1")
 _CPU_TARGETS = _TARGETS
 _CUDA_INDEX = "https://download.pytorch.org/whl/cu128"
 
+# Shown when the caller doesn't name the action. Deliberately generic: this
+# dialog now fronts inference as well as training.
+DEFAULT_REASON = "This model needs PyTorch"
+
 
 class TorchInstallDialog(tk.Toplevel):
     def __init__(
@@ -39,6 +47,7 @@ class TorchInstallDialog(tk.Toplevel):
         *,
         on_success: Callable[[], None] | None = None,
         on_cancel: Callable[[], None] | None = None,
+        reason: str | None = None,
     ) -> None:
         super().__init__(parent)
         self.title("Install PyTorch")
@@ -51,6 +60,7 @@ class TorchInstallDialog(tk.Toplevel):
 
         self._on_success = on_success
         self._on_cancel = on_cancel
+        self._reason = reason or DEFAULT_REASON
         self._proc: subprocess.Popen | None = None
         self._installing = False
         self._gpu: GpuInfo | None = detect_supported_nvidia_gpu()
@@ -70,12 +80,13 @@ class TorchInstallDialog(tk.Toplevel):
     # ----- UI build -----------------------------------------------------------
 
     def _build_header(self, parent: tk.Misc) -> None:
-        ttk.Label(parent, text="Training needs PyTorch",
+        ttk.Label(parent, text=self._reason,
                   style="Header.TLabel").pack(anchor="w")
 
         body = (
-            "Local training and local inference require PyTorch and torchvision. "
-            "The download is large and only happens once."
+            "Running or training a model on this computer requires PyTorch and "
+            "torchvision. The download is large and only happens once. "
+            "(Models classified by an AI Config server don't need it.)"
         )
         ttk.Label(parent, text=body, style="Muted.TLabel",
                   wraplength=660, justify=tk.LEFT).pack(

--- a/sorter/ui/dialog_model_evaluator.py
+++ b/sorter/ui/dialog_model_evaluator.py
@@ -26,6 +26,7 @@ from .. import eval_report, evaluator, paths
 from ..db import Database
 from ..models import Model
 from ..repository import CartridgeRepo, HeadstampRepo, SettingsRepo
+from . import torch_gate
 from .dialog_image_preview import ImagePreviewDialog
 from .theme import PALETTE
 from .widgets import ImagePanel, ScrollableFrame
@@ -372,6 +373,13 @@ class ModelEvaluatorDialog(tk.Toplevel):
             return
         if not evaluator.list_images(folder):
             messagebox.showinfo("No images", "That folder has no images to evaluate.", parent=self)
+            return
+        # Evaluation is inference over a whole folder — offer the install here
+        # rather than letting the worker raise once it's under way. On success
+        # this method re-runs and the evaluation starts.
+        if not torch_gate.ensure_torch(
+            self, self._run, reason="Evaluating needs PyTorch",
+        ):
             return
 
         # Snapshot everything the worker needs on the UI thread — the worker

--- a/sorter/ui/tab_community.py
+++ b/sorter/ui/tab_community.py
@@ -432,8 +432,11 @@ class CommunityTab(ttk.Frame):
                             f"Importing {name}: {pct}% ({step} / {total} files)"
                         )
 
+                # community_download=True marks the install as belonging to
+                # its publisher, which is what keeps the Train tab off it.
                 result = import_model(
-                    zip_path, db=self.db, progress=_import_progress,
+                    zip_path, db=self.db, community_download=True,
+                    progress=_import_progress,
                 )
                 self._record_installed_version(result[1], info)
                 return result

--- a/sorter/ui/tab_models.py
+++ b/sorter/ui/tab_models.py
@@ -27,7 +27,7 @@ from ..config import Config
 from ..db import Database
 from ..events import EventBus
 from ..model_io import ExportMode, export_model, find_update_target, import_model
-from ..models import Headstamp, HeadstampParent, Model
+from ..models import Headstamp, HeadstampParent, Model, is_foreign_model
 from ..repository import (
     CartridgeRepo,
     HeadstampParentRepo,
@@ -313,7 +313,7 @@ class ModelsTab(ttk.Frame):
 
         def match_type(m: Model) -> bool:
             is_community = bool(m.community_model_uid)
-            is_readonly = m.model_type == "ReadOnly"
+            is_readonly = is_foreign_model(m)
             if type_filter == FILTER_TYPE_COMMUNITY:
                 return is_community
             if type_filter == FILTER_TYPE_READONLY:
@@ -335,8 +335,13 @@ class ModelsTab(ttk.Frame):
         return out
 
     def _describe_type(self, m: Model) -> str:
+        # A community *download* can't be trained here (it's the publisher's
+        # model), so say "read-only" — that's the user's only clue as to why
+        # the Train tab disappears when they activate it. A model the user
+        # shared themselves has a UID but is still theirs, and reads
+        # "Community".
         is_community = bool(m.community_model_uid)
-        is_readonly = m.model_type == "ReadOnly"
+        is_readonly = is_foreign_model(m)
         if is_community and is_readonly:
             return "Community (read-only)"
         if is_community:

--- a/sorter/ui/tab_run.py
+++ b/sorter/ui/tab_run.py
@@ -1523,6 +1523,19 @@ class RunTab(ttk.Frame):
         """
         return classifier.uses_local_inference(self.app.db)
 
+    def _model_ready(self) -> bool:
+        """Refuse to start when the active model has no usable checkpoint.
+
+        `classify_active` would raise anyway, but only after the machine has
+        fed and imaged a case. Catching it here keeps the brass in the hopper
+        and puts the explanation in a dialog instead of the status bar.
+        """
+        problem = classifier.checkpoint_problem(self.app.db)
+        if problem is None:
+            return True
+        messagebox.showerror("Model not ready", problem, parent=self)
+        return False
+
     def _toggle_run(self) -> None:
         controller = self.app.run_controller
         if controller is None:
@@ -1536,6 +1549,8 @@ class RunTab(ttk.Frame):
             return
         if self._is_running:
             controller.stop()
+            return
+        if not self._model_ready():
             return
         # A local model can't classify without torch, and the failure would
         # otherwise land after the machine has already fed a case. Offer the
@@ -1564,6 +1579,8 @@ class RunTab(ttk.Frame):
                 "AI not configured",
                 "Set endpoint, API key and model on the AI Config tab first.",
             )
+            return
+        if not self._model_ready():
             return
         if self._needs_torch() and not torch_gate.ensure_torch(
             self, self._manual_feed, reason="Sorting needs PyTorch",

--- a/sorter/ui/tab_run.py
+++ b/sorter/ui/tab_run.py
@@ -30,9 +30,11 @@ from collections import defaultdict
 from tkinter import messagebox, ttk
 from typing import Callable
 
+from .. import classifier
 from ..events import EventBus
 from ..feedback import FeedbackService, debug_log, is_feedback_model
 from ..repository import ModelRepo
+from . import torch_gate
 from .theme import PALETTE, row_style
 from .widgets import ImagePanel
 
@@ -1512,6 +1514,15 @@ class RunTab(ttk.Frame):
 
     # ----- run actions --------------------------------------------------------
 
+    def _needs_torch(self) -> bool:
+        """Will the next classify in this run go through local inference?
+
+        Asks `classifier` rather than re-deriving the rule, so the install
+        prompt appears in exactly the cases where the run would otherwise
+        fail — and stays silent for AI Config users.
+        """
+        return classifier.uses_local_inference(self.app.db)
+
     def _toggle_run(self) -> None:
         controller = self.app.run_controller
         if controller is None:
@@ -1525,9 +1536,16 @@ class RunTab(ttk.Frame):
             return
         if self._is_running:
             controller.stop()
-        else:
-            self._begin_wish_list_fetch(controller)
-            controller.start()
+            return
+        # A local model can't classify without torch, and the failure would
+        # otherwise land after the machine has already fed a case. Offer the
+        # install here; on success this method re-runs and starts the run.
+        if self._needs_torch() and not torch_gate.ensure_torch(
+            self, self._toggle_run, reason="Sorting needs PyTorch",
+        ):
+            return
+        self._begin_wish_list_fetch(controller)
+        controller.start()
 
     def _manual_feed(self) -> None:
         """Run one full classify+sort cycle (same flow as a continuous run)."""
@@ -1546,6 +1564,10 @@ class RunTab(ttk.Frame):
                 "AI not configured",
                 "Set endpoint, API key and model on the AI Config tab first.",
             )
+            return
+        if self._needs_torch() and not torch_gate.ensure_torch(
+            self, self._manual_feed, reason="Sorting needs PyTorch",
+        ):
             return
         self.app.run_worker(controller.cycle_once)
 

--- a/sorter/ui/tab_train.py
+++ b/sorter/ui/tab_train.py
@@ -36,14 +36,14 @@ from pathlib import Path
 from tkinter import messagebox, ttk
 from typing import Any
 
-from .. import image_proc, local_inference, paths
+from .. import classifier, image_proc, local_inference, paths
 from ..config import Config
 from ..events import EventBus
-from ..models import Model
+from ..models import Model, is_trainable
 from ..repository import HeadstampRepo, ModelRepo, SettingsRepo
 from ..training.dataset import class_counts, save_training_image
 from ..training.manager import TrainingJob, TrainingManager
-from .dialog_install_torch import TorchInstallDialog
+from . import torch_gate
 from .dialog_training_config import TrainingConfigDialog
 from .dialog_training_progress import TrainingProgressDialog
 from .theme import PALETTE
@@ -103,6 +103,9 @@ class TrainTab(ttk.Frame):
         self._pending_output: tuple[int, str] | None = None
         self._feed_in_flight = False
         self._lock = threading.Lock()
+        # Feed offers the torch install at most once per session — see
+        # `_offer_torch_for_predictions`.
+        self._torch_prompt_shown = False
 
         self._build_top_row()
         self._build_main_split()
@@ -287,7 +290,39 @@ class TrainTab(ttk.Frame):
 
     # ----- feed/capture/save workflow ----------------------------------------
 
+    def _offer_torch_for_predictions(self, sort_label: str | None) -> bool:
+        """Offer the torch install before a Feed that would predict a label.
+
+        Returns True if the caller should carry on with the feed now.
+
+        Unlike the Run tab this is an *offer*, not a gate. Capturing and
+        labelling images works perfectly well without torch — it's how you
+        build a training set in the first place — so declining must not cost
+        the user the feed. Only the predicted-label convenience is lost, and
+        the training run they eventually start is gated properly anyway.
+
+        Asked at most once per session so a user who said no isn't nagged on
+        every case. Cancelling re-enters the feed with the flag already set,
+        which is what makes "no thanks" stick.
+        """
+        if self._torch_prompt_shown:
+            return True
+        active = self._active_model()
+        if not classifier.model_uses_local_inference(active):
+            return True
+        if local_inference.is_installed():
+            return True
+        self._torch_prompt_shown = True
+        resume = lambda: self._feed(sort_label=sort_label)  # noqa: E731
+        return torch_gate.ensure_torch(
+            self, resume,
+            reason="Predicting labels needs PyTorch",
+            on_cancel=resume,
+        )
+
     def _feed(self, sort_label: str | None = None) -> None:
+        if not self._offer_torch_for_predictions(sort_label):
+            return
         with self._lock:
             if self._feed_in_flight:
                 return
@@ -491,6 +526,19 @@ class TrainTab(ttk.Frame):
             messagebox.showinfo("Pick a model first",
                                 "Activate a model on the Models tab.", parent=self)
             return
+        if not is_trainable(m):
+            # The tab is hidden for these, so reaching here means the active
+            # model changed while the tab was open. Refuse rather than fork
+            # someone else's model.
+            messagebox.showinfo(
+                "Community model",
+                f"“{m.name}” was downloaded from the community and is managed "
+                "by its publisher, so it can't be trained here.\n\n"
+                "To build on it, export it from the Models tab and import the "
+                "archive back as your own model.",
+                parent=self,
+            )
+            return
         if self.training_manager.is_running:
             messagebox.showinfo("Training in progress",
                                 "Cancel the current run first.", parent=self)
@@ -504,8 +552,9 @@ class TrainTab(ttk.Frame):
         # Torch isn't shipped in the base venv (~2 GB; AI-Config-only users
         # don't need it). Prompt for the install once on first Train click,
         # then re-enter this method when it finishes.
-        if not local_inference.is_available():
-            TorchInstallDialog(self, on_success=self._start_training, on_cancel=None)
+        if not torch_gate.ensure_torch(
+            self, self._start_training, reason="Training needs PyTorch",
+        ):
             return
 
         paths.ensure_model_subtree(m.id)

--- a/sorter/ui/tab_train.py
+++ b/sorter/ui/tab_train.py
@@ -308,7 +308,10 @@ class TrainTab(ttk.Frame):
         if self._torch_prompt_shown:
             return True
         active = self._active_model()
-        if not classifier.model_uses_local_inference(active):
+        # No checkpoint → Feed predicts nothing either way, so there's nothing
+        # for torch to do. Capturing images for an untrained model is the
+        # normal path here, not an error.
+        if not classifier.has_local_checkpoint(active):
             return True
         if local_inference.is_installed():
             return True

--- a/sorter/ui/torch_gate.py
+++ b/sorter/ui/torch_gate.py
@@ -1,0 +1,63 @@
+"""One place that decides whether a local-model action can proceed.
+
+PyTorch is an optional ~2 GB dependency (the `[ml]` extra, deliberately not in
+`requirements.txt`), so a fresh install has no torch at all. That is correct
+for AI Config users, who classify over HTTP and never need it — but a user who
+downloads a community model and presses Start is about to need it, and the
+install must be offered *then*, not discovered when the run dies on the first
+case.
+
+The rule this module encodes: **torch is installed the first time something
+actually needs it, and never before.** Downloading, importing or activating a
+model does not trigger it — those are all just rows and files. Running,
+feeding, previewing a classification, evaluating and training do.
+
+Usage is always the same shape — hand `ensure_torch` the method it is gating,
+and let it re-enter that method once the install finishes:
+
+    def _start(self):
+        if not ensure_torch(self, self._start, reason="Sorting needs PyTorch"):
+            return
+        ...the actual work...
+
+Passing the caller itself as `proceed` is the point: the gate re-runs on the
+second pass, finds torch present, and falls through to the work. Nothing has
+to be factored out into a continuation.
+
+Must be called on the Tk main thread (it may open a modal) — so from button
+handlers and event callbacks, never from inside `run_worker`.
+"""
+from __future__ import annotations
+
+import tkinter as tk
+from typing import Callable
+
+from .. import local_inference
+from .dialog_install_torch import TorchInstallDialog
+
+
+def ensure_torch(
+    parent: tk.Misc,
+    proceed: Callable[[], None],
+    *,
+    reason: str | None = None,
+    on_cancel: Callable[[], None] | None = None,
+) -> bool:
+    """Gate a local-model action on PyTorch being installed.
+
+    Returns True when torch is already there and the caller should carry
+    straight on.
+
+    Returns False when it isn't: the install dialog is now open, and `proceed`
+    will be called if and only if the install succeeds. The caller must return
+    immediately and do nothing else — the user may still cancel.
+
+    Uses `is_installed()` (a `find_spec` probe), not `is_available()`, so this
+    never imports torch on the UI thread.
+    """
+    if local_inference.is_installed():
+        return True
+    TorchInstallDialog(
+        parent, on_success=proceed, on_cancel=on_cancel, reason=reason,
+    )
+    return False

--- a/tests/test_classifier.py
+++ b/tests/test_classifier.py
@@ -37,15 +37,20 @@ def test_falls_back_to_http_when_no_active_model(tmp_path: Path) -> None:
     m_local.assert_not_called()
 
 
-def test_falls_back_to_http_when_active_model_has_no_path(tmp_path: Path) -> None:
+def test_untrained_active_model_raises_instead_of_using_http(tmp_path: Path) -> None:
+    """A local model with no checkpoint must NOT silently classify over HTTP.
+
+    The old fallback shipped case images to whatever the AI Config tab last
+    pointed at, without saying so.
+    """
     db = _seed_db(tmp_path)
     _activate_seeded_model(db)
     image = np.zeros((10, 10, 3), dtype=np.uint8)
-    with patch("sorter.classifier.api_client.classify", return_value=("X", 42.0)) as m:
+    with patch("sorter.classifier.api_client.classify") as m:
         with patch("sorter.classifier.local_inference.classify") as m_local:
-            result = classifier.classify_active(image, ["A"], {"endpoint_url": "http://x"}, db)
-    assert result == ("X", 42.0)
-    m.assert_called_once()
+            with pytest.raises(classifier.NoLocalCheckpointError):
+                classifier.classify_active(image, ["A"], {"endpoint_url": "http://x"}, db)
+    m.assert_not_called()
     m_local.assert_not_called()
 
 
@@ -74,7 +79,8 @@ def test_no_db_falls_back_to_http(tmp_path: Path) -> None:
     assert result == ("Y", 50.0)
 
 
-def test_missing_model_file_falls_back_to_http(tmp_path: Path) -> None:
+def test_missing_model_file_raises_instead_of_using_http(tmp_path: Path) -> None:
+    """The data-folder-was-renamed case: a stale model_path must fail loudly."""
     db = _seed_db(tmp_path)
     active_id = _activate_seeded_model(db)
     model = ModelRepo(db).get(active_id)
@@ -82,8 +88,37 @@ def test_missing_model_file_falls_back_to_http(tmp_path: Path) -> None:
     ModelRepo(db).update(model)
 
     image = np.zeros((10, 10, 3), dtype=np.uint8)
-    with patch("sorter.classifier.api_client.classify", return_value=("Z", 33.0)) as m:
+    with patch("sorter.classifier.api_client.classify") as m:
         with patch("sorter.classifier.local_inference.classify") as m_local:
-            result = classifier.classify_active(image, [], {}, db)
-    assert result == ("Z", 33.0)
+            with pytest.raises(classifier.NoLocalCheckpointError) as exc:
+                classifier.classify_active(image, [], {}, db)
+    m.assert_not_called()
     m_local.assert_not_called()
+    # The message has to name the path, or the user can't tell which of the
+    # two failure modes they're in.
+    assert "does_not_exist.pth" in str(exc.value)
+
+
+def test_checkpoint_problem_is_quiet_when_nothing_is_wrong(tmp_path: Path) -> None:
+    """No nagging in AI Config mode, nor for a model that can classify."""
+    db = _seed_db(tmp_path)
+    assert classifier.checkpoint_problem(db) is None      # AI Config mode
+    assert classifier.checkpoint_problem(None) is None
+
+    active_id = _activate_seeded_model(db)
+    ckpt = tmp_path / "real.pth"
+    ckpt.write_bytes(b"dummy")
+    model = ModelRepo(db).get(active_id)
+    model.model_path = str(ckpt)
+    ModelRepo(db).update(model)
+    assert classifier.checkpoint_problem(db) is None
+
+
+def test_checkpoint_problem_explains_an_untrained_model(tmp_path: Path) -> None:
+    db = _seed_db(tmp_path)
+    _activate_seeded_model(db)
+    problem = classifier.checkpoint_problem(db)
+    assert problem is not None
+    assert "no trained model file" in problem
+    # Must say it is NOT quietly switching backends.
+    assert "AI Config" in problem

--- a/tests/test_model_ownership.py
+++ b/tests/test_model_ownership.py
@@ -1,0 +1,132 @@
+"""Ownership: which models this user may train.
+
+A community download is the publisher's model — the local checkpoint is a
+copy. Training it here forks it from the version they keep updating, and the
+archive usually ships without the images it was built from. So downloads are
+marked `CommunityManaged` at import and the Train tab hides for them.
+
+The subtle part is what ownership is *not* keyed on: `community_model_uid`.
+Sharing your own model stamps a UID onto your local copy, so a UID means
+"this model exists in the community", not "this model isn't yours".
+"""
+from __future__ import annotations
+
+import json
+import zipfile
+from pathlib import Path
+
+from sorter.db import Database
+from sorter.model_io import import_model
+from sorter.models import Model, is_foreign_model, is_trainable
+from sorter.repository import ModelRepo
+
+
+def _seed_db(tmp_path: Path) -> Database:
+    db = Database(tmp_path / "own.db")
+    db.ensure_initialized()
+    return db
+
+
+def _archive(
+    tmp_path: Path, name: str = "Shared9mm", uid: str = "uid-1",
+    model_type: str = "Standard", filename: str = "pub.zip",
+) -> Path:
+    """A share archive as a publisher would produce it — ModelType Standard,
+    because that's what the model is on *their* machine."""
+    zip_path = tmp_path / filename
+    manifest = {
+        "ModelName": name,
+        "CartridgeName": "9mm",
+        "Headstamps": ["FC", "WIN"],
+        "ExportMode": 1,
+        "ModelInfo": {
+            "Name": name,
+            "ModelMode": "convnext_tiny",
+            "ModelType": model_type,
+            "CommunityModelUID": uid,
+            "ModelVersion": 2,
+        },
+    }
+    with zipfile.ZipFile(zip_path, "w") as zf:
+        zf.writestr("manifest.json", json.dumps(manifest))
+        zf.writestr("model/pub.pth", b"CHECKPOINT")
+    return zip_path
+
+
+# ----- the predicates -------------------------------------------------------
+
+
+def test_a_locally_authored_model_is_trainable() -> None:
+    assert is_trainable(Model(name="Mine"))
+    assert not is_foreign_model(Model(name="Mine"))
+
+
+def test_a_model_you_shared_stays_trainable() -> None:
+    """Sharing stamps a UID on your own copy — it must not cost you training."""
+    mine = Model(name="Mine", community_model_uid="uid-abc", model_type="Standard")
+    assert is_trainable(mine)
+    assert not is_foreign_model(mine)
+
+
+def test_a_community_download_is_not_trainable() -> None:
+    assert not is_trainable(Model(name="Theirs", model_type="CommunityManaged"))
+    assert is_foreign_model(Model(name="Theirs", model_type="CommunityManaged"))
+
+
+def test_legacy_readonly_models_are_not_trainable() -> None:
+    assert not is_trainable(Model(name="Old", model_type="ReadOnly"))
+
+
+def test_ai_config_mode_is_not_trainable() -> None:
+    """No active model at all — the Train tab hides for this too."""
+    assert not is_trainable(None)
+
+
+# ----- import stamping ------------------------------------------------------
+
+
+def test_community_download_is_marked_not_owned(tmp_path: Path) -> None:
+    db = _seed_db(tmp_path)
+    _cart, model_id = import_model(
+        _archive(tmp_path), db=db, community_download=True,
+    )
+    saved = ModelRepo(db).get(model_id)
+    # The manifest said Standard; how it arrived is what counts.
+    assert saved.model_type == "CommunityManaged"
+    assert not is_trainable(saved)
+
+
+def test_plain_zip_import_stays_owned(tmp_path: Path) -> None:
+    """Importing a ZIP is just as likely to be restoring your own model."""
+    db = _seed_db(tmp_path)
+    _cart, model_id = import_model(_archive(tmp_path), db=db)
+    saved = ModelRepo(db).get(model_id)
+    assert saved.model_type == "Standard"
+    assert is_trainable(saved)
+
+
+def test_updating_a_download_keeps_it_not_owned(tmp_path: Path) -> None:
+    """A newer version of an installed community model stays read-only."""
+    db = _seed_db(tmp_path)
+    _cart, model_id = import_model(
+        _archive(tmp_path), db=db, community_download=True,
+    )
+    _cart2, updated_id = import_model(
+        _archive(tmp_path, filename="v2.zip"), db=db, community_download=True,
+    )
+    assert updated_id == model_id            # updated in place, not duplicated
+    assert not is_trainable(ModelRepo(db).get(model_id))
+
+
+def test_a_plain_zip_cannot_launder_a_download_into_an_owned_model(
+    tmp_path: Path,
+) -> None:
+    """The loophole: re-import the same archive from disk, without the
+    community flag, and the manifest's `Standard` would overwrite the
+    installed `CommunityManaged`."""
+    db = _seed_db(tmp_path)
+    _cart, model_id = import_model(
+        _archive(tmp_path), db=db, community_download=True,
+    )
+    import_model(_archive(tmp_path, filename="again.zip"), db=db)
+    assert not is_trainable(ModelRepo(db).get(model_id))

--- a/tests/test_torch_gate.py
+++ b/tests/test_torch_gate.py
@@ -1,0 +1,200 @@
+"""The PyTorch install gate: who gets prompted, and who never does.
+
+The rule under test is that torch is installed the first time something
+actually needs it and never before — so an AI Config user is never prompted,
+and a local-model user is prompted *before* the machine feeds a case rather
+than after the run dies on it.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from sorter import classifier, local_inference
+from sorter.db import Database
+from sorter.models import Model
+from sorter.repository import CartridgeRepo, ModelRepo, SettingsRepo
+
+
+def _seed_db(tmp_path: Path) -> Database:
+    db = Database(tmp_path / "gate.db")
+    db.ensure_initialized()
+    return db
+
+
+def _local_model(db: Database, tmp_path: Path) -> Model:
+    """An active model with a checkpoint on disk — i.e. one that needs torch."""
+    cart = CartridgeRepo(db).create("9mm-gate")
+    ckpt = tmp_path / "m.pth"
+    ckpt.write_bytes(b"NOTAREALCHECKPOINT")
+    model = ModelRepo(db).create(Model(name="Local", cartridge_id=cart.id))
+    model.model_path = str(ckpt)
+    ModelRepo(db).update(model)
+    SettingsRepo(db).set_active_model_id(model.id)
+    return model
+
+
+# ----- the routing predicate ------------------------------------------------
+# These guard the property that makes the gate correct: it must fire in
+# exactly the cases where classify_active would reach local_inference.
+
+
+def test_ai_config_mode_does_not_use_local_inference(tmp_path: Path) -> None:
+    db = _seed_db(tmp_path)
+    SettingsRepo(db).clear_active_model()
+    assert classifier.uses_local_inference(db) is False
+
+
+def test_active_model_with_checkpoint_uses_local_inference(tmp_path: Path) -> None:
+    db = _seed_db(tmp_path)
+    _local_model(db, tmp_path)
+    assert classifier.uses_local_inference(db) is True
+
+
+def test_untrained_active_model_does_not_use_local_inference(tmp_path: Path) -> None:
+    """No checkpoint yet → classify goes over HTTP, so no torch is needed."""
+    db = _seed_db(tmp_path)
+    seed = ModelRepo(db).list()[0]
+    SettingsRepo(db).set_active_model_id(seed.id)
+    assert seed.model_path in (None, "")
+    assert classifier.uses_local_inference(db) is False
+
+
+def test_missing_checkpoint_file_does_not_use_local_inference(tmp_path: Path) -> None:
+    """A model_path pointing at a deleted file falls back to HTTP, not a crash."""
+    db = _seed_db(tmp_path)
+    model = _local_model(db, tmp_path)
+    Path(model.model_path).unlink()
+    assert classifier.uses_local_inference(db) is False
+
+
+def test_no_db_does_not_use_local_inference() -> None:
+    assert classifier.uses_local_inference(None) is False
+
+
+# ----- the cheap presence probe ---------------------------------------------
+
+
+def test_is_installed_does_not_import_torch(monkeypatch) -> None:
+    """`is_installed` must not pay the import — it runs on the UI thread.
+
+    Importing torch here would also run the device probe and the environment
+    dump's synthetic benchmarks, freezing the UI on every button press.
+    """
+    called = []
+
+    def _boom():
+        called.append(1)
+        raise AssertionError("is_installed must not import torch")
+
+    monkeypatch.setattr(local_inference, "_torch", _boom)
+    local_inference.is_installed()
+    assert not called
+
+
+def test_is_installed_reports_false_when_torch_absent(monkeypatch) -> None:
+    import importlib.util
+
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: None)
+    assert local_inference.is_installed() is False
+
+
+def test_is_installed_reports_true_when_both_present(monkeypatch) -> None:
+    import importlib.util
+
+    monkeypatch.setattr(importlib.util, "find_spec", lambda name: object())
+    assert local_inference.is_installed() is True
+
+
+def test_is_installed_requires_torchvision_too(monkeypatch) -> None:
+    """torch alone isn't enough — local_inference imports torchvision.models."""
+    import importlib.util
+
+    monkeypatch.setattr(
+        importlib.util, "find_spec",
+        lambda name: object() if name == "torch" else None,
+    )
+    assert local_inference.is_installed() is False
+
+
+def test_is_installed_survives_a_broken_module(monkeypatch) -> None:
+    """find_spec raises for a half-installed package; that means 'no', not a crash."""
+    import importlib.util
+
+    def _raise(name):
+        raise ValueError("__spec__ is None")
+
+    monkeypatch.setattr(importlib.util, "find_spec", _raise)
+    assert local_inference.is_installed() is False
+
+
+# ----- the gate itself ------------------------------------------------------
+
+pytest.importorskip("tkinter")
+
+from sorter.ui import torch_gate  # noqa: E402
+
+
+class _FakeDialog:
+    """Stands in for TorchInstallDialog — constructing the real one shells out
+    to nvidia-smi and needs a display."""
+
+    instances: list["_FakeDialog"] = []
+
+    def __init__(self, parent, *, on_success=None, on_cancel=None, reason=None):
+        self.parent = parent
+        self.on_success = on_success
+        self.on_cancel = on_cancel
+        self.reason = reason
+        _FakeDialog.instances.append(self)
+
+
+@pytest.fixture
+def fake_dialog(monkeypatch):
+    _FakeDialog.instances = []
+    monkeypatch.setattr(torch_gate, "TorchInstallDialog", _FakeDialog)
+    return _FakeDialog
+
+
+def test_gate_passes_through_when_torch_is_installed(monkeypatch, fake_dialog) -> None:
+    monkeypatch.setattr(torch_gate.local_inference, "is_installed", lambda: True)
+    assert torch_gate.ensure_torch(None, lambda: None) is True
+    assert fake_dialog.instances == []
+
+
+def test_gate_blocks_and_offers_install_when_torch_is_missing(
+    monkeypatch, fake_dialog,
+) -> None:
+    monkeypatch.setattr(torch_gate.local_inference, "is_installed", lambda: False)
+    ran = []
+    assert torch_gate.ensure_torch(
+        None, lambda: ran.append("proceed"), reason="Sorting needs PyTorch",
+    ) is False
+    # Blocked: the caller's action must NOT have run yet.
+    assert ran == []
+    assert len(fake_dialog.instances) == 1
+    assert fake_dialog.instances[0].reason == "Sorting needs PyTorch"
+
+
+def test_gate_runs_the_action_only_after_a_successful_install(
+    monkeypatch, fake_dialog,
+) -> None:
+    monkeypatch.setattr(torch_gate.local_inference, "is_installed", lambda: False)
+    ran = []
+    torch_gate.ensure_torch(None, lambda: ran.append("proceed"))
+    assert ran == []
+    fake_dialog.instances[0].on_success()   # pip finished
+    assert ran == ["proceed"]
+
+
+def test_cancelling_the_install_does_not_run_the_action(
+    monkeypatch, fake_dialog,
+) -> None:
+    monkeypatch.setattr(torch_gate.local_inference, "is_installed", lambda: False)
+    ran = []
+    torch_gate.ensure_torch(None, lambda: ran.append("proceed"))
+    dialog = fake_dialog.instances[0]
+    if dialog.on_cancel is not None:
+        dialog.on_cancel()
+    assert ran == []

--- a/tests/test_torch_gate.py
+++ b/tests/test_torch_gate.py
@@ -52,21 +52,32 @@ def test_active_model_with_checkpoint_uses_local_inference(tmp_path: Path) -> No
     assert classifier.uses_local_inference(db) is True
 
 
-def test_untrained_active_model_does_not_use_local_inference(tmp_path: Path) -> None:
-    """No checkpoint yet → classify goes over HTTP, so no torch is needed."""
+def test_an_active_model_routes_locally_even_without_a_checkpoint(
+    tmp_path: Path,
+) -> None:
+    """Routing follows the active model, not the checkpoint.
+
+    A missing checkpoint is a failure to report, not a reason to switch to
+    HTTP — so this still counts as local, and `checkpoint_problem` is what
+    tells the user it won't work.
+    """
     db = _seed_db(tmp_path)
     seed = ModelRepo(db).list()[0]
     SettingsRepo(db).set_active_model_id(seed.id)
     assert seed.model_path in (None, "")
-    assert classifier.uses_local_inference(db) is False
+    assert classifier.uses_local_inference(db) is True
+    assert classifier.has_local_checkpoint(seed) is False
+    assert classifier.checkpoint_problem(db) is not None
 
 
-def test_missing_checkpoint_file_does_not_use_local_inference(tmp_path: Path) -> None:
-    """A model_path pointing at a deleted file falls back to HTTP, not a crash."""
+def test_a_deleted_checkpoint_is_reported_not_routed_to_http(
+    tmp_path: Path,
+) -> None:
     db = _seed_db(tmp_path)
     model = _local_model(db, tmp_path)
     Path(model.model_path).unlink()
-    assert classifier.uses_local_inference(db) is False
+    assert classifier.uses_local_inference(db) is True
+    assert classifier.checkpoint_problem(db) is not None
 
 
 def test_no_db_does_not_use_local_inference() -> None:

--- a/tests/test_torch_gate_tabs.py
+++ b/tests/test_torch_gate_tabs.py
@@ -226,6 +226,94 @@ def test_stopping_a_run_is_never_gated(
         tab.destroy()
 
 
+def test_start_refuses_a_model_whose_checkpoint_is_missing(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    """The data-folder-rename case: refuse, don't quietly sort via HTTP.
+
+    Also must not offer the torch install — torch isn't the problem, and
+    installing 2 GB wouldn't fix a missing checkpoint.
+    """
+    db = _db(tmp_path, monkeypatch)
+    m = _activate_local_model(db, tmp_path)
+    Path(m.model_path).unlink()          # data folder renamed / model deleted
+    app = _FakeApp(db)
+    tab = RunTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        errors = []
+        monkeypatch.setattr(
+            "sorter.ui.tab_run.messagebox.showerror",
+            lambda *a, **k: errors.append(a),
+        )
+        tab._toggle_run()
+        assert app.run_controller.started == 0
+        assert fake_dialog.instances == []
+        assert errors and "isn't there" in errors[0][1]
+    finally:
+        tab.destroy()
+
+
+def test_manual_feed_refuses_a_model_whose_checkpoint_is_missing(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    db = _db(tmp_path, monkeypatch)
+    m = _activate_local_model(db, tmp_path)
+    Path(m.model_path).unlink()
+    app = _FakeApp(db)
+    tab = RunTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        monkeypatch.setattr(
+            "sorter.ui.tab_run.messagebox.showerror", lambda *a, **k: None,
+        )
+        tab._manual_feed()
+        assert app.run_controller.cycles == 0
+    finally:
+        tab.destroy()
+
+
+def test_ai_config_start_is_not_blocked_by_the_checkpoint_check(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    """AI Config mode has no checkpoint by definition — it must still run."""
+    db = _db(tmp_path, monkeypatch)
+    SettingsRepo(db).clear_active_model()
+    app = _FakeApp(db)
+    tab = RunTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        errors = []
+        monkeypatch.setattr(
+            "sorter.ui.tab_run.messagebox.showerror",
+            lambda *a, **k: errors.append(a),
+        )
+        tab._toggle_run()
+        assert errors == []
+        assert app.run_controller.started == 1
+    finally:
+        tab.destroy()
+
+
+def test_stop_still_works_with_a_missing_checkpoint(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    """Never trap a running machine behind a dialog it can't clear."""
+    db = _db(tmp_path, monkeypatch)
+    m = _activate_local_model(db, tmp_path)
+    Path(m.model_path).unlink()
+    app = _FakeApp(db)
+    stopped = []
+    app.run_controller.stop = lambda: stopped.append(1)
+    tab = RunTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        monkeypatch.setattr(
+            "sorter.ui.tab_run.messagebox.showerror", lambda *a, **k: None,
+        )
+        tab._set_running(True)
+        tab._toggle_run()
+        assert stopped == [1]
+    finally:
+        tab.destroy()
+
+
 # ----- Train tab ------------------------------------------------------------
 
 

--- a/tests/test_torch_gate_tabs.py
+++ b/tests/test_torch_gate_tabs.py
@@ -1,0 +1,309 @@
+"""The install gate as wired into the tabs (needs a Tk display).
+
+The regression these lock down: a fresh install had no torch, and nothing on
+the download → activate → Start path checked for it, so the run died on the
+first case with a `pip install .[ml]` message. Only the Train tab's
+"Start training" button ever offered the install.
+"""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tkinter")
+pytest.importorskip("cv2")
+
+import tkinter as tk  # noqa: E402
+
+from sorter.config import Config  # noqa: E402
+from sorter.db import Database  # noqa: E402
+from sorter.events import EventBus  # noqa: E402
+from sorter.models import Model  # noqa: E402
+from sorter.repository import CartridgeRepo, ModelRepo, SettingsRepo  # noqa: E402
+from sorter.ui import torch_gate  # noqa: E402
+from sorter.ui.tab_run import RunTab  # noqa: E402
+from sorter.ui.tab_train import TrainTab  # noqa: E402
+
+
+@pytest.fixture
+def root():
+    try:
+        r = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no Tk display: {exc}")
+    r.withdraw()
+    yield r
+    r.destroy()
+
+
+class _FakeDialog:
+    instances: list["_FakeDialog"] = []
+
+    def __init__(self, parent, *, on_success=None, on_cancel=None, reason=None):
+        self.on_success = on_success
+        self.on_cancel = on_cancel
+        self.reason = reason
+        _FakeDialog.instances.append(self)
+
+
+@pytest.fixture
+def fake_dialog(monkeypatch):
+    _FakeDialog.instances = []
+    monkeypatch.setattr(torch_gate, "TorchInstallDialog", _FakeDialog)
+    return _FakeDialog
+
+
+@pytest.fixture
+def no_torch(monkeypatch):
+    """Start with torch absent; flip `installed` to model a finished pip run.
+
+    The gate re-checks on re-entry, so a test that fires `on_success` without
+    flipping this would just get a second dialog — which is exactly what the
+    app does when an "successful" install still leaves torch unimportable.
+    """
+    state = {"installed": False}
+    monkeypatch.setattr(
+        torch_gate.local_inference, "is_installed", lambda: state["installed"],
+    )
+    return state
+
+
+class _FakeController:
+    def __init__(self) -> None:
+        self.is_running = False
+        self.started = 0
+        self.cycles = 0
+
+    def start(self) -> None:
+        self.started += 1
+
+    def stop(self) -> None:
+        pass
+
+    def clear_wish_list(self) -> None:
+        pass
+
+    def cycle_once(self) -> None:
+        self.cycles += 1
+
+
+class _FakeBroker:
+    is_connected = True
+
+    def force_sort_and_move(self, slot: int) -> bool:
+        return True
+
+
+class _FakeApp:
+    def __init__(self, db) -> None:
+        self.db = db
+        self.auth = None
+        self.broker = _FakeBroker()
+        self.run_controller = _FakeController()
+
+    def capture_frame(self):
+        return None
+
+    def run_worker(self, fn, *, on_done=None, on_error=None):
+        try:
+            result = fn()
+        except Exception as exc:
+            if on_error:
+                on_error(exc)
+        else:
+            if on_done:
+                on_done(result)
+
+    def set_status(self, _msg):
+        pass
+
+
+def _db(tmp_path: Path, monkeypatch) -> Database:
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    db = Database(tmp_path / "t.db")
+    db.ensure_initialized()
+    return db
+
+
+def _activate_local_model(db: Database, tmp_path: Path) -> Model:
+    cart = CartridgeRepo(db).create("9mm-tabs")
+    ckpt = tmp_path / "trained.pth"
+    ckpt.write_bytes(b"CHECKPOINT")
+    m = ModelRepo(db).create(Model(name="Downloaded", cartridge_id=cart.id))
+    m.model_path = str(ckpt)
+    ModelRepo(db).update(m)
+    SettingsRepo(db).set_active_model_id(m.id)
+    return m
+
+
+# ----- Run tab --------------------------------------------------------------
+
+
+def test_start_offers_install_and_does_not_start_the_run(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    """The whole point: a downloaded model + Start must not feed a case."""
+    db = _db(tmp_path, monkeypatch)
+    _activate_local_model(db, tmp_path)
+    app = _FakeApp(db)
+    tab = RunTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        tab._toggle_run()
+        assert len(fake_dialog.instances) == 1
+        assert app.run_controller.started == 0     # nothing fed
+        # Install completes → the run starts, no second click needed.
+        no_torch["installed"] = True
+        fake_dialog.instances[0].on_success()
+        assert app.run_controller.started == 1
+    finally:
+        tab.destroy()
+
+
+def test_ai_config_mode_start_is_never_gated(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    """An AI Config user classifies over HTTP and must never see the prompt."""
+    db = _db(tmp_path, monkeypatch)
+    SettingsRepo(db).clear_active_model()
+    app = _FakeApp(db)
+    tab = RunTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        tab._toggle_run()
+        assert fake_dialog.instances == []
+        assert app.run_controller.started == 1
+    finally:
+        tab.destroy()
+
+
+def test_start_is_not_gated_when_torch_is_present(
+    root, tmp_path, monkeypatch, fake_dialog,
+) -> None:
+    monkeypatch.setattr(torch_gate.local_inference, "is_installed", lambda: True)
+    db = _db(tmp_path, monkeypatch)
+    _activate_local_model(db, tmp_path)
+    app = _FakeApp(db)
+    tab = RunTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        tab._toggle_run()
+        assert fake_dialog.instances == []
+        assert app.run_controller.started == 1
+    finally:
+        tab.destroy()
+
+
+def test_manual_feed_offers_install_and_does_not_cycle(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    db = _db(tmp_path, monkeypatch)
+    _activate_local_model(db, tmp_path)
+    app = _FakeApp(db)
+    tab = RunTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        tab._manual_feed()
+        assert len(fake_dialog.instances) == 1
+        assert app.run_controller.cycles == 0
+        no_torch["installed"] = True
+        fake_dialog.instances[0].on_success()
+        assert app.run_controller.cycles == 1
+    finally:
+        tab.destroy()
+
+
+def test_stopping_a_run_is_never_gated(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    """Stop must always work — never trap a running machine behind a modal."""
+    db = _db(tmp_path, monkeypatch)
+    _activate_local_model(db, tmp_path)
+    app = _FakeApp(db)
+    tab = RunTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        tab._set_running(True)
+        tab._toggle_run()
+        assert fake_dialog.instances == []
+    finally:
+        tab.destroy()
+
+
+# ----- Train tab ------------------------------------------------------------
+
+
+def test_train_feed_offers_install_but_still_feeds_when_declined(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    """Capturing images must survive a declined install.
+
+    Building a training set is exactly the no-torch workflow, so the Feed
+    button offers the install rather than gating on it.
+    """
+    db = _db(tmp_path, monkeypatch)
+    _activate_local_model(db, tmp_path)
+    app = _FakeApp(db)
+    tab = TrainTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        fed = []
+        monkeypatch.setattr(app.broker, "force_sort_and_move",
+                            lambda slot: fed.append(slot) or True)
+        tab._feed()
+        assert len(fake_dialog.instances) == 1
+        assert fed == []                    # held while the modal is up
+        fake_dialog.instances[0].on_cancel()  # "no thanks"
+        assert fed == [0]                   # …and the feed still happened
+    finally:
+        tab.destroy()
+
+
+def test_train_feed_asks_only_once_per_session(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    db = _db(tmp_path, monkeypatch)
+    _activate_local_model(db, tmp_path)
+    app = _FakeApp(db)
+    tab = TrainTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        tab._feed()
+        fake_dialog.instances[0].on_cancel()
+        tab._feed()
+        tab._feed()
+        assert len(fake_dialog.instances) == 1   # not nagged on every case
+    finally:
+        tab.destroy()
+
+
+def test_train_feed_preserves_the_sort_label_across_the_prompt(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    """The auto-feed chain passes a label; the prompt must not drop it."""
+    db = _db(tmp_path, monkeypatch)
+    _activate_local_model(db, tmp_path)
+    cfg = Config(db).load()
+    cfg.add_headstamp("FC", slot=5)
+    app = _FakeApp(db)
+    tab = TrainTab(root, config=cfg, bus=EventBus(), app=app)
+    try:
+        fed = []
+        monkeypatch.setattr(app.broker, "force_sort_and_move",
+                            lambda slot: fed.append(slot) or True)
+        tab._sort_while_training_var.set(True)
+        tab._feed(sort_label="FC")
+        fake_dialog.instances[0].on_cancel()
+        assert fed == [5]   # FC's slot, not the catch-all
+    finally:
+        tab.destroy()
+
+
+def test_train_feed_never_prompts_for_a_model_with_no_checkpoint(
+    root, tmp_path, monkeypatch, fake_dialog, no_torch,
+) -> None:
+    """A brand-new model predicts nothing, so there's nothing to install for."""
+    db = _db(tmp_path, monkeypatch)
+    seed = ModelRepo(db).list()[0]
+    SettingsRepo(db).set_active_model_id(seed.id)
+    app = _FakeApp(db)
+    tab = TrainTab(root, config=Config(db).load(), bus=EventBus(), app=app)
+    try:
+        tab._feed()
+        assert fake_dialog.instances == []
+    finally:
+        tab.destroy()

--- a/tests/test_train_tab_ownership_ui.py
+++ b/tests/test_train_tab_ownership_ui.py
@@ -1,0 +1,154 @@
+"""The Train tab is hidden for models the user doesn't own (needs Tk)."""
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+pytest.importorskip("tkinter")
+pytest.importorskip("cv2")
+
+import tkinter as tk  # noqa: E402
+from tkinter import ttk  # noqa: E402
+
+from sorter.config import Config  # noqa: E402
+from sorter.db import Database  # noqa: E402
+from sorter.events import EventBus  # noqa: E402
+from sorter.models import Model  # noqa: E402
+from sorter.repository import CartridgeRepo, ModelRepo, SettingsRepo  # noqa: E402
+from sorter.ui.app import MainWindow  # noqa: E402
+from sorter.ui.tab_train import TrainTab  # noqa: E402
+
+
+@pytest.fixture
+def root():
+    try:
+        r = tk.Tk()
+    except tk.TclError as exc:
+        pytest.skip(f"no Tk display: {exc}")
+    r.withdraw()
+    yield r
+    r.destroy()
+
+
+class _VisibilityHarness:
+    """Minimal stand-in for MainWindow.
+
+    Building a real MainWindow auto-connects serial and camera; all
+    `_apply_train_tab_visibility` actually touches is the db, the notebook
+    and the Train container, so we borrow the unbound method.
+    """
+
+    def __init__(self, root, db) -> None:
+        self.db = db
+        self.notebook = ttk.Notebook(root)
+        self.notebook.add(ttk.Frame(self.notebook), text="Run")
+        self.notebook.add(ttk.Frame(self.notebook), text="Models")
+        self._train_tab_container = ttk.Frame(self.notebook)
+        self.notebook.add(self._train_tab_container, text="Train")
+
+    def train_tab_visible(self) -> bool:
+        MainWindow._apply_train_tab_visibility(self)
+        # `tabs()` still lists a hidden tab, so ask for its state — that's
+        # what decides whether the user can actually reach it.
+        for tid in self.notebook.tabs():
+            if self.notebook.tab(tid, "text") == "Train":
+                return self.notebook.tab(tid, "state") != "hidden"
+        return False
+
+    _restore_train_tab_position = MainWindow._restore_train_tab_position
+
+
+def _db(tmp_path: Path, monkeypatch) -> Database:
+    monkeypatch.setenv("CASESORTER_DATA_DIR", str(tmp_path / "data"))
+    db = Database(tmp_path / "t.db")
+    db.ensure_initialized()
+    return db
+
+
+def _activate(db: Database, *, model_type: str, uid: str | None = None) -> Model:
+    cart = CartridgeRepo(db).create(f"c-{model_type}-{uid}")
+    m = ModelRepo(db).create(
+        Model(name="M", cartridge_id=cart.id, model_type=model_type,
+              community_model_uid=uid)
+    )
+    SettingsRepo(db).set_active_model_id(m.id)
+    return m
+
+
+def test_train_tab_shows_for_your_own_model(root, tmp_path, monkeypatch) -> None:
+    db = _db(tmp_path, monkeypatch)
+    _activate(db, model_type="Standard")
+    assert _VisibilityHarness(root, db).train_tab_visible() is True
+
+
+def test_train_tab_shows_for_a_model_you_shared(root, tmp_path, monkeypatch) -> None:
+    """A UID from sharing your own model must not cost you the Train tab."""
+    db = _db(tmp_path, monkeypatch)
+    _activate(db, model_type="Standard", uid="uid-mine")
+    assert _VisibilityHarness(root, db).train_tab_visible() is True
+
+
+def test_train_tab_hides_for_a_community_download(root, tmp_path, monkeypatch) -> None:
+    db = _db(tmp_path, monkeypatch)
+    _activate(db, model_type="CommunityManaged", uid="uid-theirs")
+    assert _VisibilityHarness(root, db).train_tab_visible() is False
+
+
+def test_train_tab_hides_for_a_readonly_model(root, tmp_path, monkeypatch) -> None:
+    db = _db(tmp_path, monkeypatch)
+    _activate(db, model_type="ReadOnly")
+    assert _VisibilityHarness(root, db).train_tab_visible() is False
+
+
+def test_train_tab_hides_in_ai_config_mode(root, tmp_path, monkeypatch) -> None:
+    db = _db(tmp_path, monkeypatch)
+    SettingsRepo(db).clear_active_model()
+    assert _VisibilityHarness(root, db).train_tab_visible() is False
+
+
+# ----- the tab's own guard --------------------------------------------------
+
+
+class _FakeApp:
+    def __init__(self, db) -> None:
+        self.db = db
+        self.auth = None
+        self.broker = None
+
+    def capture_frame(self):
+        return None
+
+    def run_worker(self, fn, *, on_done=None, on_error=None):
+        result = fn()
+        if on_done:
+            on_done(result)
+
+    def set_status(self, _msg):
+        pass
+
+
+def test_start_training_refuses_a_community_model(
+    root, tmp_path, monkeypatch,
+) -> None:
+    """Defense in depth: the tab is hidden, but if the active model changes
+    while it's open, Start must still refuse rather than fork someone else's
+    model."""
+    db = _db(tmp_path, monkeypatch)
+    _activate(db, model_type="CommunityManaged", uid="uid-theirs")
+    tab = TrainTab(root, config=Config(db).load(), bus=EventBus(), app=_FakeApp(db))
+    try:
+        shown = []
+        monkeypatch.setattr(
+            "sorter.ui.tab_train.messagebox.showinfo",
+            lambda *a, **k: shown.append(a),
+        )
+        spawned = []
+        monkeypatch.setattr(
+            tab.training_manager, "spawn", lambda *a, **k: spawned.append(a),
+        )
+        tab._start_training()
+        assert spawned == []
+        assert shown and "Community model" in shown[0][0]
+    finally:
+        tab.destroy()

--- a/tools/diagnose_active_model.py
+++ b/tools/diagnose_active_model.py
@@ -1,0 +1,103 @@
+"""Print exactly what the classifier sees when deciding local vs HTTP.
+
+Run this with the same interpreter the app uses, from the repo root:
+
+    Windows:  .venv\\Scripts\\python tools\\diagnose_active_model.py
+    Linux:    .venv/bin/python tools/diagnose_active_model.py
+
+`classify_active` picks local inference only when ALL of these hold:
+  * a model is active (settings.default_model_id is set)
+  * that row still exists
+  * its model_path is non-empty
+  * the file at model_path exists on disk
+
+If any one fails it falls back to the AI Config HTTP server, which is what a
+`localhost:8000 /v1/chat/completions` connection error means. This prints each
+condition separately so you can see which one is the problem.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent.parent))
+
+from sorter import paths  # noqa: E402
+from sorter.db import Database  # noqa: E402
+from sorter.repository import ModelRepo, SettingsRepo  # noqa: E402
+
+
+def main() -> int:
+    print(f"data root : {paths.app_data_dir()}")
+    db_path = paths.db_path()
+    print(f"database  : {db_path}  (exists={db_path.exists()})")
+    if not db_path.exists():
+        print("\n-> No database. The app has never run against this data root.")
+        return 1
+
+    db = Database(db_path)
+    db.connect()
+    settings = SettingsRepo(db)
+    models = ModelRepo(db)
+
+    active_id = settings.get_active_model_id()
+    print(f"\nactive model id (settings.default_model_id) = {active_id!r}")
+    if active_id is None:
+        print("-> AI Config mode. Every classification goes over HTTP.")
+        print("   Fix: activate a model on the Models tab.")
+        _print_library(models)
+        return 1
+
+    model = models.get(active_id)
+    if model is None:
+        print(f"-> default_model_id={active_id} points at a row that no longer exists.")
+        print("   Fix: re-activate a model on the Models tab.")
+        _print_library(models)
+        return 1
+
+    print(f"  name       : {model.name}")
+    print(f"  model_type : {model.model_type}")
+    print(f"  community  : {model.community_model_uid}")
+    print(f"  model_path : {model.model_path!r}")
+
+    if not model.model_path:
+        print("\n-> model_path is EMPTY: this model has no trained checkpoint, so")
+        print("   classification falls back to the AI Config HTTP server.")
+        print("   A community download lands here if its archive shipped without")
+        print("   the model file (an images-only share).")
+        _print_expected_checkpoint(model.id)
+        return 1
+
+    if not Path(model.model_path).exists():
+        print(f"\n-> model_path does NOT exist on disk: {model.model_path}")
+        print("   The row points at a checkpoint that was moved or deleted, so")
+        print("   classification silently falls back to the HTTP server.")
+        _print_expected_checkpoint(model.id)
+        return 1
+
+    size = Path(model.model_path).stat().st_size
+    print(f"\n-> LOCAL inference. Checkpoint present ({size / 1e6:.1f} MB).")
+    print("   If you still saw a /v1/chat/completions call, the run was started")
+    print("   before this model was activated — restart the run.")
+    return 0
+
+
+def _print_expected_checkpoint(model_id: int) -> None:
+    d = paths.model_trained_dir(model_id)
+    print(f"\n   expected checkpoint dir: {d}")
+    if d.exists():
+        found = list(d.iterdir())
+        print(f"   contents: {[p.name for p in found] or 'EMPTY'}")
+    else:
+        print("   contents: directory does not exist")
+
+
+def _print_library(models: ModelRepo) -> None:
+    print("\ninstalled models:")
+    for m in models.list():
+        has = bool(m.model_path and Path(m.model_path).exists())
+        print(f"  id={m.id:<4} {m.name:<28} type={m.model_type:<17} checkpoint={has}")
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

This change implements a PyTorch install gate that fires at the moment a local model action actually needs it — not before, not after a crash. It also removes the silent HTTP fallback when a local model's checkpoint is missing, replacing it with an explicit error that surfaces the problem to the user before a case is fed.

## Key Changes

**Core routing logic (`classifier.py`)**
- Removed silent HTTP fallback for missing checkpoints; now raises `NoLocalCheckpointError` instead
- Added `active_model()`, `uses_local_inference()`, `has_local_checkpoint()`, and `checkpoint_problem()` predicates so the UI can ask "does this need PyTorch?" and "can this model actually classify?" before starting a run
- These predicates are kept in lock-step with `classify_active` to ensure the install gate sees the same conditions the classifier does
- Detailed error messages distinguish between missing `model_path` (untrained model) and missing file on disk (data folder renamed)

**Install gate (`torch_gate.py`, new)**
- Single entry point `ensure_torch(parent, proceed, reason, on_cancel)` that gates any local-model action
- Checks torch presence without importing it (uses `importlib.util.find_spec` to avoid the 2+ second device probe and environment dump)
- Opens `TorchInstallDialog` only when needed; re-enters the caller's method once install completes
- Callers use the pattern: `if not ensure_torch(self, self._start): return`

**Run tab (`tab_run.py`)**
- Added `_needs_torch()` and `_model_ready()` checks before starting or feeding
- Refuses to start with a missing checkpoint (shows error dialog, doesn't feed)
- Gates Start and manual feed on torch via `ensure_torch`
- Stop always works, never trapped behind a modal

**Train tab (`tab_train.py`)**
- Feed offers the torch install (not a gate — capturing images works without torch)
- Offer appears at most once per session
- Declining the install still allows the feed to proceed
- Preserves the sort label across the prompt

**Model ownership (`models.py`, `model_io.py`)**
- Added `is_foreign_model()` and `is_trainable()` predicates
- Community downloads are stamped `CommunityManaged` at import; `ReadOnly` is the legacy equivalent
- `community_model_uid` is NOT part of ownership — sharing your own model stamps a UID, so a UID means "exists in community", not "isn't yours"
- Train tab hides for foreign models and refuses to start training if the active model changes to one

**UI visibility (`app.py`, `tab_models.py`)**
- Train tab now hides for community downloads and read-only models, not just AI Config mode
- Models tab shows ownership status

**Torch import fix (`local_inference.py`)**
- Added `importlib.invalidate_caches()` before first torch import to handle in-app installs (pip runs while the process is live)
- Added `is_installed()` probe that checks for torch/torchvision without importing

**Dialog updates (`dialog_install_torch.py`)**
- Now accepts `reason` parameter to explain which action is asking (e.g., "Sorting needs PyTorch" vs. "Training needs PyTorch")

## Tests

Added comprehensive test suites:
- `test_torch_gate.py` — routing predicates, cheap presence probe, gate behavior
- `test_torch_gate_tabs.py` — Run tab (Start, manual feed, stop), Train tab (feed offer, once-per-session), checkpoint validation
- `test_model_ownership.py` — ownership predicates, import stamping, update behavior
- `test_train_tab_ownership_ui.py` — Train tab visibility and refusal

## Notable Implementation Details

- The gate re-checks torch on re-entry, so a test that fires `on_success` without flipping `is_installed` gets a second dialog — exactly what the app does when an "successful" install still leaves torch unimportable
- Checkpoint validation happens before any case is fed, keeping the brass in the hopper
- AI Config users

https://claude.ai/code/session_01DGkPJAokoSxzH5BkQzbxFj