### PR TITLE
docs: document DCO enforcement and how to fix a missed sign-off

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -182,3 +182,14 @@ git commit -s -m "Your message"
 
 This appends a `Signed-off-by: Your Name <you@example.com>` line to the commit.
 The full DCO text is at <https://developercertificate.org>.
+
+Forgot on a commit you have already made?
+
+```bash
+git commit --amend -s                 # the most recent commit
+git rebase --signoff origin/main      # every commit on your branch
+git push --force-with-lease
+```
+
+Enforced by the [DCO app](https://github.com/apps/dco), which posts a `DCO`
+status on each pull request and skips bot and merge commits.


### PR DESCRIPTION
## Description

`CONTRIBUTING.md` and the PR template ask for `git commit -s`, but never say what checks it — and nothing does.

PR #21's head commit carries 16 check runs (pytest matrix, ruff, workflow lint, PR title, labeler, launcher/installer smoke, CodeQL, Snyk) and **none is a DCO check**, so the [DCO app](https://github.com/apps/dco) isn't installed. The rule is honour-system, and it shows: of the last 12 commits on `main`, 4 are unsigned — two Renovate commits, two merge commits — plus PR #21's own head commit `29b5280a`.

This documents the intent. Enforcing it is one admin click, below.

## Changes

`CONTRIBUTING.md` only, 11 lines: name the DCO app as the enforcement, note that it skips bot and merge commits, and add the remediation people otherwise have to go look up (`--amend -s`, `rebase --signoff`, `--force-with-lease`).

> **@sjseth — the enforcement needs repo-admin, one click:**
> https://github.com/apps/dco/installations/select_target
>
> Optionally add `DCO` to required status checks on `main` afterwards, so it blocks merges rather than just reporting.

## Notes on what this deliberately does *not* do

**No DCO workflow.** The app is the canonical implementation — actively maintained, no CI minutes, and its edge cases (merge commits, bots, members-only, remediation commits) are already solved. Both serious implementations are Apps (`dcoapp/app`, 339★; CNCF's `dco2`, a drop-in replacement). The available Actions are 4–15★ hobby projects, one stale since 2022 — a poor supply-chain trade for checking a text trailer.

**No Renovate sign-off config.** Considered and dropped: `dcoapp/app` exempts bots, so Renovate's PRs pass untouched and a `commitBody` trailer would be redundant.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#contributions--licensing-dco)
- [x] Tests pass locally — n/a, docs only
- [x] I have updated `CLAUDE.md` if this changes architecture, a module boundary, or a subsystem described there — n/a
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)