### PR TITLE
chore: turn Discussions off and route questions to the Discord

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,9 @@
+# Points at the project page rather than a raw discord.gg invite on purpose:
+# the invite lives behind a free account there, so publishing one here would
+# route around that, and it would rot the moment the invite is rotated. The
+# project page is the owner's own entry point and stays valid.
 blank_issues_enabled: false
 contact_links:
   - name: Question / usage help
-    url: https://github.com/sjseth/AI-Case-Sorter-Py/discussions
-    about: Please ask usage questions here rather than in an issue.
+    url: https://www.reloadingrecipes.com/HeadstampSorter
+    about: Ask in the project Discord — the invite is on the project page (free account).

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -40,7 +40,11 @@ repository:
   has_issues: true
   has_wiki: false
   has_projects: false
-  has_discussions: true # the issue templates route support questions here
+  # Off: the project's user community is the Discord, not a GitHub tab, and a
+  # second half-used venue only splits the audience and leaves questions
+  # unanswered. Support questions route to Discord via the issue-form contact
+  # link; this repo's Issues stay for bugs and features.
+  has_discussions: false
 
   # Squash-only. Merge commits and rebase both produce histories that break the
   # one assumption everything else here depends on: that each commit on main is

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,8 +12,8 @@ By participating in this project you agree to abide by our
 
 - Report bugs or request features via [GitHub Issues](https://github.com/sjseth/AI-Case-Sorter-Py/issues/new/choose)
   — pick the bug report or feature request form so we get what we need to reproduce it.
-- General questions belong in [Discussions](https://github.com/sjseth/AI-Case-Sorter-Py/discussions),
-  not Issues.
+- Ask usage questions in the project **Discord**, not Issues — the invite is on the
+  [project page](https://www.reloadingrecipes.com/HeadstampSorter) (free account).
 - Improve documentation — including [`CLAUDE.md`](CLAUDE.md), the architecture map.
 - Fix bugs or add features via pull requests (the PR template lists the checklist).
 - Report **security** issues privately — see [`SECURITY.md`](SECURITY.md). Please


### PR DESCRIPTION
## Description

`.github/settings.yml` declares `has_discussions: true`, but the tab is **off** on the live repo. So the two things that pointed at it were already dead ends for anyone who followed them:

- the issue-form contact link (`ISSUE_TEMPLATE/config.yml` → `/discussions`)
- `CONTRIBUTING.md`: *"General questions belong in Discussions, not Issues"*

This settles it in the direction the project actually works: the user community is the **Discord**. A second, half-used venue only splits the audience and leaves questions unanswered. Issues stay for bugs and features; usage questions go to Discord.

## Changes

| File | Change |
|---|---|
| `.github/settings.yml` | `has_discussions: false` |
| `.github/ISSUE_TEMPLATE/config.yml` | contact link → project page, worded as the Discord route |
| `CONTRIBUTING.md` | "General questions belong in Discussions" → Discord |

## ⚠️ Merging this applies the whole settings file for the first time

The Settings app was installed *after* `.github/settings.yml` landed on `main`, and installing it doesn't retroactively apply what's already there — it acts on a commit that touches the file. This PR is that commit. Live state confirms nothing has been applied yet.

So merging changes considerably more than the one line above. **Repository settings** (7):

| Setting | Now | After |
|---|---|---|
| `has_projects` | true | **false** |
| `allow_merge_commit` | true | **false** |
| `allow_rebase_merge` | true | **false** |
| `squash_merge_commit_title` | COMMIT_OR_PR_TITLE | **PR_TITLE** |
| `delete_branch_on_merge` | false | **true** |
| `allow_auto_merge` | false | **true** |
| `allow_update_branch` | false | **true** |

`has_discussions` is already `false` live, so that one is a no-op — this PR aligns the declaration with reality.

**Labels:** 16 exist, 24 are declared; the 11 missing ones get created (`ui`, `training`, `hardware`, `community`, `launcher`, `triage`, `bot-renovate-stop`, `security`, `needs-hardware-test`, `renovate-version-patch`, `renovate-version-digest`). Undeclared labels aren't deleted, so `duplicate`/`invalid`/`wontfix` stay — 27 total.

That last part fixes three things that are silently broken today: `labeler.yml` errors on labels that don't exist, the issue forms' `triage` label is being dropped, and the Renovate labels referenced in `renovate.json5` do nothing.

Note that merge commits and rebase merges being turned off is a real behavioural change — squash-only from then on, which is what the file intends (each commit on `main` has to be a Conventional Commits subject `git-cliff` can derive a version from).

All of this is already-reviewed content in the file; it just hasn't taken effect until now. Flagging it so it isn't a surprise.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#contributions--licensing-dco)
- [x] Tests pass locally — n/a, no code change
- [x] I have updated `CLAUDE.md` if this changes architecture, a module boundary, or a subsystem described there — n/a
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)