### PR TITLE
ci: manage the deployment environments and flag settings PRs

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -68,3 +68,12 @@ dependencies:
           - 'pyproject.toml'
           - 'uv.lock'
   - head-branch: ['^renovate/', '^dependabot/']
+
+# Deliberately loud, and the only label here that is a warning rather than a
+# classification. Merging a PR that touches this file does not just change a
+# file: the Settings app applies it to the live repository. Some of what it can
+# change is invisible in a diff of it -- merge methods, branch protection, who
+# is allowed to approve a deployment.
+"⚠️ REPO SETTINGS":
+  - changed-files:
+      - any-glob-to-any-file: '.github/settings.yml'

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -29,12 +29,6 @@
 #      no equivalent here, so those two stay manual. The wanted state is
 #      alerts ON, automated fixes OFF: Renovate owns dependency PRs here, and
 #      running both bots opens duplicate PRs for the same CVE.
-#
-# NOTE ON BRANCH PROTECTION: the `branches:` block below is commented out on
-# purpose. Requiring an approving review makes it impossible to merge your own
-# PR (GitHub won't let you approve your own), which locks a solo maintainer or
-# a fork owner out of their own repo. Uncomment it upstream, where PRs get an
-# actual second pair of eyes -- see the comment on that block.
 
 repository:
   has_issues: true
@@ -172,14 +166,14 @@ labels:
 #
 # Free on public repos; protection rules only cost money on private ones.
 #
-# No deployment_branch_policy on purpose. `protected_branches: true` would
-# restrict deployments to protected branches, and (a) nothing is protected here
-# yet -- the branches: block above is commented out -- and (b) these jobs run on
-# `release` events, where the ref is a tag, not a branch. Either alone would
-# block every deployment.
 # Both gated by the same reviewer, so a release takes two approvals: one before
 # the TestPyPI rehearsal, one before the PyPI publish. Nothing reaches an index
 # without a human saying so.
+#
+# No deployment_branch_policy on purpose. `protected_branches: true` restricts
+# deployments to protected branches, and these jobs run on `release` events
+# where the ref is a tag rather than a branch -- it would block every
+# deployment.
 environments:
   # TestPyPI, the rehearsal.
   - name: test
@@ -191,27 +185,3 @@ environments:
     reviewers:
       - id: 3073671 # sjseth
         type: User
-
-# Uncomment upstream. Deliberately inactive by default -- see the note at the
-# top: required_approving_review_count: 1 prevents a solo maintainer from
-# merging their own PR at all.
-#
-# branches:
-#   - name: main
-#     protection:
-#       required_pull_request_reviews:
-#         required_approving_review_count: 1
-#         dismiss_stale_reviews: true
-#         require_code_owner_reviews: false
-#       required_status_checks:
-#         strict: true
-#         contexts:
-#           - "ruff (check + format)"
-#           - "lint the workflows themselves"
-#           - "release version mapping"
-#           - "pytest (ubuntu-latest, py3.12)"
-#           - "pytest (windows-latest, py3.12)"
-#           - "Validate PR title"
-#       required_conversation_resolution: true
-#       enforce_admins: false
-#       restrictions: null

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -151,6 +151,43 @@ labels:
     color: "d876e3"
     description: "Further information is requested"
 
+  # Applied by labeler.yml on any PR touching .github/settings.yml. Merging one
+  # of those does not just change a file -- the Settings app applies it to the
+  # live repo, including things no diff makes obvious (merge methods, branch
+  # protection, who can approve a deployment). Loud on purpose.
+  - name: "⚠️ REPO SETTINGS"
+    color: "b60205"
+    description: "⚠️ Changes .github/settings.yml -- merging APPLIES it to the live repository"
+
+# Deployment environments, referenced by .github/workflows/publish.yml.
+#
+# `stable` is the PyPI publish, and it is the one irreversible step in the whole
+# release: a version can be yanked but never replaced. The reviewer requirement
+# is the in-flow confirmation before that happens -- the job sits pending until
+# somebody approves it.
+#
+# Free on public repos; protection rules only cost money on private ones.
+#
+# No deployment_branch_policy on purpose. `protected_branches: true` would
+# restrict deployments to protected branches, and (a) nothing is protected here
+# yet -- the branches: block above is commented out -- and (b) these jobs run on
+# `release` events, where the ref is a tag, not a branch. Either alone would
+# block every deployment.
+# Both gated by the same reviewer, so a release takes two approvals: one before
+# the TestPyPI rehearsal, one before the PyPI publish. Nothing reaches an index
+# without a human saying so.
+environments:
+  # TestPyPI, the rehearsal.
+  - name: test
+    reviewers:
+      - id: 3073671 # sjseth
+        type: User
+
+  - name: stable
+    reviewers:
+      - id: 3073671 # sjseth
+        type: User
+
 # Uncomment upstream. Deliberately inactive by default -- see the note at the
 # top: required_approving_review_count: 1 prevents a solo maintainer from
 # merging their own PR at all.

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -151,7 +151,7 @@ jobs:
       (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
     runs-on: ubuntu-latest
     environment:
-      name: prod
+      name: stable
       url: https://pypi.org/p/ai-case-sorter
     permissions:
       id-token: write # required for trusted publishing (OIDC) -- no API token stored


### PR DESCRIPTION
## Description

`publish.yml` names two environments — `test` and `prod` — that **don't exist**. The repo has zero environments configured. GitHub auto-creates one on first use with no protection rules at all, so the `prod` block was decoration: the PyPI publish, the single irreversible step in a release, had no gate on it.

This declares them as code, with a required reviewer, *before* the day `PYPI_PUBLISH_ENABLED` gets switched on.

## Changes

**`.github/settings.yml`** — new `environments:` block:

```yaml
environments:
  - name: test
    reviewers:
      - id: 3073671   # sjseth
        type: User
  - name: stable
    reviewers:
      - id: 3073671   # sjseth
        type: User
```

Both gated by the same reviewer, so a release takes two approvals: one before the TestPyPI rehearsal, one before the PyPI publish. Nothing reaches an index without a human saying so.

**`publish.yml`** — `prod` → `stable`, matching the vocabulary the project already uses for the non-prerelease channel (`/releases/latest`, "stable users" in `CLAUDE.md`).

**New `⚠️ REPO SETTINGS` label** (red), applied by `labeler.yml` to any PR touching `.github/settings.yml`. Merging one of those doesn't just change a file — the Settings app applies it to the live repository, and some of what it can change (merge methods, branch protection, who may approve a deployment) isn't obvious from the diff. This PR carries it.

## Notes

**Cost:** environment protection rules are free on public repositories. The paid tier only applies to private/internal repos.

**No `deployment_branch_policy`, deliberately.** `protected_branches: true` restricts deployments to protected branches, and (a) nothing is protected here yet — the `branches:` block in `settings.yml` is commented out — and (b) these jobs run on `release` events, where the ref is a tag, not a branch. Either alone would block every deployment.

**Reviewer is a numeric user ID**, not a username — that's the API's shape, and the Settings app passes it through. `3073671` is `sjseth`, verified via the API.

**This won't take effect until the Settings app applies the file.** The app was installed after `settings.yml` was already on `main`, and installing doesn't retroactively apply — it acts on a commit touching the file. This is such a commit, so merging it applies the whole file, including the seven repository settings and eleven labels that are currently declared but not live. Same caveat as #23; whichever merges second is a no-op for the parts the first already applied.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#contributions--licensing-dco)
- [x] Tests pass locally — n/a, no code change
- [x] I have updated `CLAUDE.md` if this changes architecture, a module boundary, or a subsystem described there — n/a
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)