### PR TITLE
ci: improve the release flow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Callable so release.yml can gate a release on the same checks that
+  # guard main, rather than reimplementing them.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,7 +59,7 @@ jobs:
         if: runner.os == 'Windows'
         run: uv run --locked --python ${{ matrix.python-version }} pytest -q --junitxml=build/junit.xml
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
         with:
           name: junit-${{ matrix.os }}-py${{ matrix.python-version }}
@@ -80,7 +80,7 @@ jobs:
       # The version here is just what runs bootstrap.py itself -- bootstrap.py
       # provisions the app's actual interpreter separately via uv, per
       # .python-version. That decoupling is the whole point being tested.
-      - uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6.3.0
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: "3.13"
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,6 +7,9 @@ on:
   # Callable so release.yml can gate a release on the same checks that
   # guard main, rather than reimplementing them.
   workflow_call:
+  # Manual runs: re-running the matrix against main without pushing anything,
+  # e.g. to check a flake or a newly released Python.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -7,10 +7,8 @@ name: Verify Installer
 # repo with none yet it would only ever hit the "no release, fall back to
 # the source zip" branch. So this gets its own trigger rather than
 # build.yml's blanket one: path-filtered on PR/push (fast feedback exactly
-# when the script itself changes, near-zero cost otherwise), plus
-# release:published -- the single most realistic moment, since the default
-# checkout for that event resolves to the tagged commit, testing the
-# installer as it existed at release time against the release just cut.
+# when the script itself changes, near-zero cost otherwise), plus a
+# workflow_call so release.yml can run it against the release it just cut.
 #
 # The workflow file is in its own path filter: without that, a PR editing
 # only this file never runs the job it changes.
@@ -24,8 +22,23 @@ on:
     paths:
       - "installer/**"
       - ".github/workflows/installer-smoke.yml"
-  release:
-    types: [published]
+
+  # Called by release.yml, rather than triggering on release:published.
+  #
+  # Two reasons it cannot be a release trigger. The sdist this exercises is
+  # attached by the release job, and release:published fires alongside that
+  # upload -- the race lands on the "no matching asset, fall back to the source
+  # archive" branch and fails on the missing _version.py, which is exactly what
+  # happened on the 1.0.0 rename. And the release under test is a *prerelease*
+  # at this point, which /releases/latest deliberately excludes, so the default
+  # installer path would verify the previous release and pass while proving
+  # nothing about this one.
+  workflow_call:
+    inputs:
+      tag:
+        description: "Release tag to verify. Omit to test whatever /releases/latest resolves to."
+        required: false
+        type: string
 
 permissions:
   contents: read
@@ -59,9 +72,25 @@ jobs:
       #
       # -NoLaunch keeps this scoped to install + extract; the full
       # bootstrap.py/uv-sync path is launcher-smoke's job, not this one's.
+      #
+      # -Version pins the release under test when one is passed in. Without it
+      # the script resolves /releases/latest, which is the wrong target twice
+      # over during a release: the new release is still a prerelease and so
+      # excluded from `latest`, and any concurrent release would decide what
+      # gets tested. On the path/PR triggers no tag is passed and `latest` is
+      # the right answer.
       - name: Run the installer for real
         shell: powershell
-        run: .\installer\install-windows.ps1 -Repo $env:GITHUB_REPOSITORY -NoLaunch
+        env:
+          TAG: ${{ inputs.tag }}
+        run: |
+          if ($env:TAG) {
+            Write-Host "Verifying release $env:TAG"
+            .\installer\install-windows.ps1 -Repo $env:GITHUB_REPOSITORY -Version $env:TAG -NoLaunch
+          } else {
+            Write-Host "Verifying whatever /releases/latest resolves to"
+            .\installer\install-windows.ps1 -Repo $env:GITHUB_REPOSITORY -NoLaunch
+          }
 
       # The real assertion: not "the script exited 0" but "a working install
       # landed with the version the sdist actually carries" -- proves the
@@ -73,6 +102,8 @@ jobs:
       # The rejection half is the earlier step's job.
       - name: Verify the install
         shell: powershell
+        env:
+          TAG: ${{ inputs.tag }}
         run: |
           $dest = "$env:LOCALAPPDATA\Programs\CaseSorter"
           if (-not (Test-Path "$dest\main.py")) {
@@ -87,7 +118,21 @@ jobs:
           $content = Get-Content $versionFile -Raw
           Write-Host "----- sorter/_version.py -----"
           Write-Host $content
-          if ($content -notmatch "__version__\s*=.*'[0-9]") {
+          if ($content -notmatch "__version__\s*=.*'([0-9][^']*)'") {
             Write-Error "sorter/_version.py does not carry a real version."
             exit 1
+          }
+          $installed = $Matches[1]
+
+          # When a tag was passed, "a real version" is not enough -- it has to
+          # be *this* release. Anything else means the installer matched some
+          # other release's asset, which is precisely the silent degradation
+          # this job exists to catch.
+          if ($env:TAG) {
+            $expected = $env:TAG -replace '^v', ''
+            if ($installed -ne $expected) {
+              Write-Error "Installed version '$installed' is not the release under test ('$expected')."
+              exit 1
+            }
+            Write-Host "Installed version matches the release under test: $installed"
           }

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -40,6 +40,16 @@ on:
         required: false
         type: string
 
+  # Manual runs, with the same optional pin. Useful when /releases/latest is not
+  # the release you want to check -- including the case where it predates a
+  # package rename and so carries an sdist the current installer cannot match.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Release tag to verify. Omit to test whatever /releases/latest resolves to."
+        required: false
+        type: string
+
 permissions:
   contents: read
 
@@ -70,6 +80,27 @@ jobs:
       # calls out by name for its BOM/codepage decoding quirks -- pwsh would
       # not exercise that at all.
       #
+      # Cheap up-front diagnosis. When this job fails it is usually not the
+      # installer being broken but the release it resolved to not carrying an
+      # sdist under the name the installer matches -- after a package rename
+      # every release cut before it is in exactly that state, and the symptom
+      # is an unhelpful "sorter\_version.py is missing" three steps later.
+      - name: Show the release under test
+        shell: bash
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ inputs.tag }}
+        run: |
+          if [ -n "$TAG" ]; then
+            ENDPOINT="releases/tags/$TAG"
+          else
+            ENDPOINT="releases/latest"
+          fi
+          echo "Resolving $ENDPOINT"
+          gh api "repos/${GITHUB_REPOSITORY}/${ENDPOINT}" \
+            --jq '"tag: \(.tag_name)   prerelease: \(.prerelease)", "assets:", (.assets[].name | "  - \(.)")' \
+            || echo "::warning::No release at $ENDPOINT -- the installer will fall back to the source archive and this job will fail."
+
       # -NoLaunch keeps this scoped to install + extract; the full
       # bootstrap.py/uv-sync path is launcher-smoke's job, not this one's.
       #

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [main]
   pull_request:
+  # Callable so release.yml can gate a release on the same checks that
+  # guard main, rather than reimplementing them.
+  workflow_call:
 
 permissions:
   contents: read

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,10 @@ on:
   # Callable so release.yml can gate a release on the same checks that
   # guard main, rather than reimplementing them.
   workflow_call:
+  # Manual runs: the release-config job pins git-cliff's version mapping, which
+  # can drift when that tool is upgraded rather than when this repo changes --
+  # so it needs to be runnable without a commit to hang it on.
+  workflow_dispatch:
 
 permissions:
   contents: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,10 +1,16 @@
 name: Publish
 
+# No release: trigger any more -- release.yml owns the whole release, including
+# tagging, attaching artifacts, verification and publishing. Two workflows both
+# firing on release:published is what produced the race this replaced: the
+# installer check ran alongside the asset upload rather than after it.
+#
+# What is left here is the continuous half: build and check the packaging path
+# on every push to main, plus a manual escape hatch for publishing an already
+# built artifact.
 on:
   push:
     branches: [main]
-  release:
-    types: [published]
   workflow_dispatch:
     inputs:
       target:
@@ -26,8 +32,6 @@ jobs:
   package:
     name: Build and check
     runs-on: ubuntu-latest
-    permissions:
-      contents: write # only used by the release-upload step below
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -45,45 +49,6 @@ jobs:
       - name: Build
         run: uv build
 
-      # hatch-vcs reads the tag back from git rather than trusting the event
-      # payload; this catches them disagreeing, e.g. a dirty working tree
-      # making hatch-vcs append .devN+dirty to an otherwise-correct tag.
-      - name: Assert the built version matches the release tag
-        if: github.event_name == 'release'
-        env:
-          TAG: ${{ github.event.release.tag_name }}
-        run: |
-          BUILT="$(grep -oP "(?<=^__version__ = version = ')[^']+" sorter/_version.py)"
-          if [ "$BUILT" != "$TAG" ]; then
-            echo "::error::Built version '$BUILT' does not match release tag '$TAG' -- refusing to publish."
-            exit 1
-          fi
-
-      # The updater matches this filename exactly (updater._expected_asset_name)
-      # and silently falls back to the source archive when it misses -- losing
-      # the baked-in version the sdist exists to deliver. hatchling normalizes
-      # the version per PEP 440, so a tag like 1.2.3-rc1 builds as 1.2.3rc1 and
-      # would never match. Assert the name here so that fails the release
-      # instead of quietly degrading every client.
-      #
-      # Checked inside the artifact, not the workspace: that proves the file
-      # the updater downloads actually carries the version, rather than just
-      # proving hatch-vcs ran.
-      - name: Assert the sdist is named and stamped as the updater expects
-        if: github.event_name == 'release'
-        env:
-          TAG: ${{ github.event.release.tag_name }}
-        run: |
-          SDIST="dist/ai_case_sorter-${TAG#v}.tar.gz"
-          if [ ! -f "$SDIST" ]; then
-            echo "::error::Expected $SDIST; built $(ls dist/*.tar.gz). The updater matches by exact name and would fall back to the source archive."
-            exit 1
-          fi
-          if ! tar -tzf "$SDIST" | grep -qE '(^|/)sorter/_version\.py$'; then
-            echo "::error::$SDIST does not contain sorter/_version.py -- an install from it would report 0.0.0+unknown."
-            exit 1
-          fi
-
       - name: Check package metadata
         run: pipx run twine check --strict dist/*
 
@@ -92,40 +57,15 @@ jobs:
           name: dist
           path: dist/
 
-      # No separate app-archive build step: sorter/updater.py's _pick_asset
-      # downloads the sdist above by exact name (ai_case_sorter-<tag>.tar.gz).
-      # hatch-vcs's build hook already stamps sorter/_version.py into every
-      # build target, sdist included, so it carries the correct version with
-      # nothing extra to keep in sync. This used to be a hand-built zip
-      # (git archive + a manual copy of _version.py); that second build path
-      # was the actual cause of a real version mismatch once, so it's gone
-      # rather than fixed again.
-      #
-      # Attaches the wheel + sdist to the release that triggered this run --
-      # a real "pre-built download" story with zero PyPI dependency, live
-      # regardless of whether publish-to-pypi below is ever turned on.
-      #
-      # --clobber so a re-run replaces its own artifacts rather than failing
-      # half-uploaded: without it, an asset already present wins and the
-      # updater would serve whatever got there first.
-      - name: Attach artifacts to the release
-        if: github.event_name == 'release'
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          TAG: ${{ github.event.release.tag_name }}
-        run: gh release upload --clobber "$TAG" dist/*
-
-  # Gated behind a repo variable, unset = off, so merging this workflow
-  # changes nothing until a maintainer deliberately opts in (Settings ->
-  # Actions -> Variables -> PYPI_PUBLISH_ENABLED = true). A skipped job
-  # reports as skipped, not failed, and nothing here is in any other job's
-  # `needs:`, so a disabled or failing publish can never block a release.
+  # Manual only. The release path publishes from release.yml, where it is gated
+  # on the installer verification; these two exist for the case that needs a
+  # human anyway -- re-publishing after a transient index failure, or pushing a
+  # build to TestPyPI to look at. Reaching an index still requires approving the
+  # `test`/`stable` environment.
   publish-to-testpypi:
     name: Publish to TestPyPI
     needs: package
-    if: |
-      (github.event_name == 'release' && vars.PYPI_PUBLISH_ENABLED == 'true') ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi')
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'testpypi'
     runs-on: ubuntu-latest
     environment:
       name: test
@@ -146,12 +86,10 @@ jobs:
   publish-to-pypi:
     name: Publish to PyPI
     needs: package
-    if: |
-      (github.event_name == 'release' && vars.PYPI_PUBLISH_ENABLED == 'true') ||
-      (github.event_name == 'workflow_dispatch' && inputs.target == 'pypi')
+    if: github.event_name == 'workflow_dispatch' && inputs.target == 'pypi'
     runs-on: ubuntu-latest
     environment:
-      name: prod
+      name: stable
       url: https://pypi.org/p/ai-case-sorter
     permissions:
       id-token: write # required for trusted publishing (OIDC) -- no API token stored

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -52,7 +52,7 @@ jobs:
       - name: Check package metadata
         run: pipx run twine check --strict dist/*
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,33 @@
 name: Release
 
+# The whole release, start to finish, in one workflow.
+#
+# Previously this stopped at "draft release created" and publish.yml took over
+# on release:published. That split had two problems. Everything that verified
+# the release ran *after* it was public -- so a failure meant a bad release was
+# already live and already visible to every updater polling /releases/latest.
+# And publish.yml attached the sdist after publication, leaving a window (26
+# seconds, measured on 1.0.0) where the release existed with no matching asset
+# and clients silently fell back to the source archive.
+#
+# The shape that fixes both is to make the release *invisible* until it has been
+# verified:
+#
+#   prepare  ->  checks  ->  [approval]  ->  release (prerelease + assets)
+#                                              ->  verify installer
+#                                              ->  promote to latest
+#                                              ->  TestPyPI  ->  PyPI
+#
+# A prerelease is the key. It is publicly readable by exact tag, so the
+# installer can be run against it for real, but /releases/latest excludes it --
+# so updater.py and a default installer run cannot see it. If verification
+# fails, nothing was ever served: no user saw the release, and PyPI (the one
+# irreversible step) never ran.
+#
+# No draft anywhere. A draft would be invisible to the verification too --
+# /releases/tags/<tag> 404s for the unauthenticated fetch the installer does --
+# which is exactly why the release is a prerelease and not a draft.
+
 on:
   workflow_dispatch:
     inputs:
@@ -17,7 +45,7 @@ on:
         type: boolean
         default: false
       dry-run:
-        description: "Validate and preview only -- no tag pushed, no draft release created."
+        description: "Validate and preview only -- no checks run, no tag pushed, nothing published."
         required: false
         type: boolean
         default: true
@@ -30,10 +58,17 @@ permissions:
   contents: read
 
 jobs:
-  release:
+  # Resolves what would be released and writes the summary. Deliberately does
+  # nothing durable: a dry run is exactly this job and nothing else, so the
+  # preview costs one cheap job rather than a full pipeline.
+  prepare:
+    name: resolve version and notes
     runs-on: ubuntu-latest
-    permissions:
-      contents: write
+    outputs:
+      version: ${{ steps.resolve.outputs.version }}
+      auto: ${{ steps.resolve.outputs.auto }}
+      source: ${{ steps.resolve.outputs.source }}
+      previous: ${{ steps.previous.outputs.tag }}
     steps:
       - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
         with:
@@ -48,8 +83,8 @@ jobs:
         with:
           version: ${{ inputs.version }}
 
-      # Captured before "Push tag" creates the new tag at HEAD -- git
-      # describe run after that would find the just-created tag instead.
+      # Captured before the release job creates the new tag -- git describe run
+      # after that would find the just-created tag instead.
       - name: Record previous tag
         id: previous
         run: |
@@ -95,8 +130,8 @@ jobs:
             echo "source=$SOURCE"
           } >> "$GITHUB_OUTPUT"
 
-      # Also enforced in check-release.yml: this prevents before tagging,
-      # that catches a release made by hand in the UI.
+      # Also enforced in check-release.yml: this prevents before tagging, that
+      # catches a release made by hand in the UI.
       - uses: ./.github/actions/check-release-branch
         with:
           ref: ${{ inputs.ref || github.ref }}
@@ -115,40 +150,12 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: git-cliff --config cliff.toml --latest --unreleased --strip all --output NOTES.md
 
-      # persist-credentials: false means `origin` has no auth; push to an
-      # explicit tokenised URL rather than leaving one in .git/config.
-      - name: Push tag
-        if: ${{ !inputs.dry-run }}
-        env:
-          VERSION: ${{ steps.resolve.outputs.version }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          REPO: ${{ github.repository }}
-        run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git tag "$VERSION"
-          git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$VERSION"
-
-      - name: Create draft GitHub Release
-        if: ${{ !inputs.dry-run }}
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VERSION: ${{ steps.resolve.outputs.version }}
-        run: |
-          # gh release create has no --json; it prints the URL on stdout.
-          DRAFT_URL=$(gh release create "$VERSION" \
-            --title "$VERSION" \
-            --notes-file NOTES.md \
-            --draft)
-          {
-            echo "### Release draft created"
-            echo ""
-            echo "**Version:** \`$VERSION\`"
-            echo ""
-            echo "**Draft URL:** $DRAFT_URL"
-            echo ""
-            echo "Review the draft and click **Publish release** to trigger the publish workflows."
-          } >> "$GITHUB_STEP_SUMMARY"
+      # Handed to the release job rather than regenerated there: the notes the
+      # reviewer approved are then provably the notes that ship.
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: release-notes
+          path: NOTES.md
 
       - name: Summary
         if: always()
@@ -164,10 +171,10 @@ jobs:
           # expand for both.
           if [ "$DRY_RUN" = "true" ]; then
             HEADING="Release (dry run)"
-            MODE="dry run -- no tag pushed, no release created"
+            MODE="dry run -- nothing tagged, nothing published"
           else
             HEADING="Release"
-            MODE="tag pushed, draft release created"
+            MODE="awaiting approval, then tag + prerelease + verify + publish"
           fi
           {
             echo "### $HEADING"
@@ -197,3 +204,240 @@ jobs:
             echo ""
             echo "</details>"
           } >> "$GITHUB_STEP_SUMMARY"
+
+  # The same checks that guard main, called rather than reimplemented, and run
+  # *before* the approval gate so the reviewer is approving something already
+  # green rather than a version string.
+  lint:
+    name: checks
+    needs: prepare
+    if: ${{ !inputs.dry-run }}
+    uses: ./.github/workflows/lint.yml
+    permissions:
+      contents: read
+
+  test:
+    name: checks
+    needs: prepare
+    if: ${{ !inputs.dry-run }}
+    uses: ./.github/workflows/build.yml
+    permissions:
+      contents: read
+
+  # THE APPROVAL GATE. `environment: stable` is what makes this job sit pending
+  # until a required reviewer approves it -- that is the in-flow confirmation,
+  # and by this point the summary above shows the version, the notes and a
+  # green check run.
+  #
+  # Environment protection rules are free on public repositories; the paid tier
+  # applies to private ones only.
+  release:
+    name: tag and create the prerelease
+    needs: [prepare, lint, test]
+    if: ${{ !inputs.dry-run }}
+    runs-on: ubuntu-latest
+    environment:
+      name: stable
+      url: ${{ steps.create.outputs.url }}
+    permissions:
+      contents: write
+    outputs:
+      version: ${{ needs.prepare.outputs.version }}
+    steps:
+      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+          fetch-tags: true
+          ref: ${{ inputs.ref || github.ref }}
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: release-notes
+
+      # Caching disabled deliberately: this job's output can end up on PyPI, so
+      # a cache-poisoning risk here is a supply-chain concern, not just a speed
+      # tradeoff -- unlike the routine test matrix, which has no publish step
+      # downstream.
+      - uses: astral-sh/setup-uv@c771a70e6277c0a99b617c7a806ffedaca235ff9 # v9.0.0
+        with:
+          enable-cache: false
+
+      # Tagged locally first, and pushed only once the artifacts built from it
+      # have been checked. hatch-vcs derives the version from `git describe`, so
+      # the tag has to exist before the build for the artifact to carry the
+      # right version -- but nothing is published to the world until the checks
+      # below pass.
+      - name: Create the tag locally
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag "$VERSION"
+
+      - name: Build
+        run: uv build
+
+      # hatch-vcs reads the tag back from git rather than trusting the input;
+      # this catches them disagreeing, e.g. a dirty working tree making
+      # hatch-vcs append .devN+dirty to an otherwise-correct tag.
+      - name: Assert the built version matches the tag
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          BUILT="$(grep -oP "(?<=^__version__ = version = ')[^']+" sorter/_version.py)"
+          if [ "$BUILT" != "$VERSION" ]; then
+            echo "::error::Built version '$BUILT' does not match '$VERSION' -- refusing to release."
+            exit 1
+          fi
+
+      # The updater matches this filename exactly (updater._expected_asset_name)
+      # and silently falls back to the source archive when it misses -- losing
+      # the baked-in version the sdist exists to deliver. hatchling normalizes
+      # the version per PEP 440, so a tag like 1.2.3-rc1 builds as 1.2.3rc1 and
+      # would never match.
+      #
+      # Checked inside the artifact, not the workspace: that proves the file the
+      # updater downloads actually carries the version, rather than just proving
+      # hatch-vcs ran.
+      - name: Assert the sdist is named and stamped as the updater expects
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          SDIST="dist/ai_case_sorter-${VERSION#v}.tar.gz"
+          if [ ! -f "$SDIST" ]; then
+            echo "::error::Expected $SDIST; built $(ls dist/*.tar.gz). The updater matches by exact name and would fall back to the source archive."
+            exit 1
+          fi
+          if ! tar -tzf "$SDIST" | grep -qE '(^|/)sorter/_version\.py$'; then
+            echo "::error::$SDIST does not contain sorter/_version.py -- an install from it would report 0.0.0+unknown."
+            exit 1
+          fi
+
+      - name: Check package metadata
+        run: pipx run twine check --strict dist/*
+
+      # persist-credentials: false means `origin` has no auth; push to an
+      # explicit tokenised URL rather than leaving one in .git/config.
+      - name: Push the tag
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+        run: git push "https://x-access-token:${GH_TOKEN}@github.com/${REPO}.git" "$VERSION"
+
+      # --prerelease is what keeps this invisible until verified: publicly
+      # readable by exact tag, so the installer can be run against it, but
+      # excluded from /releases/latest, so no updater and no default installer
+      # run can reach it yet.
+      #
+      # Assets are passed to `create` rather than uploaded afterwards, so the
+      # release never exists in a state where its sdist is missing.
+      - name: Create the prerelease with its artifacts
+        id: create
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          URL=$(gh release create "$VERSION" \
+            --title "$VERSION" \
+            --notes-file NOTES.md \
+            --prerelease \
+            dist/*)
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Prerelease created"
+            echo ""
+            echo "\`$VERSION\` -- $URL"
+            echo ""
+            echo "Not visible to updaters yet: \`/releases/latest\` excludes prereleases."
+            echo "It is promoted only if the installer verification below passes."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: dist
+          path: dist/
+
+  # Installs the release for real, on Windows, from the assets just attached --
+  # pinned to this tag, since /releases/latest would resolve to the *previous*
+  # release while this one is still a prerelease.
+  verify-installer:
+    name: verify
+    needs: [prepare, release]
+    uses: ./.github/workflows/installer-smoke.yml
+    permissions:
+      contents: read
+    with:
+      tag: ${{ needs.prepare.outputs.version }}
+
+  # The moment the release becomes real. One flag flip, with the assets already
+  # in place -- so there is no window where /releases/latest returns a release
+  # whose sdist has not landed yet.
+  promote:
+    name: promote to latest
+    needs: [prepare, verify-installer]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Promote the prerelease
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          VERSION: ${{ needs.prepare.outputs.version }}
+          REPO: ${{ github.repository }}
+        run: |
+          gh release edit "$VERSION" --repo "$REPO" --prerelease=false --latest
+          {
+            echo "### Released"
+            echo ""
+            echo "\`$VERSION\` is now the latest release. Updaters will pick it up."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+  # Gated behind a repo variable, unset = off, so this changes nothing until a
+  # maintainer deliberately opts in (Settings -> Actions -> Variables ->
+  # PYPI_PUBLISH_ENABLED = true).
+  publish-to-testpypi:
+    name: publish to TestPyPI
+    needs: promote
+    if: vars.PYPI_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: test
+      url: https://test.pypi.org/p/ai-case-sorter
+    permissions:
+      id-token: write # required for trusted publishing (OIDC) -- no API token stored
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          repository-url: https://test.pypi.org/legacy/
+          skip-existing: true
+
+  # Last, because it is the only step that cannot be undone: a PyPI version can
+  # be yanked but never replaced. Everything before it -- the tag, the release,
+  # even the promotion -- can be deleted and redone.
+  publish-to-pypi:
+    name: publish to PyPI
+    needs: [promote, publish-to-testpypi]
+    if: vars.PYPI_PUBLISH_ENABLED == 'true'
+    runs-on: ubuntu-latest
+    environment:
+      name: stable
+      url: https://pypi.org/p/ai-case-sorter
+    permissions:
+      id-token: write # required for trusted publishing (OIDC) -- no API token stored
+    steps:
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: dist
+          path: dist/
+
+      - uses: pypa/gh-action-pypi-publish@dc37677b2e1c63e2034f94d8a5b11f265b73ba33 # v1.14.2
+        with:
+          skip-existing: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -152,7 +152,7 @@ jobs:
 
       # Handed to the release job rather than regenerated there: the notes the
       # reviewer approved are then provably the notes that ship.
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: release-notes
           path: NOTES.md
@@ -355,7 +355,7 @@ jobs:
             echo "It is promoted only if the installer verification below passes."
           } >> "$GITHUB_STEP_SUMMARY"
 
-      - uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: dist
           path: dist/

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -22,9 +22,9 @@ jobs:
         with:
           persist-credentials: false
 
-      - uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6.5.0
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: "22"
+          node-version: "24"
 
       - name: Validate renovate.json5
         run: npx --yes --package renovate@44 -- renovate-config-validator .github/renovate.json5

--- a/.github/workflows/validate-renovate.yml
+++ b/.github/workflows/validate-renovate.yml
@@ -11,6 +11,10 @@ on:
       - ".github/renovate.json5"
       - ".github/workflows/validate-renovate.yml"
 
+  # Manual runs: Renovate's config schema evolves server-side, so a config that
+  # validated last month can break with no commit here to trigger a re-check.
+  workflow_dispatch:
+
 permissions:
   contents: read
 

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -28,15 +28,41 @@
      catches "meant 0.3.0, typed 0.2.0" before it becomes a tag.
    - `dry-run`: **defaults to on.** Shows the resolved version and generated notes in the job
      summary without pushing a tag or creating anything. Uncheck it to actually release.
-4. The workflow tags the chosen ref, generates changelog notes from commits since the last tag
-   via [git-cliff](https://git-cliff.org/) (`cliff.toml`), and opens a **draft** GitHub
-   Release with those notes. Nothing is published automatically -- review the draft and click
-   **Publish release** yourself.
-5. Publishing the release triggers `check-release.yml`, which validates the tag format and
-   target branch. (Publishing a release also triggers whatever's wired to `release: published`
-   in the future -- e.g. attaching build artifacts and, if enabled, publishing to PyPI.
-   Artifact attachment is live; PyPI publishing ships disabled, gated on the repo variable
-   `PYPI_PUBLISH_ENABLED`, which is unset by default.)
+4. The workflow resolves the version and generates changelog notes from commits since the last
+   tag via [git-cliff](https://git-cliff.org/) (`cliff.toml`), then puts both in the job
+   summary. **A dry run stops here** -- nothing else has happened.
+5. Lint and the full test matrix run, so what you approve next is already green.
+6. **The run pauses for approval.** The job that tags is bound to the `stable` environment, so
+   it sits pending until a required reviewer approves it on the run page. There is no draft to
+   publish by hand -- this is the confirmation step.
+7. On approval it tags the ref, builds, checks the artifacts (built version matches the tag;
+   the sdist is named and stamped as the updater expects), pushes the tag, and creates the
+   GitHub Release **as a prerelease with its artifacts already attached**.
+8. The Windows installer is run for real against that exact tag, and the resulting install has
+   to carry that exact version.
+9. Only then is the prerelease promoted to the latest release -- one flag flip, assets already
+   in place.
+10. Finally TestPyPI, then PyPI. Both are gated on the repo variable `PYPI_PUBLISH_ENABLED`,
+    unset by default, and each waits on its environment's reviewer.
+
+### Why a prerelease rather than a draft
+
+The release has to be verifiable before anyone can reach it, and those two pull in opposite
+directions. A draft is invisible to the verification too: `/releases/tags/<tag>` returns 404 to
+the unauthenticated fetch the installer makes, so there would be nothing to install.
+
+A prerelease is readable by exact tag, but `/releases/latest` excludes it -- and that is the
+endpoint both `sorter/updater.py` and `install-windows.ps1` use. So the release is fully
+testable while staying invisible to every real client until step 9.
+
+If verification fails the release stays a prerelease: nobody was served it, and PyPI never ran.
+The tag and prerelease are left in place for a human to delete or supersede -- fixing forward
+with a patch version is usually cleaner than deleting a pushed tag.
+
+This also closes a window that used to exist: artifacts were attached *after* publication, so
+for a short time (26 seconds, measured on 1.0.0) `/releases/latest` returned a release with no
+matching sdist, and clients silently fell back to the source archive and installed something
+reporting `0.0.0+unknown`.
 
 ## Versioning
 


### PR DESCRIPTION
## The problem

Nothing verified a release until after it was public, and two workflows raced.

`release.yml` stopped at a draft. Publishing it fired `publish.yml` and `installer-smoke.yml` **simultaneously**, so the installer check ran alongside the asset upload rather than after it — and the release was already live and visible to every updater polling `/releases/latest` before either finished. Measured on 1.0.0:

```
15:52:24  release published   → /releases/latest returns 1.0.0
15:52:50  artifacts attached  → sdist + wheel appear
```

For those 26 seconds the release existed with no matching sdist. Both `updater.py` and `install-windows.ps1` resolve `/releases/latest` and match by exact filename, so anyone updating in that window fell back to the source archive and installed a build reporting `0.0.0+unknown`. That is the same failure `installer-smoke` reported during the project rename — the check working, not the check being wrong.

## The new flow

```
prepare → checks → ⏸ approval → prerelease + assets
                                  → verify installer
                                  → promote to latest
                                  → TestPyPI → PyPI
```

Everything before the approval is reversible, so the reviewer confirms something already green rather than a version string. PyPI is last because it is the only step that cannot be undone.

## Why a prerelease, not a draft

The release has to be verifiable before anyone can reach it, and those two pull in opposite directions:

- A **draft** is invisible to the verification too — `/releases/tags/<tag>` 404s for the unauthenticated fetch the installer makes.
- A **prerelease** is readable by exact tag, but `/releases/latest` excludes it — and that is the endpoint both clients use.

So it is fully testable while invisible to every real client until promotion. No draft, no manual publish click. If verification fails, nothing was served, PyPI never ran, and the tag + prerelease stay for a human to delete or supersede.

## Changes

| File | Change |
|---|---|
| `release.yml` | rewritten into the 8-job pipeline above |
| `installer-smoke.yml` | `release: published` → `workflow_call` with a `tag` input; installer pinned with `-Version`; asserts the installed version **is the one under test** |
| `publish.yml` | loses its `release:` trigger; keeps build-on-main + manual publish |
| `lint.yml`, `build.yml` | gain `workflow_call` so the release runs the same checks that guard main |
| all four check workflows | gain `workflow_dispatch` |
| `RELEASING.md` | documents the flow and the prerelease rationale |

## Verified end to end

Run on my fork, full pipeline including the approval gate:

- **0.2.0** — checks → prerelease → installer verification → promoted
- **0.2.1** — same, with the gate engaged and approved ([run](https://github.com/jimisola/AI-Case-Sorter-Py/actions/runs/31030550553))

Both produced correctly-named assets and promoted cleanly. `PYPI_PUBLISH_ENABLED` unset, so the publish jobs skipped.

## What this needs from you

The `test` and `stable` environments must exist **with a required reviewer**. GitHub auto-creates them on first use with *no* protection rules — which is exactly what happened on my fork, and the first release ran straight through without asking. #24 declares them in `settings.yml`; otherwise Settings → Environments.

`prod` is renamed to `stable` to match the vocabulary already used for the non-prerelease channel.

`actionlint` 1.7.7 (the version `lint.yml` pins) — clean.