### PR TITLE
ci: settle the Renovate/Dependabot split and turn on branch protection

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -35,11 +35,25 @@
     enabled: true,
   },
 
+  // Renovate fixes CVEs; Dependabot only reports them. This reads GitHub's
+  // Dependabot alerts, so it is inert unless settings.yml's
+  // `enable_vulnerability_alerts` is applied.
+  //
+  // Renovate defaults this block to `minimumReleaseAge: null` and
+  // `prCreation: "immediate"`, so the soak times below never delay a security
+  // fix -- they guard against a freshly published malicious version, which is
+  // the opposite situation.
   vulnerabilityAlerts: {
     enabled: true,
     addLabels: ["security"],
+    // Not the usual `chore`: puts a CVE fix in cliff.toml's Security group
+    // rather than Miscellaneous, matching Dependabot's prefix for the same
+    // change. Accepted type in check-semantic-pr.yml.
+    semanticCommitType: "security",
   },
 
+  // OSV.dev directly rather than GitHub's advisories -- a supplement to the
+  // above, not a substitute for it.
   osvVulnerabilityAlerts: true,
 
   packageRules: [

--- a/.github/settings.yml
+++ b/.github/settings.yml
@@ -24,17 +24,11 @@
 #
 #   1. labels: safe-settings nests them under `labels: { include: [...] }`
 #      (and supports `exclude:`); this format takes a flat `labels: [...]`.
-#   2. security: safe-settings has a `repository.security` block with
-#      `enableVulnerabilityAlerts` / `enableAutomatedSecurityFixes`. There is
-#      no equivalent here, so those two stay manual. The wanted state is
-#      alerts ON, automated fixes OFF: Renovate owns dependency PRs here, and
-#      running both bots opens duplicate PRs for the same CVE.
-#
-# NOTE ON BRANCH PROTECTION: the `branches:` block below is commented out on
-# purpose. Requiring an approving review makes it impossible to merge your own
-# PR (GitHub won't let you approve your own), which locks a solo maintainer or
-# a fork owner out of their own repo. Uncomment it upstream, where PRs get an
-# actual second pair of eyes -- see the comment on that block.
+#   2. security: safe-settings puts these in a `repository.security` block as
+#      `enableVulnerabilityAlerts` / `enableAutomatedSecurityFixes`; this
+#      format takes them as flat `enable_vulnerability_alerts` /
+#      `enable_automated_security_fixes` keys inside `repository:`. Same
+#      effect, different spelling -- a rename if this file ever moves.
 
 repository:
   has_issues: true
@@ -61,8 +55,26 @@ repository:
   squash_merge_commit_message: COMMIT_MESSAGES
 
   delete_branch_on_merge: true
+  # Required for Renovate's `platformAutomerge` -- without it Renovate merges
+  # the PR itself rather than GitHub holding it until the checks pass. The
+  # branches block below is the other half: GitHub only offers auto-merge on a
+  # branch that requires something.
   allow_auto_merge: true
   allow_update_branch: true
+
+  # The Renovate/Dependabot boundary: Dependabot detects, Renovate fixes.
+  # There is deliberately no .github/dependabot.yml -- Renovate covers both
+  # ecosystems here (pypi, github-actions), and without that file Dependabot
+  # opens nothing.
+  #
+  # Alerts ON is load-bearing: Renovate's `vulnerabilityAlerts` reads them, so
+  # with alerts off that block is inert and coverage narrows to OSV silently.
+  # Automated fixes OFF is the toggle that would have Dependabot open PRs of
+  # its own -- two bots fixing the same CVE, and its PR titles are not
+  # Conventional Commits, which check-semantic-pr.yml rejects and git-cliff
+  # needs.
+  enable_vulnerability_alerts: true
+  enable_automated_security_fixes: false
 
 # Referenced by .github/labeler.yml, which auto-applies them by changed path.
 # actions/labeler does NOT create labels -- it errors on any that don't exist,
@@ -155,26 +167,39 @@ labels:
     color: "d876e3"
     description: "Further information is requested"
 
-# Uncomment upstream. Deliberately inactive by default -- see the note at the
-# top: required_approving_review_count: 1 prevents a solo maintainer from
-# merging their own PR at all.
-#
-# branches:
-#   - name: main
-#     protection:
-#       required_pull_request_reviews:
-#         required_approving_review_count: 1
-#         dismiss_stale_reviews: true
-#         require_code_owner_reviews: false
-#       required_status_checks:
-#         strict: true
-#         contexts:
-#           - "ruff (check + format)"
-#           - "lint the workflows themselves"
-#           - "release version mapping"
-#           - "pytest (ubuntu-latest, py3.12)"
-#           - "pytest (windows-latest, py3.12)"
-#           - "Validate PR title"
-#       required_conversation_resolution: true
-#       enforce_admins: false
-#       restrictions: null
+# This block used to be commented out wholesale because
+# `required_approving_review_count: 1` locks a solo maintainer out of their own
+# repo -- GitHub won't let you approve your own PR. Only the count needed
+# relaxing, so only the count is relaxed: 0 still requires a *pull request*,
+# still runs the checks, still resolves conversations. Raise it to 1 on any
+# repo with a second maintainer and change nothing else.
+branches:
+  - name: main
+    protection:
+      required_pull_request_reviews:
+        required_approving_review_count: 0
+        # On at 0 so an approval can't outlive the commits it approved, and so
+        # raising the count inherits the right behaviour.
+        dismiss_stale_reviews: true
+        require_code_owner_reviews: false
+
+      required_status_checks:
+        # The branch must be current with main to merge; Renovate rebases its
+        # own branches to satisfy this.
+        strict: true
+        contexts:
+          - "ruff (check + format)"
+          - "lint the workflows themselves"
+          - "release version mapping"
+          - "pytest (ubuntu-latest, py3.12)"
+          - "pytest (windows-latest, py3.12)"
+          - "Validate PR title"
+
+      # Off by default on GitHub: a review comment can't be merged past
+      # without being answered or explicitly resolved.
+      required_conversation_resolution: true
+
+      # False so an admin can bypass a broken required check without turning
+      # protection off in a hurry and forgetting to turn it back on.
+      enforce_admins: false
+      restrictions: null

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -68,10 +68,14 @@ jobs:
       - name: Install yamllint
         run: pip install yamllint==1.38.0
 
+      # settings.yml and labeler.yml are named explicitly: both fail silently
+      # when malformed -- the Settings app reports a bad config in a UI nobody
+      # opens, and actions/labeler just skips.
       - name: yamllint
         run: |
           yamllint -d "{extends: relaxed, rules: {line-length: {max: 200}}}" \
-            .github/workflows/ .github/actions/
+            .github/workflows/ .github/actions/ \
+            .github/settings.yml .github/labeler.yml
 
   # cliff.toml decides the released version, so a wrong answer here ships a
   # wrong release. The test skips without git-cliff, hence a job that installs it.


### PR DESCRIPTION
## What & Why

Renovate already covers both ecosystems in this repo — `pypi` via `pyproject.toml`/`uv.lock`, and `github-actions` — so Dependabot's job here is detection only. Nothing said so, and the comment that came closest to saying it was wrong.

**`settings.yml` can control both Dependabot toggles after all.** `enable_vulnerability_alerts` and `enable_automated_security_fixes` are real keys of repository-settings/app's [repository plugin](https://github.com/repository-settings/app/blob/master/lib/plugins/repository.js) ([docs](https://github.com/repository-settings/app/blob/master/docs/plugins/repository.md)) — the plugin pulls them out and calls the `/vulnerability-alerts` and `/automated-security-fixes` endpoints. The file's header claimed there was no equivalent to safe-settings' security block and left both manual.

- **Alerts ON** is load-bearing, not belt-and-braces: Renovate's `vulnerabilityAlerts` reads *GitHub's* Dependabot alerts. With alerts off it is inert and CVE coverage narrows to whatever `osvVulnerabilityAlerts` turns up, with no error anywhere.
- **Automated fixes OFF** — that's the toggle that makes Dependabot open PRs. Renovate already fixes CVEs promptly (it defaults that block to `minimumReleaseAge: null` / `prCreation: immediate`, so the 3/7/14-day soak times never delay a security fix), and Dependabot's PR titles are not Conventional Commits, which `check-semantic-pr.yml` rejects and git-cliff needs.
- **No `.github/dependabot.yml`.** Without one Dependabot opens nothing, so the file would only pre-stage config for a scenario nobody has asked for. The reasoning is recorded in `settings.yml` instead.

**Renovate's CVE PRs now use `semanticCommitType: "security"`**, so a fix lands in `cliff.toml`'s Security group — top of the release notes — instead of Miscellaneous.

**Branch protection is active.** It had been commented out wholesale to work around one setting: a required approving review locks a solo maintainer out of their own repo, since GitHub won't let you approve your own PR. Only the count needed relaxing, so only the count is relaxed — `required_approving_review_count: 0` still requires a *pull request*, still runs the checks. The rest is enabled: required status checks, `dismiss_stale_reviews`, `required_conversation_resolution`. Raising the count to 1 is now a one-line change. It also gives GitHub something to hold a PR on, without which `platformAutomerge` has no auto-merge button to drive and Renovate merges by itself.

**yamllint** extended to `settings.yml` and `labeler.yml`, both of which fail *silently* when malformed.

No action or tool versions are touched.

## Test Plan

- [x] `renovate-config-validator .github/renovate.json5` — passes
- [x] `yamllint` with the repo's exact config over workflows, actions, `settings.yml`, `labeler.yml` — clean
- [x] All six `required_status_checks.contexts` verified against the actual job `name:` values in `lint.yml`, `build.yml`, `check-semantic-pr.yml`
- [x] `security` confirmed as an accepted type in `check-semantic-pr.yml` and as a `cliff.toml` commit-parser group

## Note

No Settings app is installed on my fork, so I could only verify this file's *format*, not its application. Worth knowing before merging: if no app is installed here either, `settings.yml` remains documentation and the two security toggles have to be set by hand under Settings → Advanced Security.