### PR TITLE
test: cover the serial parser, event bus and DB migrations; unify the legacy-DB fixture

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,7 @@ jobs:
     outputs:
       version: ${{ needs.prepare.outputs.version }}
     steps:
-      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -244,7 +244,7 @@ jobs:
     outputs:
       version: ${{ needs.prepare.outputs.version }}
     steps:
-      - uses: actions/checkout@fbc6f3992d24b796d5a048ff273f7fcc4a7b6c09 # v5.1.0
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
         with:
           persist-credentials: false
           fetch-depth: 0

--- a/tests/unit/_legacy_db.py
+++ b/tests/unit/_legacy_db.py
@@ -1,0 +1,104 @@
+"""One hand-written pre-SCHEMA_VERSION database, shared by the migration tests.
+
+Three modules used to carry their own copy of a "legacy" schema
+(`test_db.py`, `test_headstamp_parents.py`, `test_parent_runtime.py`), which
+meant three things to keep in step and three chances to drift.
+
+The tables are deliberately kept to the **minimum the inserts need**. An
+earlier version of this helper reproduced the current `models` DDL verbatim,
+all 24 columns of it, which made the fixture look like it covered a
+`models` migration when no such migration exists — `_apply_column_migrations`
+only ever touches `headstamps.parent_id` and `headstamp_parents.slot`. A
+genuinely old `models` table is left exactly as it is found. Keeping the
+fixture minimal states that honestly and cannot drift out of date, since
+there is nothing here to keep in sync. That gap is issue #44.
+"""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+# The columns `models` carried before any of the later additions. Everything
+# the current DDL has beyond this is what a real legacy DB would be *missing*
+# — and would go on missing, because nothing migrates this table.
+LEGACY_MODEL_COLUMNS = {"id", "name", "cartridge_id", "model_mode"}
+
+
+def write_legacy_db(
+    path: Path,
+    *,
+    user_version: int,
+    with_parents_table: bool,
+    with_parent_id: bool = False,
+) -> None:
+    """Lay down a pre-SCHEMA_VERSION database by hand.
+
+    Only the tables the column migrations touch are given their *old* shape:
+    `headstamps` without `parent_id` (unless `with_parent_id`), and optionally
+    a `headstamp_parents` that carries no `slot` of its own. Everything else
+    is the minimum the seed rows below need.
+
+    Note `user_version` is essentially decorative: `_apply_column_migrations`
+    decides what to do by inspecting the columns that are actually present,
+    not by reading the stamp, so the same DB shape migrates identically at any
+    starting version. It is set only so the "did the stamp get bumped" assertion
+    has somewhere to start from.
+    """
+    conn = sqlite3.connect(path, isolation_level=None)
+    conn.executescript(
+        """
+        CREATE TABLE cartridges (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL UNIQUE
+        );
+        CREATE TABLE models (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL,
+          cartridge_id INTEGER NOT NULL,
+          model_mode TEXT NOT NULL DEFAULT 'convnext_tiny'
+        );
+        CREATE TABLE settings (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+        """
+    )
+    conn.execute(
+        "CREATE TABLE headstamps ("
+        "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+        "  name TEXT NOT NULL,"
+        "  model_id INTEGER NOT NULL,"
+        "  slot INTEGER NOT NULL DEFAULT 0,"
+        + ("  parent_id INTEGER," if with_parent_id else "")
+        + "  UNIQUE(model_id, name))"
+    )
+    if with_parents_table:
+        # Old shape: parents existed but carried no slot of their own.
+        conn.execute(
+            "CREATE TABLE headstamp_parents ("
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "  name TEXT NOT NULL,"
+            "  model_id INTEGER NOT NULL,"
+            "  UNIQUE(model_id, name))"
+        )
+
+    conn.execute("INSERT INTO cartridges(id, name) VALUES (1, '9mm')")
+    conn.execute("INSERT INTO models(id, name, cartridge_id, model_mode) VALUES (1, 'Legacy', 1, 'convnext_small')")
+    conn.execute("INSERT INTO headstamps(name, model_id, slot) VALUES ('WIN', 1, 3)")
+    conn.execute("INSERT INTO headstamps(name, model_id, slot) VALUES ('FC', 1, 5)")
+    if with_parents_table:
+        conn.execute("INSERT INTO headstamp_parents(id, name, model_id) VALUES (1, 'Winchester', 1)")
+    conn.execute("INSERT INTO settings(key, value) VALUES ('api', ?)", (json.dumps({"model": "legacy"}),))
+    conn.execute(f"PRAGMA user_version = {user_version}")
+    conn.close()
+
+
+def columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    """The column names of `table`.
+
+    `PRAGMA` cannot take a bound parameter in sqlite3, hence the f-string; the
+    table name is always a test literal.
+    """
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -3,12 +3,13 @@
 from __future__ import annotations
 
 import json
-import sqlite3
 from pathlib import Path
 
 import pytest
 
 from sorter.db import DEFAULT_CARTRIDGE_NAME, DEFAULT_MODEL_MODE, SCHEMA_VERSION, Database
+
+from ._legacy_db import LEGACY_MODEL_COLUMNS, columns, write_legacy_db
 
 
 def test_fresh_db_seeds_default_cartridge_and_model(tmp_path: Path) -> None:
@@ -100,105 +101,21 @@ def _user_version(db: Database) -> int:
     return db.conn.execute("PRAGMA user_version").fetchone()[0]
 
 
-def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
-    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
-
-
-def _write_legacy_db(path: Path, *, user_version: int, with_parents_table: bool) -> None:
-    """Lay down a pre-SCHEMA_VERSION database by hand.
-
-    Only the tables the column migrations touch are given their *old* shape:
-    `headstamps` without `parent_id`, and (optionally) `headstamp_parents`
-    without `slot`. Everything else is close enough to current that the
-    idempotent DDL leaves it alone.
-    """
-    conn = sqlite3.connect(path, isolation_level=None)
-    conn.execute("PRAGMA foreign_keys = ON")
-    conn.executescript(
-        """
-        CREATE TABLE cartridges (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          name TEXT NOT NULL UNIQUE
-        );
-        CREATE TABLE models (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          name TEXT NOT NULL,
-          cartridge_id INTEGER NOT NULL REFERENCES cartridges(id) ON DELETE RESTRICT,
-          model_mode TEXT NOT NULL
-            CHECK(model_mode IN ('convnext_tiny','convnext_small','convnext_base','convnext_large')),
-          model_type TEXT NOT NULL DEFAULT 'Standard'
-            CHECK(model_type IN ('Standard','ReadOnly','CommunityManaged')),
-          community_model_uid TEXT,
-          model_version INTEGER NOT NULL DEFAULT 1,
-          enable_image_processing INTEGER NOT NULL DEFAULT 1,
-          image_processing_json TEXT,
-          training_config_json TEXT,
-          ai_model_config_json TEXT,
-          use_primer_mask INTEGER NOT NULL DEFAULT 0,
-          hide_primer INTEGER NOT NULL DEFAULT 1,
-          primer_mask_size INTEGER NOT NULL DEFAULT 135,
-          last_training_date TEXT,
-          last_training_duration INTEGER NOT NULL DEFAULT 0,
-          trained_image_count INTEGER NOT NULL DEFAULT 0,
-          training_confusion_table TEXT,
-          feedback_loop_enabled INTEGER NOT NULL DEFAULT 0,
-          feedback_loop_confidence_floor INTEGER NOT NULL DEFAULT 95,
-          feedback_loop_upload_mode TEXT NOT NULL DEFAULT 'Manual',
-          model_path TEXT,
-          created_at TEXT NOT NULL DEFAULT (datetime('now')),
-          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
-        );
-        -- Old shape: no parent_id column.
-        CREATE TABLE headstamps (
-          id INTEGER PRIMARY KEY AUTOINCREMENT,
-          name TEXT NOT NULL,
-          model_id INTEGER NOT NULL REFERENCES models(id) ON DELETE CASCADE,
-          slot INTEGER NOT NULL DEFAULT 0,
-          UNIQUE(model_id, name)
-        );
-        CREATE TABLE settings (
-          key TEXT PRIMARY KEY,
-          value TEXT NOT NULL
-        );
-        """
-    )
-    if with_parents_table:
-        # Old shape: parents existed but carried no slot of their own.
-        conn.execute(
-            "CREATE TABLE headstamp_parents ("
-            "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
-            "  name TEXT NOT NULL,"
-            "  model_id INTEGER NOT NULL REFERENCES models(id) ON DELETE CASCADE,"
-            "  UNIQUE(model_id, name))"
-        )
-
-    cart_id = conn.execute("INSERT INTO cartridges(name) VALUES ('9mm')").lastrowid
-    model_id = conn.execute(
-        "INSERT INTO models(name, cartridge_id, model_mode) VALUES ('Legacy', ?, 'convnext_small')",
-        (cart_id,),
-    ).lastrowid
-    conn.execute("INSERT INTO headstamps(name, model_id, slot) VALUES ('WIN', ?, 3)", (model_id,))
-    conn.execute("INSERT INTO headstamps(name, model_id, slot) VALUES ('FC', ?, 5)", (model_id,))
-    if with_parents_table:
-        conn.execute("INSERT INTO headstamp_parents(name, model_id) VALUES ('Winchester', ?)", (model_id,))
-    conn.execute("INSERT INTO settings(key, value) VALUES ('api', ?)", (json.dumps({"model": "legacy"}),))
-    conn.execute(f"PRAGMA user_version = {user_version}")
-    conn.close()
-
-
 def test_migration_from_v1_adds_columns_and_keeps_rows(tmp_path: Path) -> None:
     db_path = tmp_path / "legacy.db"
-    _write_legacy_db(db_path, user_version=1, with_parents_table=False)
+    write_legacy_db(db_path, user_version=1, with_parents_table=False)
 
     db = Database(db_path)
     db.ensure_initialized()
 
     assert _user_version(db) == SCHEMA_VERSION
 
-    # The column migration added parent_id; the DDL created the tables that
-    # did not exist yet.
-    assert "parent_id" in _columns(db.conn, "headstamps")
-    assert {"slot", "model_id", "name"} <= _columns(db.conn, "headstamp_parents")
+    # The column migration added parent_id to the existing headstamps table.
+    assert "parent_id" in columns(db.conn, "headstamps")
+    # headstamp_parents and slot_templates did not exist at all, so these come
+    # from the idempotent CREATE TABLE IF NOT EXISTS pass, NOT from a column
+    # migration — _apply_column_migrations skips a table it has to create.
+    assert {"slot", "model_id", "name"} <= columns(db.conn, "headstamp_parents")
     assert db.conn.execute("SELECT COUNT(*) FROM slot_templates").fetchone()[0] == 0
 
     # Pre-existing data survives untouched, with a sane default for the new column.
@@ -217,15 +134,38 @@ def test_migration_from_v1_adds_columns_and_keeps_rows(tmp_path: Path) -> None:
     assert settings["api"]["model"] == "legacy"
 
 
+def test_an_existing_models_table_is_not_migrated_at_all(tmp_path: Path) -> None:
+    """Characterization: `models` has no column migration, so it stays legacy.
+
+    `_apply_column_migrations` only ever touches `headstamps.parent_id` and
+    `headstamp_parents.slot`, and the schema DDL is CREATE TABLE IF NOT EXISTS,
+    so a `models` table that predates `model_type` / `community_model_uid` /
+    the feedback-loop columns keeps its old shape forever. Every repository
+    read of those columns then raises OperationalError on such a database.
+
+    See issue #44, which proposes making the migration a real ordered ladder.
+    Flipping this assertion is the point of that fix.
+    """
+    db_path = tmp_path / "legacy.db"
+    write_legacy_db(db_path, user_version=1, with_parents_table=False)
+
+    db = Database(db_path)
+    db.ensure_initialized()
+
+    assert columns(db.conn, "models") == LEGACY_MODEL_COLUMNS
+    for missing in ("model_type", "community_model_uid", "feedback_loop_enabled"):
+        assert missing not in columns(db.conn, "models")
+
+
 def test_migration_adds_slot_to_an_existing_headstamp_parents_table(tmp_path: Path) -> None:
     db_path = tmp_path / "legacy.db"
-    _write_legacy_db(db_path, user_version=3, with_parents_table=True)
+    write_legacy_db(db_path, user_version=3, with_parents_table=True)
 
     db = Database(db_path)
     db.ensure_initialized()
 
     assert _user_version(db) == SCHEMA_VERSION
-    assert "slot" in _columns(db.conn, "headstamp_parents")
+    assert "slot" in columns(db.conn, "headstamp_parents")
 
     parents = db.dump_table("headstamp_parents")
     assert len(parents) == 1
@@ -235,20 +175,24 @@ def test_migration_adds_slot_to_an_existing_headstamp_parents_table(tmp_path: Pa
 
 def test_migration_is_idempotent_on_an_already_migrated_db(tmp_path: Path) -> None:
     db_path = tmp_path / "legacy.db"
-    _write_legacy_db(db_path, user_version=1, with_parents_table=True)
+    write_legacy_db(db_path, user_version=1, with_parents_table=True)
 
     db = Database(db_path)
     db.ensure_initialized()
     first = {
         table: db.dump_table(table) for table in ("cartridges", "models", "headstamps", "headstamp_parents", "settings")
     }
-    columns = {table: _columns(db.conn, table) for table in first}
+    cols = {table: columns(db.conn, table) for table in first}
 
-    db.ensure_initialized()
+    # A second *process* is the realistic repeat, not a second call on the same
+    # object: a fresh Database re-runs connect()'s WAL setup against a file that
+    # is already in WAL mode, which the same-object path never exercises.
+    reopened = Database(db_path)
+    reopened.ensure_initialized()
 
-    assert _user_version(db) == SCHEMA_VERSION
-    assert {table: db.dump_table(table) for table in first} == first
-    assert {table: _columns(db.conn, table) for table in first} == columns
+    assert _user_version(reopened) == SCHEMA_VERSION
+    assert {table: reopened.dump_table(table) for table in first} == first
+    assert {table: columns(reopened.conn, table) for table in first} == cols
 
 
 def test_ensure_initialized_does_not_downgrade_user_version(tmp_path: Path) -> None:

--- a/tests/unit/test_db.py
+++ b/tests/unit/test_db.py
@@ -3,11 +3,12 @@
 from __future__ import annotations
 
 import json
+import sqlite3
 from pathlib import Path
 
 import pytest
 
-from sorter.db import DEFAULT_CARTRIDGE_NAME, DEFAULT_MODEL_MODE, Database
+from sorter.db import DEFAULT_CARTRIDGE_NAME, DEFAULT_MODEL_MODE, SCHEMA_VERSION, Database
 
 
 def test_fresh_db_seeds_default_cartridge_and_model(tmp_path: Path) -> None:
@@ -93,6 +94,171 @@ def test_foreign_key_constraint_enforced(tmp_path: Path) -> None:
 
     with pytest.raises(Exception):  # IntegrityError
         db.conn.execute("INSERT INTO models(name, cartridge_id, model_mode) VALUES ('bad', 9999, 'convnext_tiny')")
+
+
+def _user_version(db: Database) -> int:
+    return db.conn.execute("PRAGMA user_version").fetchone()[0]
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})").fetchall()}
+
+
+def _write_legacy_db(path: Path, *, user_version: int, with_parents_table: bool) -> None:
+    """Lay down a pre-SCHEMA_VERSION database by hand.
+
+    Only the tables the column migrations touch are given their *old* shape:
+    `headstamps` without `parent_id`, and (optionally) `headstamp_parents`
+    without `slot`. Everything else is close enough to current that the
+    idempotent DDL leaves it alone.
+    """
+    conn = sqlite3.connect(path, isolation_level=None)
+    conn.execute("PRAGMA foreign_keys = ON")
+    conn.executescript(
+        """
+        CREATE TABLE cartridges (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL UNIQUE
+        );
+        CREATE TABLE models (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL,
+          cartridge_id INTEGER NOT NULL REFERENCES cartridges(id) ON DELETE RESTRICT,
+          model_mode TEXT NOT NULL
+            CHECK(model_mode IN ('convnext_tiny','convnext_small','convnext_base','convnext_large')),
+          model_type TEXT NOT NULL DEFAULT 'Standard'
+            CHECK(model_type IN ('Standard','ReadOnly','CommunityManaged')),
+          community_model_uid TEXT,
+          model_version INTEGER NOT NULL DEFAULT 1,
+          enable_image_processing INTEGER NOT NULL DEFAULT 1,
+          image_processing_json TEXT,
+          training_config_json TEXT,
+          ai_model_config_json TEXT,
+          use_primer_mask INTEGER NOT NULL DEFAULT 0,
+          hide_primer INTEGER NOT NULL DEFAULT 1,
+          primer_mask_size INTEGER NOT NULL DEFAULT 135,
+          last_training_date TEXT,
+          last_training_duration INTEGER NOT NULL DEFAULT 0,
+          trained_image_count INTEGER NOT NULL DEFAULT 0,
+          training_confusion_table TEXT,
+          feedback_loop_enabled INTEGER NOT NULL DEFAULT 0,
+          feedback_loop_confidence_floor INTEGER NOT NULL DEFAULT 95,
+          feedback_loop_upload_mode TEXT NOT NULL DEFAULT 'Manual',
+          model_path TEXT,
+          created_at TEXT NOT NULL DEFAULT (datetime('now')),
+          updated_at TEXT NOT NULL DEFAULT (datetime('now'))
+        );
+        -- Old shape: no parent_id column.
+        CREATE TABLE headstamps (
+          id INTEGER PRIMARY KEY AUTOINCREMENT,
+          name TEXT NOT NULL,
+          model_id INTEGER NOT NULL REFERENCES models(id) ON DELETE CASCADE,
+          slot INTEGER NOT NULL DEFAULT 0,
+          UNIQUE(model_id, name)
+        );
+        CREATE TABLE settings (
+          key TEXT PRIMARY KEY,
+          value TEXT NOT NULL
+        );
+        """
+    )
+    if with_parents_table:
+        # Old shape: parents existed but carried no slot of their own.
+        conn.execute(
+            "CREATE TABLE headstamp_parents ("
+            "  id INTEGER PRIMARY KEY AUTOINCREMENT,"
+            "  name TEXT NOT NULL,"
+            "  model_id INTEGER NOT NULL REFERENCES models(id) ON DELETE CASCADE,"
+            "  UNIQUE(model_id, name))"
+        )
+
+    cart_id = conn.execute("INSERT INTO cartridges(name) VALUES ('9mm')").lastrowid
+    model_id = conn.execute(
+        "INSERT INTO models(name, cartridge_id, model_mode) VALUES ('Legacy', ?, 'convnext_small')",
+        (cart_id,),
+    ).lastrowid
+    conn.execute("INSERT INTO headstamps(name, model_id, slot) VALUES ('WIN', ?, 3)", (model_id,))
+    conn.execute("INSERT INTO headstamps(name, model_id, slot) VALUES ('FC', ?, 5)", (model_id,))
+    if with_parents_table:
+        conn.execute("INSERT INTO headstamp_parents(name, model_id) VALUES ('Winchester', ?)", (model_id,))
+    conn.execute("INSERT INTO settings(key, value) VALUES ('api', ?)", (json.dumps({"model": "legacy"}),))
+    conn.execute(f"PRAGMA user_version = {user_version}")
+    conn.close()
+
+
+def test_migration_from_v1_adds_columns_and_keeps_rows(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy.db"
+    _write_legacy_db(db_path, user_version=1, with_parents_table=False)
+
+    db = Database(db_path)
+    db.ensure_initialized()
+
+    assert _user_version(db) == SCHEMA_VERSION
+
+    # The column migration added parent_id; the DDL created the tables that
+    # did not exist yet.
+    assert "parent_id" in _columns(db.conn, "headstamps")
+    assert {"slot", "model_id", "name"} <= _columns(db.conn, "headstamp_parents")
+    assert db.conn.execute("SELECT COUNT(*) FROM slot_templates").fetchone()[0] == 0
+
+    # Pre-existing data survives untouched, with a sane default for the new column.
+    headstamps = {h["name"]: h for h in db.dump_table("headstamps")}
+    assert set(headstamps) == {"WIN", "FC"}
+    assert headstamps["WIN"]["slot"] == 3
+    assert headstamps["FC"]["slot"] == 5
+    assert headstamps["WIN"]["parent_id"] is None
+
+    models = db.dump_table("models")
+    assert len(models) == 1, "an existing DB must not be re-seeded"
+    assert models[0]["name"] == "Legacy"
+    assert models[0]["model_mode"] == "convnext_small"
+
+    settings = {r["key"]: json.loads(r["value"]) for r in db.dump_table("settings")}
+    assert settings["api"]["model"] == "legacy"
+
+
+def test_migration_adds_slot_to_an_existing_headstamp_parents_table(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy.db"
+    _write_legacy_db(db_path, user_version=3, with_parents_table=True)
+
+    db = Database(db_path)
+    db.ensure_initialized()
+
+    assert _user_version(db) == SCHEMA_VERSION
+    assert "slot" in _columns(db.conn, "headstamp_parents")
+
+    parents = db.dump_table("headstamp_parents")
+    assert len(parents) == 1
+    assert parents[0]["name"] == "Winchester"
+    assert parents[0]["slot"] == 0, "new NOT NULL column backfills to its default"
+
+
+def test_migration_is_idempotent_on_an_already_migrated_db(tmp_path: Path) -> None:
+    db_path = tmp_path / "legacy.db"
+    _write_legacy_db(db_path, user_version=1, with_parents_table=True)
+
+    db = Database(db_path)
+    db.ensure_initialized()
+    first = {
+        table: db.dump_table(table) for table in ("cartridges", "models", "headstamps", "headstamp_parents", "settings")
+    }
+    columns = {table: _columns(db.conn, table) for table in first}
+
+    db.ensure_initialized()
+
+    assert _user_version(db) == SCHEMA_VERSION
+    assert {table: db.dump_table(table) for table in first} == first
+    assert {table: _columns(db.conn, table) for table in first} == columns
+
+
+def test_ensure_initialized_does_not_downgrade_user_version(tmp_path: Path) -> None:
+    db = Database(tmp_path / "test.db")
+    db.ensure_initialized()
+    db.conn.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 10}")
+    db.ensure_initialized()
+    # The bump is guarded by `current_version < SCHEMA_VERSION`, so a DB
+    # written by a newer build keeps its stamp.
+    assert _user_version(db) == SCHEMA_VERSION + 10
 
 
 def test_model_mode_check_constraint(tmp_path: Path) -> None:

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -81,6 +81,9 @@ def test_drain_returns_the_count_dispatched() -> None:
 
 
 def test_drain_on_an_empty_bus_returns_zero() -> None:
+    # Distinct from the trailing `drain() == 0` in the two tests above: this is
+    # a bus that has never been posted to, so it covers the very first call the
+    # Tk timer makes at startup, before anything has been published.
     assert EventBus().drain() == 0
 
 
@@ -144,12 +147,12 @@ def test_unsubscribe_removes_only_the_named_handler() -> None:
 def test_unsubscribe_of_an_unknown_topic_or_handler_is_harmless() -> None:
     bus = EventBus()
     bus.unsubscribe("never/subscribed", print)
-    handler: list[object] = []
-    bus.subscribe("t", handler.append)
+    seen: list[object] = []
+    bus.subscribe("t", seen.append)
     bus.unsubscribe("t", print)  # registered handler untouched
     bus.post("t", 1)
     bus.drain()
-    assert handler == [1]
+    assert seen == [1]
 
 
 def test_a_raising_handler_is_swallowed_and_the_drain_continues() -> None:
@@ -199,13 +202,13 @@ def test_subscribing_during_a_drain_does_not_disturb_the_dispatch() -> None:
 
 def test_posts_from_worker_threads_are_all_delivered() -> None:
     bus = EventBus()
-    seen: list[int] = []
+    seen: list[object] = []
 
-    def record(payload: object) -> None:
-        assert isinstance(payload, int)
-        seen.append(payload)
-
-    bus.subscribe("t", record)
+    # NB: collect unconditionally and check the payloads *after* the drain. An
+    # `assert` inside the handler would be inert — drain() catches every
+    # handler exception (the behavior characterized above), so it could only
+    # ever surface indirectly as a missing element.
+    bus.subscribe("t", seen.append)
 
     def worker(base: int) -> None:
         for i in range(20):
@@ -218,4 +221,6 @@ def test_posts_from_worker_threads_are_all_delivered() -> None:
         t.join()
 
     assert bus.drain(max_items=1000) == 60
-    assert sorted(seen) == sorted(list(range(20)) + list(range(100, 120)) + list(range(200, 220)))
+    assert all(isinstance(x, int) for x in seen), "payloads round-trip unchanged"
+    numbers = [x for x in seen if isinstance(x, int)]
+    assert sorted(numbers) == sorted(list(range(20)) + list(range(100, 120)) + list(range(200, 220)))

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -1,0 +1,216 @@
+"""Tests for the EventBus — the only sanctioned worker-thread -> UI channel.
+
+`sorter/events.py` had no test module at all. It is small, but every worker
+thread in the app funnels through it, so the delivery guarantees (and the
+non-guarantees) are worth pinning.
+"""
+
+from __future__ import annotations
+
+import threading
+
+from sorter.events import EventBus
+
+
+def test_subscribe_post_drain_delivers_to_the_subscriber() -> None:
+    bus = EventBus()
+    seen: list[object] = []
+    bus.subscribe("run/status", seen.append)
+
+    bus.post("run/status", {"state": "running"})
+    assert seen == [], "post() alone must not dispatch; drain() does"
+
+    assert bus.drain() == 1
+    assert seen == [{"state": "running"}]
+
+
+def test_payload_defaults_to_none() -> None:
+    bus = EventBus()
+    seen: list[object] = []
+    bus.subscribe("mode/changed", seen.append)
+    bus.post("mode/changed")
+    bus.drain()
+    assert seen == [None]
+
+
+def test_delivery_is_scoped_to_the_topic() -> None:
+    bus = EventBus()
+    run: list[object] = []
+    serial: list[object] = []
+    bus.subscribe("run/status", run.append)
+    bus.subscribe("serial/status", serial.append)
+
+    bus.post("run/status", 1)
+    bus.drain()
+
+    assert run == [1]
+    assert serial == []
+
+
+def test_multiple_subscribers_on_one_topic_all_fire() -> None:
+    bus = EventBus()
+    a: list[object] = []
+    b: list[object] = []
+    bus.subscribe("run/history", a.append)
+    bus.subscribe("run/history", b.append)
+
+    bus.post("run/history", "WIN")
+    assert bus.drain() == 1, "one event dispatched, regardless of subscriber count"
+    assert a == ["WIN"]
+    assert b == ["WIN"]
+
+
+def test_posting_to_a_topic_with_no_subscribers_is_a_no_op() -> None:
+    bus = EventBus()
+    bus.post("nobody/listening", 42)
+    # The event is still consumed from the queue and counted.
+    assert bus.drain() == 1
+    assert bus.drain() == 0
+
+
+def test_drain_returns_the_count_dispatched() -> None:
+    bus = EventBus()
+    seen: list[object] = []
+    bus.subscribe("t", seen.append)
+    for i in range(5):
+        bus.post("t", i)
+
+    assert bus.drain() == 5
+    assert seen == [0, 1, 2, 3, 4]
+    assert bus.drain() == 0
+
+
+def test_drain_on_an_empty_bus_returns_zero() -> None:
+    assert EventBus().drain() == 0
+
+
+def test_max_items_caps_a_drain_and_leaves_the_rest_queued() -> None:
+    bus = EventBus()
+    seen: list[object] = []
+    bus.subscribe("t", seen.append)
+    for i in range(10):
+        bus.post("t", i)
+
+    assert bus.drain(max_items=4) == 4
+    assert seen == [0, 1, 2, 3]
+
+    assert bus.drain(max_items=4) == 4
+    assert seen == list(range(8))
+
+    # FIFO order is preserved across the drains.
+    assert bus.drain() == 2
+    assert seen == list(range(10))
+
+
+def test_unsubscribe_stops_delivery() -> None:
+    bus = EventBus()
+    seen: list[object] = []
+
+    def handler(payload: object) -> None:
+        seen.append(payload)
+
+    bus.subscribe("t", handler)
+    bus.post("t", 1)
+    bus.drain()
+    assert seen == [1]
+
+    bus.unsubscribe("t", handler)
+    bus.post("t", 2)
+    assert bus.drain() == 1, "the event is still consumed, just not delivered"
+    assert seen == [1]
+
+
+def test_unsubscribe_removes_only_the_named_handler() -> None:
+    bus = EventBus()
+    a: list[object] = []
+    b: list[object] = []
+
+    def handler_a(payload: object) -> None:
+        a.append(payload)
+
+    def handler_b(payload: object) -> None:
+        b.append(payload)
+
+    bus.subscribe("t", handler_a)
+    bus.subscribe("t", handler_b)
+    bus.unsubscribe("t", handler_a)
+
+    bus.post("t", 1)
+    bus.drain()
+    assert a == []
+    assert b == [1]
+
+
+def test_unsubscribe_of_an_unknown_topic_or_handler_is_harmless() -> None:
+    bus = EventBus()
+    bus.unsubscribe("never/subscribed", print)
+    handler: list[object] = []
+    bus.subscribe("t", handler.append)
+    bus.unsubscribe("t", print)  # registered handler untouched
+    bus.post("t", 1)
+    bus.drain()
+    assert handler == [1]
+
+
+def test_a_raising_handler_is_swallowed_and_the_drain_continues() -> None:
+    # Characterization: handler exceptions are caught and dropped on the floor
+    # with no logging at all, so a broken UI handler fails completely silently.
+    # Issue #32 proposes logging the exception here; the swallow itself stays
+    # (one bad handler must not take down the Tk drain loop), so only the
+    # logging is added and this assertion should keep holding.
+    bus = EventBus()
+    other: list[object] = []
+    later: list[object] = []
+
+    def boom(_payload: object) -> None:
+        raise RuntimeError("handler blew up")
+
+    bus.subscribe("t", boom)
+    bus.subscribe("t", other.append)
+    bus.subscribe("u", later.append)
+
+    bus.post("t", "first")
+    bus.post("u", "second")
+
+    # Neither the sibling subscriber nor the next queued event is lost.
+    assert bus.drain() == 2
+    assert other == ["first"]
+    assert later == ["second"]
+
+
+def test_subscribing_during_a_drain_does_not_disturb_the_dispatch() -> None:
+    # drain() iterates a copy of the handler list, so mutating subscriptions
+    # from inside a handler is safe.
+    bus = EventBus()
+    late: list[object] = []
+
+    def subscribe_more(_payload: object) -> None:
+        bus.subscribe("t", late.append)
+
+    bus.subscribe("t", subscribe_more)
+    bus.post("t", 1)
+    bus.drain()
+    assert late == [], "the newly added handler must not see the in-flight event"
+
+    bus.post("t", 2)
+    bus.drain()
+    assert late == [2]
+
+
+def test_posts_from_worker_threads_are_all_delivered() -> None:
+    bus = EventBus()
+    seen: list[object] = []
+    bus.subscribe("t", seen.append)
+
+    def worker(base: int) -> None:
+        for i in range(20):
+            bus.post("t", base + i)
+
+    threads = [threading.Thread(target=worker, args=(base,)) for base in (0, 100, 200)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert bus.drain(max_items=1000) == 60
+    assert sorted(seen) == sorted(list(range(20)) + list(range(100, 120)) + list(range(200, 220)))

--- a/tests/unit/test_events.py
+++ b/tests/unit/test_events.py
@@ -199,8 +199,13 @@ def test_subscribing_during_a_drain_does_not_disturb_the_dispatch() -> None:
 
 def test_posts_from_worker_threads_are_all_delivered() -> None:
     bus = EventBus()
-    seen: list[object] = []
-    bus.subscribe("t", seen.append)
+    seen: list[int] = []
+
+    def record(payload: object) -> None:
+        assert isinstance(payload, int)
+        seen.append(payload)
+
+    bus.subscribe("t", record)
 
     def worker(base: int) -> None:
         for i in range(20):

--- a/tests/unit/test_headstamp_parents.py
+++ b/tests/unit/test_headstamp_parents.py
@@ -2,7 +2,6 @@
 
 from __future__ import annotations
 
-import sqlite3
 from pathlib import Path
 
 from sorter.db import Database
@@ -13,6 +12,8 @@ from sorter.repository import (
     HeadstampRepo,
     ModelRepo,
 )
+
+from ._legacy_db import columns, write_legacy_db
 
 
 def _new_db(tmp_path: Path) -> Database:
@@ -97,41 +98,26 @@ def test_deleting_model_cascades_parents(tmp_path: Path) -> None:
 
 
 def test_migration_adds_parent_id_to_v1_db(tmp_path: Path) -> None:
-    """A pre-existing v1 headstamps table (no parent_id) is upgraded in place."""
+    """A pre-existing v1 headstamps table (no parent_id) is upgraded in place.
+
+    The schema-level assertions about this migration live in
+    `test_db.py`; what this one adds is that the parent *relationship* works
+    end-to-end through the repos afterwards.
+    """
     db_path = tmp_path / "legacy.db"
-    # Hand-build a v1-shaped DB: headstamps without parent_id, no parents table.
-    conn = sqlite3.connect(db_path)
-    conn.executescript(
-        """
-        CREATE TABLE cartridges(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE);
-        CREATE TABLE models(
-            id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL,
-            cartridge_id INTEGER NOT NULL, model_mode TEXT NOT NULL DEFAULT 'convnext_tiny'
-        );
-        CREATE TABLE headstamps(
-            id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL,
-            model_id INTEGER NOT NULL, slot INTEGER NOT NULL DEFAULT 0,
-            UNIQUE(model_id, name)
-        );
-        INSERT INTO cartridges(id, name) VALUES (1, '9mm');
-        INSERT INTO models(id, name, cartridge_id, model_mode) VALUES (1, 'old', 1, 'convnext_tiny');
-        INSERT INTO headstamps(name, model_id, slot) VALUES ('WIN', 1, 0);
-        PRAGMA user_version = 1;
-        """
-    )
-    conn.commit()
-    conn.close()
+    write_legacy_db(db_path, user_version=1, with_parents_table=False)
 
     # Opening through Database should add the column and the parents table.
     db = Database(db_path)
     db.ensure_initialized()
 
-    cols = {r[1] for r in db.conn.execute("PRAGMA table_info(headstamps)").fetchall()}
-    assert "parent_id" in cols
+    assert "parent_id" in columns(db.conn, "headstamps")
 
     # The new table exists and the parent relationship works end-to-end.
     p = HeadstampParentRepo(db).add(1, "WIN-GROUP")
     win = next(h for h in HeadstampRepo(db).list_for_model(1) if h.name == "WIN")
     assert win.parent_id is None
     HeadstampRepo(db).set_parent(win.id, p.id)
-    assert HeadstampRepo(db).list_for_model(1)[0].parent_id == p.id
+    reread = {h.name: h for h in HeadstampRepo(db).list_for_model(1)}
+    assert reread["WIN"].parent_id == p.id
+    assert reread["FC"].parent_id is None, "only the linked headstamp is touched"

--- a/tests/unit/test_parent_runtime.py
+++ b/tests/unit/test_parent_runtime.py
@@ -13,6 +13,8 @@ from sorter.repository import (
     SettingsRepo,
 )
 
+from ._legacy_db import columns, write_legacy_db
+
 
 def _new_db(tmp_path: Path) -> Database:
     db = Database(tmp_path / "test.db")
@@ -149,33 +151,17 @@ def test_routing_ignores_parents_when_disabled(tmp_path: Path) -> None:
 
 
 def test_parent_slot_column_migrates_on_v2_db(tmp_path: Path) -> None:
-    """A v2 headstamp_parents table (no slot column) gains it on open."""
-    import sqlite3
+    """A v2 headstamp_parents table (no slot column) gains it on open.
 
+    The schema-level assertions (column present, existing rows backfilled to
+    0) live in `test_db.py`; what this one adds is that the slot is writable
+    through the repo afterwards.
+    """
     db_path = tmp_path / "v2.db"
-    conn = sqlite3.connect(db_path)
-    conn.executescript(
-        """
-        CREATE TABLE cartridges(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL UNIQUE);
-        CREATE TABLE models(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL,
-            cartridge_id INTEGER NOT NULL, model_mode TEXT NOT NULL DEFAULT 'convnext_tiny');
-        CREATE TABLE headstamp_parents(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL,
-            model_id INTEGER NOT NULL, UNIQUE(model_id, name));
-        CREATE TABLE headstamps(id INTEGER PRIMARY KEY AUTOINCREMENT, name TEXT NOT NULL,
-            model_id INTEGER NOT NULL, slot INTEGER NOT NULL DEFAULT 0,
-            parent_id INTEGER, UNIQUE(model_id, name));
-        INSERT INTO cartridges(id, name) VALUES (1, '9mm');
-        INSERT INTO models(id, name, cartridge_id) VALUES (1, 'm', 1);
-        INSERT INTO headstamp_parents(id, name, model_id) VALUES (1, 'Brass', 1);
-        PRAGMA user_version = 2;
-        """
-    )
-    conn.commit()
-    conn.close()
+    write_legacy_db(db_path, user_version=2, with_parents_table=True, with_parent_id=True)
 
     db = Database(db_path)
     db.ensure_initialized()
-    cols = {r[1] for r in db.conn.execute("PRAGMA table_info(headstamp_parents)").fetchall()}
-    assert "slot" in cols
+    assert "slot" in columns(db.conn, "headstamp_parents")
     HeadstampParentRepo(db).update_slot(1, 4)
     assert HeadstampParentRepo(db).get(1).slot == 4

--- a/tests/unit/test_serial_broker.py
+++ b/tests/unit/test_serial_broker.py
@@ -15,6 +15,8 @@ This was found by reading the code, not observed on hardware.
 
 from __future__ import annotations
 
+import threading
+import time
 from typing import Any
 
 import pytest
@@ -41,14 +43,10 @@ class _Sink:
         broker.on_received.append(self.received.append)
 
 
-def _broker() -> SerialBroker:
-    """A broker that has never touched a real port."""
-    return SerialBroker(port="/dev/null-not-opened")
-
-
 @pytest.fixture
 def broker() -> SerialBroker:
-    return _broker()
+    """A broker that has never touched a real port."""
+    return SerialBroker(port="/dev/null-not-opened")
 
 
 @pytest.fixture
@@ -57,6 +55,14 @@ def sink(broker: SerialBroker) -> _Sink:
 
 
 def _feed(broker: SerialBroker, chunk: str) -> None:
+    """Push `chunk` through the parser exactly as the buffer holds it.
+
+    Note this bypasses `_reader_loop`, which stamps a newline onto every chunk
+    it forwards (`line if line.endswith("\\n") else line + "\\n"`). So the
+    partial-line buffering exercised below is `_process_buffer`'s own contract,
+    not a state the production reader can actually produce — see
+    `test_reader_loop_stamps_a_newline_onto_a_partial_read` for that half.
+    """
     broker._buf += chunk
     broker._process_buffer()
 
@@ -117,6 +123,26 @@ def test_partial_line_is_held_until_the_terminator_arrives(broker: SerialBroker,
     assert sink.waiting == ["waiting"]
 
 
+def test_reader_loop_stamps_a_newline_onto_a_partial_read(broker: SerialBroker, sink: _Sink) -> None:
+    """Characterization: a timed-out mid-line read is dispatched, not buffered.
+
+    `_reader_loop` appends `line + "\\n"` whenever pyserial's `readline()`
+    returns without a terminator — which is exactly what a read timeout on a
+    half-transmitted line produces. So `_process_buffer`'s buffering never
+    engages in production: the fragment is treated as a complete line and
+    routed on the spot. Combined with the unanchored substring matching above,
+    a line split mid-word is how a fragment could be misrouted. See issue #34.
+    """
+    fake = _PartialReadSerial(["waiti"], broker._stop_event)
+    broker._sp = fake  # type: ignore[assignment]
+
+    broker._reader_loop()
+
+    assert sink.response == ["waiti"], "the partial was dispatched as a complete line"
+    assert sink.waiting == []
+    assert broker._buf == "", "nothing was left buffered for the rest of the line"
+
+
 def test_crlf_terminator_is_stripped(broker: SerialBroker, sink: _Sink) -> None:
     _feed(broker, "done\r\n")
     assert sink.done == ["done"]
@@ -168,7 +194,7 @@ def test_error_line_containing_ok_is_routed_to_on_ok(broker: SerialBroker, sink:
     assert sink.error == []
 
 
-@pytest.mark.parametrize("line", ["token", "lookup", "broken", "bookkeeping", "hooked up"])
+@pytest.mark.parametrize("line", ["token", "bookkeeping"])
 def test_word_merely_containing_ok_fires_on_ok(broker: SerialBroker, sink: _Sink, line: str) -> None:
     # Characterization: any line containing the substring "ok" anywhere is
     # treated as an acknowledgement. See issue #34.
@@ -177,7 +203,7 @@ def test_word_merely_containing_ok_fires_on_ok(broker: SerialBroker, sink: _Sink
     assert sink.response == []
 
 
-@pytest.mark.parametrize("line", ["abandoned", "sensor calibration done at 12:00", "undone"])
+@pytest.mark.parametrize("line", ["abandoned", "sensor calibration done at 12:00"])
 def test_line_merely_containing_done_fires_on_done(broker: SerialBroker, sink: _Sink, line: str) -> None:
     # Characterization: "done" is checked first and unanchored, so a diagnostic
     # line that merely mentions it satisfies a pending feed/sort wait. See
@@ -185,6 +211,38 @@ def test_line_merely_containing_done_fires_on_done(broker: SerialBroker, sink: _
     _feed(broker, line + "\n")
     assert sink.done == [line]
     assert sink.response == []
+
+
+def test_a_diagnostic_line_satisfies_a_pending_feed_one(broker: SerialBroker) -> None:
+    """Characterization: the `done` substring completes a real feed/sort wait.
+
+    This is the consequence that makes the unanchored matching matter rather
+    than merely being untidy. `feed_one()` / `sort_and_move()` /
+    `force_sort_and_move()` all return by waiting on `on_done`, so a board line
+    that only *mentions* "done" reports a physical operation as complete when
+    nothing completed. See issue #34.
+    """
+    fake = _WritableSerial()
+    broker._sp = fake  # type: ignore[assignment]
+
+    def feed_when_awaited() -> None:
+        # _await_topic appends its handler after send_command returns; wait for
+        # it to land rather than sleeping a fixed amount, so this stays fast
+        # and deterministic.
+        for _ in range(2000):
+            if broker.on_done:
+                break
+            time.sleep(0.001)
+        _feed(broker, "sensor calibration done at 12:00\n")
+
+    waiter = threading.Thread(target=feed_when_awaited)
+    waiter.start()
+    try:
+        assert broker.feed_one() is True, "a mere mention of 'done' satisfied the wait"
+    finally:
+        waiter.join()
+
+    assert fake.written == [b"xf:0\n"]
 
 
 def test_done_beats_ok_beats_error_beats_waiting(broker: SerialBroker, sink: _Sink) -> None:
@@ -216,7 +274,6 @@ class _FakeSerial:
         self._read_all_text = read_all_text
         self.is_open = True
         self.timeout: float | None = None
-        self.dtr = False
         self.written: list[bytes] = []
         self.closed = False
 
@@ -232,68 +289,148 @@ class _FakeSerial:
         self.written.append(data)
         return len(data)
 
+    def flush(self) -> None:
+        pass
+
     def close(self) -> None:
         self.closed = True
         self.is_open = False
 
 
-def _patch_serial(monkeypatch: pytest.MonkeyPatch, fake: _FakeSerial) -> None:
-    def _factory(**_kwargs: Any) -> _FakeSerial:
+class _WritableSerial(_FakeSerial):
+    """A fake that only has to accept writes — used for send_command paths."""
+
+    def __init__(self) -> None:
+        super().__init__(lines=[])
+
+
+class _PartialReadSerial:
+    """Returns each line verbatim, then stops the reader loop.
+
+    Unlike `_FakeSerial` the lines are *not* newline-terminated, which is what
+    a pyserial read timeout mid-line looks like.
+    """
+
+    def __init__(self, lines: list[str], stop_event: threading.Event) -> None:
+        self._lines = list(lines)
+        self._stop_event = stop_event
+        self.is_open = True
+
+    def readline(self) -> bytes:
+        if not self._lines:
+            self._stop_event.set()
+            return b""
+        return self._lines.pop(0).encode("ascii")
+
+
+def _patch_serial(monkeypatch: pytest.MonkeyPatch, fake: _FakeSerial) -> dict[str, Any]:
+    """Point `serial.Serial` at `fake`, returning the kwargs it was built with.
+
+    `serial_broker` does a plain `import serial`, so `serial_broker.serial` *is*
+    the pyserial module object — this patch is process-global for the duration
+    of the test, not scoped to the importing module. It is safe only because
+    monkeypatch restores it and the suite is never run in parallel (see
+    `tests/conftest.py`); don't "fix" it into a module-local patch, there isn't
+    one to make.
+    """
+    captured: dict[str, Any] = {}
+
+    def _factory(**kwargs: Any) -> _FakeSerial:
+        captured.update(kwargs)
         return fake
 
     monkeypatch.setattr(serial_broker.serial, "Serial", _factory)
+    return captured
 
 
-def test_try_open_accepts_a_version_line_containing_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_try_open_accepts_a_version_line_containing_ok(broker: SerialBroker, monkeypatch: pytest.MonkeyPatch) -> None:
     # Characterization: the handshake accepts ANY version reply containing the
     # substring "ok" — including one that is reporting a problem. See issue #34.
     fake = _FakeSerial(lines=["\n", "not ok, firmware broken\n"])
-    _patch_serial(monkeypatch, fake)
-    broker = _broker()
-    assert broker.try_open() is True
-    assert broker.is_connected is True
-    assert broker.firmware_version == "not ok, firmware broken"
-    assert fake.written == [b"version\n"]
-    assert fake.timeout == serial_broker.READ_TIMEOUT_S
+    kwargs = _patch_serial(monkeypatch, fake)
+    try:
+        assert broker.try_open() is True
+        assert broker.is_connected is True
+        assert broker.firmware_version == "not ok, firmware broken"
+        assert fake.written == [b"version\n"]
+        # The port is opened at the (user-configurable) probe timeout and only
+        # relaxed to the steady-state read timeout once the board answers.
+        assert kwargs["port"] == "/dev/null-not-opened"
+        assert kwargs["baudrate"] == broker.baud
+        assert kwargs["timeout"] == broker.handshake_timeout_s
+        assert fake.timeout == serial_broker.READ_TIMEOUT_S
+    finally:
+        broker.close()
 
 
-def test_try_open_accepts_anything_containing_7_dot(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_try_open_accepts_anything_containing_7_dot(broker: SerialBroker, monkeypatch: pytest.MonkeyPatch) -> None:
     # Characterization: "7." is the firmware-family check, unanchored, so a
     # timestamp or a bare "17.5" passes the handshake. See issue #34.
     fake = _FakeSerial(lines=["\n", "boot at 17.5s\n"])
     _patch_serial(monkeypatch, fake)
-    broker = _broker()
-    assert broker.try_open() is True
-    assert broker.firmware_version == "boot at 17.5s"
+    try:
+        assert broker.try_open() is True
+        assert broker.firmware_version == "boot at 17.5s"
+    finally:
+        broker.close()
 
 
-def test_try_open_accepts_a_real_version_string(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_try_open_accepts_a_real_version_string(broker: SerialBroker, monkeypatch: pytest.MonkeyPatch) -> None:
     fake = _FakeSerial(lines=["\n", "7.4.1\n"])
     _patch_serial(monkeypatch, fake)
-    broker = _broker()
-    assert broker.try_open() is True
-    assert broker.firmware_version == "7.4.1"
+    try:
+        assert broker.try_open() is True
+        assert broker.firmware_version == "7.4.1"
+    finally:
+        broker.close()
 
 
 def test_try_open_accepts_a_ready_banner_even_without_a_version(
-    monkeypatch: pytest.MonkeyPatch,
+    broker: SerialBroker, monkeypatch: pytest.MonkeyPatch
 ) -> None:
-    # The banner check is case-SENSITIVE ("Ready", not lowercased) unlike the
-    # version check right above it in try_open.
     fake = _FakeSerial(lines=["Ready\n", "\n"])
     _patch_serial(monkeypatch, fake)
-    broker = _broker()
-    assert broker.try_open() is True
-    assert broker.firmware_version == "Unknown"
+    try:
+        assert broker.try_open() is True
+        assert broker.firmware_version == "Unknown"
+    finally:
+        broker.close()
 
 
-def test_try_open_rejects_an_unrecognized_board(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_try_open_reads_the_ready_banner_out_of_the_read_all_tail(
+    broker: SerialBroker, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The banner is `readline()` + `read_all()`, and boards are chatty.
+
+    `readline()` returns at the first newline, so on a multi-line boot banner
+    the "Ready" line arrives in the `read_all()` tail — the realistic path.
+    """
+    fake = _FakeSerial(lines=["booting...\n", "\n"], read_all_text="init ok\nReady\n")
+    _patch_serial(monkeypatch, fake)
+    try:
+        assert broker.try_open() is True
+        assert broker.firmware_version == "Unknown"
+    finally:
+        broker.close()
+
+
+def test_try_open_ready_banner_check_is_case_sensitive(broker: SerialBroker, monkeypatch: pytest.MonkeyPatch) -> None:
+    # Characterization: the banner check is `"Ready" in banner` on the RAW
+    # text, while the version check immediately above it lowercases first. So a
+    # board announcing itself in lowercase is rejected. See issue #34.
+    fake = _FakeSerial(lines=["ready\n", "\n"])
+    _patch_serial(monkeypatch, fake)
+    assert broker.try_open() is False
+    assert broker.is_connected is False
+
+
+def test_try_open_rejects_an_unrecognized_board(broker: SerialBroker, monkeypatch: pytest.MonkeyPatch) -> None:
     fake = _FakeSerial(lines=["garbage\n", "3.2.1\n"])
     _patch_serial(monkeypatch, fake)
-    broker = _broker()
     assert broker.try_open() is False
     assert broker.is_connected is False
     assert fake.closed is True
+    assert broker._sp is None, "the rejected port handle is dropped, not just closed"
 
 
 def test_try_open_without_require_serial_ready_accepts_anything(
@@ -302,16 +439,19 @@ def test_try_open_without_require_serial_ready_accepts_anything(
     fake = _FakeSerial(lines=["garbage\n", "3.2.1\n"])
     _patch_serial(monkeypatch, fake)
     broker = SerialBroker(port="/dev/null-not-opened", require_serial_ready=False)
-    assert broker.try_open() is True
+    try:
+        assert broker.try_open() is True
+    finally:
+        broker.close()
 
 
 def test_try_open_returns_false_when_the_port_cannot_be_opened(
+    broker: SerialBroker,
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     def _boom(**_kwargs: Any) -> Any:
         raise serial_broker.serial.SerialException("no such port")
 
     monkeypatch.setattr(serial_broker.serial, "Serial", _boom)
-    broker = _broker()
     assert broker.try_open() is False
     assert broker.is_connected is False

--- a/tests/unit/test_serial_broker.py
+++ b/tests/unit/test_serial_broker.py
@@ -1,0 +1,317 @@
+"""Characterization tests for the real SerialBroker line parser and handshake.
+
+`test_serial_emulator.py` exercises the *fake* broker; nothing covered the real
+`SerialBroker._process_buffer` / `try_open` until now.
+
+Several assertions here deliberately pin behavior that is arguably wrong — the
+dispatch chain is a sequence of unanchored `in` substring tests, so a line like
+``"error: broken sensor"`` is routed to `on_ok` (because "broken" contains
+"ok") and never reaches `on_error`. GitHub issue #34 proposes tightening that
+matching. These tests exist so the fix shows up as an explicit, reviewable flip
+of the assertions rather than as an invisible behavior change.
+
+This was found by reading the code, not observed on hardware.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from sorter import serial_broker
+from sorter.serial_broker import SerialBroker
+
+
+class _Sink:
+    """Records which callback lists fired, and with what payloads."""
+
+    def __init__(self, broker: SerialBroker) -> None:
+        self.done: list[str] = []
+        self.ok: list[str] = []
+        self.error: list[str] = []
+        self.waiting: list[str] = []
+        self.response: list[str] = []
+        self.received: list[str] = []
+        broker.on_done.append(self.done.append)
+        broker.on_ok.append(self.ok.append)
+        broker.on_error.append(self.error.append)
+        broker.on_waiting.append(self.waiting.append)
+        broker.on_response.append(self.response.append)
+        broker.on_received.append(self.received.append)
+
+
+def _broker() -> SerialBroker:
+    """A broker that has never touched a real port."""
+    return SerialBroker(port="/dev/null-not-opened")
+
+
+@pytest.fixture
+def broker() -> SerialBroker:
+    return _broker()
+
+
+@pytest.fixture
+def sink(broker: SerialBroker) -> _Sink:
+    return _Sink(broker)
+
+
+def _feed(broker: SerialBroker, chunk: str) -> None:
+    broker._buf += chunk
+    broker._process_buffer()
+
+
+# ----- clean routing ---------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("line", "attr"),
+    [
+        ("done", "done"),
+        ("ok", "ok"),
+        ("error", "error"),
+        ("waiting", "waiting"),
+    ],
+)
+def test_clean_token_routes_to_its_own_callback(broker: SerialBroker, sink: _Sink, line: str, attr: str) -> None:
+    _feed(broker, line + "\n")
+    assert getattr(sink, attr) == [line]
+    others = {"done", "ok", "error", "waiting", "response"} - {attr}
+    for other in others:
+        assert getattr(sink, other) == [], f"{line!r} unexpectedly fired on_{other}"
+
+
+def test_unrecognized_line_falls_through_to_on_response(broker: SerialBroker, sink: _Sink) -> None:
+    _feed(broker, "feedspeed:60\n")
+    assert sink.response == ["feedspeed:60"]
+    assert sink.done == sink.ok == sink.error == sink.waiting == []
+
+
+def test_every_line_fires_on_received(broker: SerialBroker, sink: _Sink) -> None:
+    _feed(broker, "done\nfeedspeed:60\nwaiting\n")
+    assert sink.received == ["done", "feedspeed:60", "waiting"]
+
+
+def test_matching_is_case_insensitive(broker: SerialBroker, sink: _Sink) -> None:
+    _feed(broker, "DONE\nOK\nERROR\nWaiting\n")
+    assert sink.done == ["DONE"]
+    assert sink.ok == ["OK"]
+    assert sink.error == ["ERROR"]
+    assert sink.waiting == ["Waiting"]
+
+
+def test_most_recent_response_tracks_last_line(broker: SerialBroker) -> None:
+    _feed(broker, "first\nsecond\n")
+    assert broker.read_line() == "second"
+    # read_line() consumes it.
+    assert broker.read_line() == ""
+
+
+# ----- buffering / line splitting --------------------------------------------
+
+
+def test_partial_line_is_held_until_the_terminator_arrives(broker: SerialBroker, sink: _Sink) -> None:
+    _feed(broker, "wai")
+    assert sink.received == []
+    _feed(broker, "ting\n")
+    assert sink.waiting == ["waiting"]
+
+
+def test_crlf_terminator_is_stripped(broker: SerialBroker, sink: _Sink) -> None:
+    _feed(broker, "done\r\n")
+    assert sink.done == ["done"]
+    assert sink.received == ["done"]
+
+
+def test_blank_and_whitespace_only_lines_are_skipped(broker: SerialBroker, sink: _Sink) -> None:
+    _feed(broker, "\n\r\n   \n\t\n")
+    assert sink.received == []
+    assert sink.response == []
+
+
+def test_multiple_lines_in_one_feed_all_dispatch(broker: SerialBroker, sink: _Sink) -> None:
+    _feed(broker, "done\nwaiting\nfeedspeed:60\n")
+    assert sink.done == ["done"]
+    assert sink.waiting == ["waiting"]
+    assert sink.response == ["feedspeed:60"]
+    assert broker._buf == ""
+
+
+def test_trailing_partial_line_stays_in_the_buffer(broker: SerialBroker, sink: _Sink) -> None:
+    _feed(broker, "done\npartial")
+    assert sink.done == ["done"]
+    assert broker._buf == "partial"
+
+
+def test_handler_exception_does_not_stop_the_remaining_handlers(broker: SerialBroker) -> None:
+    seen: list[str] = []
+
+    def boom(_payload: str) -> None:
+        raise RuntimeError("handler blew up")
+
+    broker.on_done.append(boom)
+    broker.on_done.append(seen.append)
+    _feed(broker, "done\n")
+    assert seen == ["done"]
+
+
+# ----- characterization: unanchored substring matching -----------------------
+
+
+def test_error_line_containing_ok_is_routed_to_on_ok(broker: SerialBroker, sink: _Sink) -> None:
+    # Characterization: matching is an unanchored substring test and the "ok"
+    # branch `continue`s before the "error" branch is ever reached, so
+    # "br-OK-en" wins and this fires on_ok. The error is silently reported as a
+    # success. See issue #34 — flipping this assertion is the point of that fix.
+    _feed(broker, "error: broken sensor\n")
+    assert sink.ok == ["error: broken sensor"]
+    assert sink.error == []
+
+
+@pytest.mark.parametrize("line", ["token", "lookup", "broken", "bookkeeping", "hooked up"])
+def test_word_merely_containing_ok_fires_on_ok(broker: SerialBroker, sink: _Sink, line: str) -> None:
+    # Characterization: any line containing the substring "ok" anywhere is
+    # treated as an acknowledgement. See issue #34.
+    _feed(broker, line + "\n")
+    assert sink.ok == [line]
+    assert sink.response == []
+
+
+@pytest.mark.parametrize("line", ["abandoned", "sensor calibration done at 12:00", "undone"])
+def test_line_merely_containing_done_fires_on_done(broker: SerialBroker, sink: _Sink, line: str) -> None:
+    # Characterization: "done" is checked first and unanchored, so a diagnostic
+    # line that merely mentions it satisfies a pending feed/sort wait. See
+    # issue #34.
+    _feed(broker, line + "\n")
+    assert sink.done == [line]
+    assert sink.response == []
+
+
+def test_done_beats_ok_beats_error_beats_waiting(broker: SerialBroker, sink: _Sink) -> None:
+    # Characterization: the branches are checked in a fixed order and each one
+    # `continue`s, so a line matching several only ever fires the first. See
+    # issue #34.
+    _feed(broker, "done ok error waiting\n")
+    assert sink.done == ["done ok error waiting"]
+    assert sink.ok == sink.error == sink.waiting == []
+
+
+def test_json_config_payload_containing_ok_never_reaches_on_response(broker: SerialBroker, sink: _Sink) -> None:
+    # Characterization: get_config() captures JSON from on_response, so a board
+    # config whose keys happen to contain "ok"/"done" would be swallowed by the
+    # ack branches and the getconfig call would time out. See issue #34.
+    _feed(broker, '{"feedspeed": 60, "lookahead": 2}\n')
+    assert sink.ok == ['{"feedspeed": 60, "lookahead": 2}']
+    assert sink.response == []
+
+
+# ----- try_open handshake ----------------------------------------------------
+
+
+class _FakeSerial:
+    """Minimal stand-in for serial.Serial covering only what try_open touches."""
+
+    def __init__(self, lines: list[str], read_all_text: str = "") -> None:
+        self._lines = list(lines)
+        self._read_all_text = read_all_text
+        self.is_open = True
+        self.timeout: float | None = None
+        self.dtr = False
+        self.written: list[bytes] = []
+        self.closed = False
+
+    def readline(self) -> bytes:
+        if not self._lines:
+            return b""
+        return self._lines.pop(0).encode("ascii")
+
+    def read_all(self) -> bytes:
+        return self._read_all_text.encode("ascii")
+
+    def write(self, data: bytes) -> int:
+        self.written.append(data)
+        return len(data)
+
+    def close(self) -> None:
+        self.closed = True
+        self.is_open = False
+
+
+def _patch_serial(monkeypatch: pytest.MonkeyPatch, fake: _FakeSerial) -> None:
+    def _factory(**_kwargs: Any) -> _FakeSerial:
+        return fake
+
+    monkeypatch.setattr(serial_broker.serial, "Serial", _factory)
+
+
+def test_try_open_accepts_a_version_line_containing_ok(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Characterization: the handshake accepts ANY version reply containing the
+    # substring "ok" — including one that is reporting a problem. See issue #34.
+    fake = _FakeSerial(lines=["\n", "not ok, firmware broken\n"])
+    _patch_serial(monkeypatch, fake)
+    broker = _broker()
+    assert broker.try_open() is True
+    assert broker.is_connected is True
+    assert broker.firmware_version == "not ok, firmware broken"
+    assert fake.written == [b"version\n"]
+    assert fake.timeout == serial_broker.READ_TIMEOUT_S
+
+
+def test_try_open_accepts_anything_containing_7_dot(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Characterization: "7." is the firmware-family check, unanchored, so a
+    # timestamp or a bare "17.5" passes the handshake. See issue #34.
+    fake = _FakeSerial(lines=["\n", "boot at 17.5s\n"])
+    _patch_serial(monkeypatch, fake)
+    broker = _broker()
+    assert broker.try_open() is True
+    assert broker.firmware_version == "boot at 17.5s"
+
+
+def test_try_open_accepts_a_real_version_string(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeSerial(lines=["\n", "7.4.1\n"])
+    _patch_serial(monkeypatch, fake)
+    broker = _broker()
+    assert broker.try_open() is True
+    assert broker.firmware_version == "7.4.1"
+
+
+def test_try_open_accepts_a_ready_banner_even_without_a_version(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    # The banner check is case-SENSITIVE ("Ready", not lowercased) unlike the
+    # version check right above it in try_open.
+    fake = _FakeSerial(lines=["Ready\n", "\n"])
+    _patch_serial(monkeypatch, fake)
+    broker = _broker()
+    assert broker.try_open() is True
+    assert broker.firmware_version == "Unknown"
+
+
+def test_try_open_rejects_an_unrecognized_board(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake = _FakeSerial(lines=["garbage\n", "3.2.1\n"])
+    _patch_serial(monkeypatch, fake)
+    broker = _broker()
+    assert broker.try_open() is False
+    assert broker.is_connected is False
+    assert fake.closed is True
+
+
+def test_try_open_without_require_serial_ready_accepts_anything(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    fake = _FakeSerial(lines=["garbage\n", "3.2.1\n"])
+    _patch_serial(monkeypatch, fake)
+    broker = SerialBroker(port="/dev/null-not-opened", require_serial_ready=False)
+    assert broker.try_open() is True
+
+
+def test_try_open_returns_false_when_the_port_cannot_be_opened(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    def _boom(**_kwargs: Any) -> Any:
+        raise serial_broker.serial.SerialException("no such port")
+
+    monkeypatch.setattr(serial_broker.serial, "Serial", _boom)
+    broker = _broker()
+    assert broker.try_open() is False
+    assert broker.is_connected is False

--- a/tests/unit/test_serial_broker.py
+++ b/tests/unit/test_serial_broker.py
@@ -203,11 +203,17 @@ def test_word_merely_containing_ok_fires_on_ok(broker: SerialBroker, sink: _Sink
     assert sink.response == []
 
 
-@pytest.mark.parametrize("line", ["abandoned", "sensor calibration done at 12:00"])
+@pytest.mark.parametrize("line", ["abandoned", "sensor calibration done at 12:00", "undone"])
 def test_line_merely_containing_done_fires_on_done(broker: SerialBroker, sink: _Sink, line: str) -> None:
     # Characterization: "done" is checked first and unanchored, so a diagnostic
     # line that merely mentions it satisfies a pending feed/sort wait. See
     # issue #34.
+    #
+    # "undone" is the case worth keeping of these: it is the semantic
+    # *inversion* — a board reporting that an operation was reversed reads as
+    # one that completed. The "ok" branch has a dedicated test for its
+    # equivalent ("error: broken sensor"); this is the "done" branch's, and
+    # "done" is the one a pending feed_one()/sort_and_move() waits on.
     _feed(broker, line + "\n")
     assert sink.done == [line]
     assert sink.response == []


### PR DESCRIPTION
## What this is

**Test-only.** No files under `sorter/` are touched — production behavior is unchanged.

Two parts:

1. **New coverage** for three areas that had thin or none: the real serial parser, the event bus, and the DB migration path.
2. **One shared legacy-DB fixture**, replacing three hand-written copies. This is why `test_headstamp_parents.py` and `test_parent_runtime.py` appear in the diff.

## What is covered

**`tests/unit/test_serial_broker.py` (new, 33 tests)**

`test_serial_emulator.py` exercises the *fake* broker; the real `SerialBroker._process_buffer` and `try_open` had no tests at all. This adds:

- clean `done` / `ok` / `error` / `waiting` tokens each routing to their own callback list, and an unrecognized line falling through to `on_response`
- line buffering: partial lines split across two feeds, `\r\n` vs `\n`, blank/whitespace-only lines, several lines in one chunk, a trailing partial staying in the buffer
- that `_reader_loop` stamps a newline onto a partial read, so a timed-out mid-line read is dispatched immediately rather than buffered — `_process_buffer`'s buffering never actually engages in production
- case-insensitive matching, `on_received` firing for every line, and a raising handler not stopping its siblings
- the `try_open` handshake: version-line acceptance, the `Ready` banner path (including the realistic case where a chatty board delivers it in the `read_all()` tail rather than on the first line), that the banner check is case-*sensitive* while the version check right above it is not, `require_serial_ready=False`, rejection of an unrecognized board, the constructor kwargs (so dropping the user-configurable probe timeout would fail), and a port that fails to open

A fake serial object is injected throughout — no real port is opened anywhere.

**`tests/unit/test_events.py` (new, 14 tests)**

`sorter/events.py` had no test module. Covers subscribe/post/drain delivery, topic scoping, multiple subscribers, `drain()`'s return count, the `max_items` cap leaving the remainder queued in FIFO order, unsubscribe, posting to a topic with no subscribers, subscribing from inside a handler, and concurrent posts from worker threads.

**`tests/unit/test_db.py` (11 tests, +5)**

Migration coverage for the `PRAGMA user_version` schema path. A database is written at an older shape (`headstamps` without `parent_id`; optionally `headstamp_parents` without `slot`), then `ensure_initialized()` runs and the tests assert that `user_version` lands on `SCHEMA_VERSION`, the added columns exist with sane defaults, pre-existing rows survive with their data intact and the DB is **not** re-seeded, the migration is idempotent across a second `Database` instance, and a DB stamped by a newer build is not downgraded. All on `tmp_path` — the real data root is never touched.

## The shared fixture, and the gap it exposed

`test_db.py`, `test_headstamp_parents.py` and `test_parent_runtime.py` had each grown their own hand-written "legacy" SQLite schema. They are now one `tests/unit/_legacy_db.py`.

Its `models` table is deliberately **trimmed to the four columns that predate everything else**, rather than being a copy of the current 24-column DDL. The copy was actively misleading: it made the fixture look like it covered a `models` migration when no such migration exists, and it would have drifted silently the next time a column was added.

That gap is now pinned rather than hidden. `_apply_column_migrations` only ever touches `headstamps.parent_id` and `headstamp_parents.slot`, and the schema DDL is `CREATE TABLE IF NOT EXISTS` — so an existing `models` table is **never migrated at all**, while `user_version` is stamped current regardless. Filed as #44; `test_an_existing_models_table_is_not_migrated_at_all` is expected to flip when that lands.

The two pre-existing modules keep the assertions that are theirs alone (that the parent *relationship* and `update_slot` work through the repos after migrating); only the duplicated schema went away.

## Characterization tests — please read this part

Several serial assertions **deliberately pin current behavior that [#34](https://github.com/sjseth/AI-Case-Sorter-Py/issues/34) argues is wrong.** Each one carries a comment saying so directly above it. The dispatch chain in `_process_buffer` is a sequence of unanchored `in` substring tests, each of which `continue`s, so today:

- `"error: broken sensor"` fires **`on_ok`** and never reaches `on_error` — "br**ok**en" matches the earlier branch
- any line containing `ok` anywhere (`token`, `bookkeeping`) fires `on_ok`
- any line containing `done` anywhere fires `on_done` — including `"undone"`, the semantic *inversion*, where a board reporting an operation was reversed reads as one that completed
- **a diagnostic line merely mentioning "done" satisfies a real pending `feed_one()`** — `feed_one` / `sort_and_move` / `force_sort_and_move` all return by waiting on `on_done`, so this is the consequence that makes the unanchored matching matter rather than merely being untidy
- a JSON `getconfig` payload containing `ok` in a key never reaches `on_response`, which is where `get_config()` captures it
- `try_open` accepts any banner containing `ok` — including `"not ok, firmware broken"` — and anything containing `7.`, e.g. `"boot at 17.5s"`

The `EventBus` tests do the same for [#32](https://github.com/sjseth/AI-Case-Sorter-Py/issues/32): a handler that raises is swallowed with no logging. #32 adds logging while keeping the swallow (one bad handler must not take down the Tk drain loop), so that assertion should keep holding either way.

The point is that these two issues become safe to act on: the diff that fixes them will show exactly which behaviors change, instead of the change being invisible.

**To be clear and not overclaim: this parser behavior was found by code review. It has not been observed on hardware**, and I don't know whether any real firmware emits a line that trips it. The tests make no claim about impact — they only record what the code does today.

## Notes

- Commit type is `test:` on purpose — no version bump.
- `ruff check` and `ruff format --check` clean.
- **Mutation-checked**, which is the property that makes the characterization tests worth having: applying the plausible #34 fix (anchoring the substring tests, `"7." in` → `startswith`) fails **exactly the characterization tests and nothing else** — every behavioral test stays green.
