### PR TITLE
fix(camera): bind the loop variable in the backend-probe closures

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -91,8 +91,9 @@ ignore = [
 # variables), so they're deferred to a follow-up review pass.
 #
 # Pinned per-file rather than disabled repo-wide, which is what they were
-# first written as. B023 (closure doesn't bind the loop variable) and F841 are
-# bug classes, not style: switched off globally they'd also silence every
+# first written as. B023 (closure doesn't bind the loop variable) -- since
+# cleared, which is this table working as intended -- and F841 are bug
+# classes, not style: switched off globally they'd also silence every
 # *new* occurrence anywhere in the tree, which is the opposite of "deferred" --
 # it's "permanently invisible". Scoped like this the deferral stays honest, the
 # rest of the codebase keeps the check, and the list shrinks visibly as the
@@ -111,7 +112,6 @@ ignore = [
 "sorter/eval_report.py" = ["W291", "W293"]
 
 # --- deferred pre-existing findings (see the note above [tool.ruff.lint]) ---
-"sorter/camera.py" = ["B023"]                     # backend-probe closures
 "sorter/community_api.py" = ["B904"]              # raise without `from` in except
 "sorter/evaluator.py" = ["B007"]                  # unused loop control variable
 "sorter/local_inference.py" = ["F841"]            # unused local

--- a/sorter/camera.py
+++ b/sorter/camera.py
@@ -214,13 +214,13 @@ def enumerate_devices(max_index: int = 10, probe_timeout_s: float = 1.5) -> list
     for idx in _candidate_indices(max_index):
         result: list[bool] = [False]
 
-        def _probe(i: int = idx) -> None:
+        def _probe(i: int = idx, res: list[bool] = result) -> None:
             cap = cv2.VideoCapture(i, backend)
             try:
                 if cap.isOpened():
                     ok, _ = cap.read()
                     if ok:
-                        result[0] = True
+                        res[0] = True
             finally:
                 cap.release()
 
@@ -291,7 +291,7 @@ def list_cameras_with_metadata(max_index: int = 10, probe_timeout_s: float = 2.5
     for idx in candidates:
         result: dict = {"opened": False, "resolutions": [], "name": ""}
 
-        def _probe(i: int = idx) -> None:
+        def _probe(i: int = idx, res: dict = result) -> None:
             cap = cv2.VideoCapture(i, backend)
             try:
                 if not cap.isOpened():
@@ -308,8 +308,8 @@ def list_cameras_with_metadata(max_index: int = 10, probe_timeout_s: float = 2.5
                 ok, _ = cap.read()
                 if not ok:
                     return
-                result["opened"] = True
-                result["resolutions"] = resolutions
+                res["opened"] = True
+                res["resolutions"] = resolutions
             finally:
                 cap.release()
 


### PR DESCRIPTION
Fixes the `B023` findings in `sorter/camera.py`'s two backend-probe helpers
(`enumerate_devices`, `list_cameras_with_metadata`) and removes the per-file
ignore that was hiding them.

Follow-up to PR #14 §9.6.

## The findings

A plain `ruff check` reports success here — the `[tool.ruff.lint.per-file-ignores]`
entry masks it. With `--isolated`, on `main`:

```
$ uv run ruff check --isolated --select B023 sorter/camera.py
B023 Function definition does not bind loop variable `result`
   --> sorter/camera.py:223:25
    |
221 |                     ok, _ = cap.read()
222 |                     if ok:
223 |                         result[0] = True
    |                         ^^^^^^
224 |             finally:
225 |                 cap.release()
    |

B023 Function definition does not bind loop variable `result`
   --> sorter/camera.py:311:17
    |
309 |                 if not ok:
310 |                     return
311 |                 result["opened"] = True
    |                 ^^^^^^
312 |                 result["resolutions"] = resolutions
313 |             finally:
    |

B023 Function definition does not bind loop variable `result`
   --> sorter/camera.py:312:17
    |
310 |                     return
311 |                 result["opened"] = True
312 |                 result["resolutions"] = resolutions
    |                 ^^^^^^
313 |             finally:
314 |                 cap.release()
    |

Found 3 errors.
```

After this change, the same command reports `All checks passed!`.

## What was actually wrong

Both helpers loop over candidate device indices, define a `_probe` closure, and
run it on a worker thread.

- **The loop index was already bound correctly**, via a default argument
  (`def _probe(i: int = idx)`). That part was fine and is untouched.
- **The `result` accumulator was not bound.** The closure captured the
  enclosing-scope name, so each thread wrote through whatever `result` referred
  to at the moment it ran, not the object created for its own iteration.

§9.6 of #14 described this as an unbound *loop variable*, which was imprecise:
the loop variable is fine, the accumulator is not. Worth stating because it
changes what the fix looks like — `idx` needs nothing.

## Severity: reachable today

**An earlier revision of this description called the bug latent rather than
live. That was wrong, and the correction is the main reason this PR is worth
reading.**

The claim was that each probe thread is `join()`ed inside the same loop
iteration, so only one closure is ever live at a time. That holds only when the
join *succeeds*. `t.join(probe_timeout_s)` is a **timeout** join on a
`daemon=True` thread — precisely the case the docstring exists for:

> Each probe runs in a worker thread; we move on if it exceeds probe_timeout_s
> (some V4L2 devices hang indefinitely on open).

On timeout the loop moves on while the abandoned thread keeps running. When it
eventually returns from `cap.read()`, the pre-fix code resolved the name
`result` *at that moment* — and by then it pointed at a later index's
accumulator.

Reproduced against stub probes that mirror the pre-fix closure semantics
exactly (`i` bound via default argument as it always was, `result` left as a
free variable):

```
idx0: opens at t=1.3s, but its own join(1.0) already timed out at t=1.0
idx1: never opens; its own probe takes 0.95s to fail
-> idx0's straggler fires at t=1.3s, inside idx1's join window, and writes
   into the rebound cell — which is now idx1's list
found = [1]      # idx1 falsely reported as a detected camera
```

So the consequences are:

- `enumerate_devices` reports a camera at an index where there is none, and
  misses the one that actually responded.
- `list_cameras_with_metadata` attaches one device's resolution list to a
  different device.

Nothing exotic is needed to trigger this — just a second probe that itself
takes a while to fail, which is ordinary when scanning up to 10 candidate
indices on a machine with a flaky or slow-opening V4L2 device.

**To be clear about provenance: this has not been observed on hardware and no
bug report prompted it.** It was found by code review and confirmed by
reproduction, not by a user hitting it. But it is a real defect on a real code
path, not a style finding.

## The change

`result` is now bound per iteration as a default argument, matching the idiom
the code already uses for the index — no new pattern introduced:

```python
def _probe(i: int = idx, res: list[bool] = result) -> None:
```

```python
def _probe(i: int = idx, res: dict = result) -> None:
```

The `"sorter/camera.py" = ["B023"]` entry is removed from
`[tool.ruff.lint.per-file-ignores]` so the pattern cannot come back unnoticed.
Every other entry in that table is left alone. The explanatory comment above
the table cited B023 as a *current* example of a rule pinned per-file rather
than disabled repo-wide; it now records it as cleared, which is that comment's
own stated expectation ("the list shrinks visibly as the follow-up lands").

### Scope note

The read sites in the loop bodies (`camera.py:230`, `:319`, `:324`) still
reference the loop-scoped `result`, which is correct as the code stands, since
each is reached after that iteration's `join()`. Probing devices concurrently —
the obvious optimization for a scan costing up to `probe_timeout_s` per index
across up to 10 of them — would require reworking those reads as well. This
change is a **precondition** for that, not the whole of it.

## Tests

No test added. There is no existing camera-probe coverage, and a regression
test would need a fake `cv2.VideoCapture` plus an orchestrated hanging probe to
recreate the timing above — disproportionate for a five-line fix. `ruff`
enforcing `B023` repo-wide is the durable structural guard here, and it now
does.

## Verification

- `uv run ruff check --isolated --select B023 sorter/camera.py` — clean (3 findings before)
- `uv run ruff check` — clean
- `uv run ruff format --check` — clean
- `uv run pytest` — `594 passed, 16 skipped in 284.71s`; the 16 skips are the
  pre-existing integration tests that need `git-cliff`
