### PR TITLE
refactor: clear the deferred ruff ignores

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,19 +86,19 @@ select = [
 ignore = [
     "E501",  # line length is enforced by the formatter, not the linter
 ]
-# Pre-existing findings as of the tool-adoption PR: real, but not a formatting
-# concern, and fixing them changes behavior (closures, exception chaining, loop
-# variables), so they're deferred to a follow-up review pass.
+# The tool-adoption PR deferred a batch of pre-existing findings here rather
+# than disabling the rules repo-wide, so that the deferral stayed honest: B023
+# (closure doesn't bind the loop variable) and F841 are bug classes, not style,
+# and switching them off globally would also have silenced every *new*
+# occurrence anywhere in the tree. Scoped per-file the rest of the codebase
+# keeps the check and the list shrinks visibly as the follow-up lands -- which
+# is what happened: the mechanical ones (B904, B007, F841) are fixed and gone
+# from the table below. What is left is kept on purpose, each with its reason.
 #
-# Pinned per-file rather than disabled repo-wide, which is what they were
-# first written as. B023 (closure doesn't bind the loop variable) and F841 are
-# bug classes, not style: switched off globally they'd also silence every
-# *new* occurrence anywhere in the tree, which is the opposite of "deferred" --
-# it's "permanently invisible". Scoped like this the deferral stays honest, the
-# rest of the codebase keeps the check, and the list shrinks visibly as the
-# follow-up lands. Ruff errors on a per-file-ignore whose file no longer trips
-# the rule only under --extend-select preview settings, so re-check with
-# `ruff check --select ...` when clearing one out.
+# Ruff errors on a per-file-ignore whose file no longer trips the rule only
+# under --extend-select preview settings, so when clearing one out, re-check
+# with `ruff check --isolated --select ...` -- that bypasses this table and so
+# proves the finding is actually fixed rather than still masked.
 
 [tool.ruff.lint.per-file-ignores]
 # Must run on whatever ancient interpreter the user's system provides, since
@@ -110,16 +110,10 @@ ignore = [
 # part of the port; don't rewrite it.
 "sorter/eval_report.py" = ["W291", "W293"]
 
-# --- deferred pre-existing findings (see the note above [tool.ruff.lint]) ---
+# --- kept on purpose (see the note above [tool.ruff.lint]) ---
 "sorter/camera.py" = ["B023"]                     # backend-probe closures
-"sorter/community_api.py" = ["B904"]              # raise without `from` in except
-"sorter/evaluator.py" = ["B007"]                  # unused loop control variable
-"sorter/local_inference.py" = ["F841"]            # unused local
 "sorter/model_io.py" = ["UP042"]                  # str+Enum -> StrEnum changes behavior subtly
-"sorter/ui/dialog_training_config.py" = ["B007"]  # unused loop control variable
-"sorter/ui/tab_train.py" = ["F841"]               # unused local
-"tests/unit/test_db.py" = ["B017"]                     # assert-raises-Exception, deliberate here
-"tests/unit/test_repository.py" = ["F841"]             # unused fixture local
+"tests/unit/test_db.py" = ["B017"]                # assert-raises-Exception, deliberate here
 
 [tool.ruff.lint.isort]
 known-first-party = ["sorter"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -86,24 +86,25 @@ select = [
 ignore = [
     "E501",  # line length is enforced by the formatter, not the linter
 ]
-# The tool-adoption PR deferred a batch of pre-existing findings here rather
-# than disabling the rules repo-wide, so that the deferral stayed honest: B023
-# (closure doesn't bind the loop variable) and F841 are bug classes, not style,
-# and switching them off globally would also have silenced every *new*
-# occurrence anywhere in the tree. Scoped per-file the rest of the codebase
-# keeps the check and the list shrinks visibly as the follow-up lands -- which
-# is what happened: the mechanical ones (B904, B007, F841) are fixed and gone
-# from the table below. What is left is kept on purpose, each with its reason.
+# Findings are pinned per-file below rather than switched off repo-wide: scoped
+# like this the rest of the tree keeps the check, so a *new* occurrence still
+# fails CI instead of landing silently. The batch the tool-adoption PR deferred
+# (B904, B007, F841) has since been fixed and removed from the table; what is
+# left is kept on purpose, each with its reason.
 #
-# Ruff errors on a per-file-ignore whose file no longer trips the rule only
-# under --extend-select preview settings, so when clearing one out, re-check
-# with `ruff check --isolated --select ...` -- that bypasses this table and so
-# proves the finding is actually fixed rather than still masked.
+# Ruff never flags a per-file-ignore whose file no longer trips the rule, so a
+# stale entry here is invisible -- no mode of the linter reports one. When
+# clearing one out, re-check with
+# `ruff check --isolated --target-version py312 --select ...`: --isolated
+# bypasses this table, and --target-version puts back the one setting it
+# discards that matters here. Without it, version-gated rules (UP042) report a
+# false pass and the entry looks stale when it is still live.
 
 [tool.ruff.lint.per-file-ignores]
 # Must run on whatever ancient interpreter the user's system provides, since
 # its job is to provision a newer one. pyupgrade rewrites would silently
-# break it on exactly the systems it exists to serve.
+# break it on exactly the systems it exists to serve. Preventive, not deferred:
+# the file is clean today, and this entry is what keeps it that way.
 "bootstrap.py" = ["UP"]
 # Contains an embedded HTML/JS template as a verbatim port of the legacy
 # WinForms app's report (see CLAUDE.md). Whitespace inside that string is

--- a/sorter/community_api.py
+++ b/sorter/community_api.py
@@ -524,8 +524,8 @@ class CommunityApi:
             )
         try:
             data = resp.json()
-        except ValueError:
-            raise CommunityApiError(f"FileUploadRequest returned non-JSON: {text[:200]!r}")
+        except ValueError as exc:
+            raise CommunityApiError(f"FileUploadRequest returned non-JSON: {text[:200]!r}") from exc
         if not isinstance(data, dict):
             raise CommunityApiError("FileUploadRequest returned an unexpected payload.")
         ticket = SasResponse.from_json(data)

--- a/sorter/evaluator.py
+++ b/sorter/evaluator.py
@@ -102,7 +102,7 @@ def _score_token_match(target: list[str], model: list[str]) -> float:
     positional = sum(1 for i in range(min(len(target), len(model))) if _tokens_equivalent(target[i], model[i]))
     score += positional * 50.0
     in_order, last = True, -1
-    for t, m in sorted(matches, key=lambda x: x[0]):
+    for _, m in sorted(matches, key=lambda x: x[0]):
         if m < last:
             in_order = False
             break

--- a/sorter/local_inference.py
+++ b/sorter/local_inference.py
@@ -203,7 +203,7 @@ def _dump_environment(torch_mod: Any) -> None:
                 t = time.perf_counter()
                 iters = 10
                 for _ in range(iters):
-                    y = x @ x
+                    _ = x @ x
                 torch_mod.cuda.synchronize()
                 ms_per = (time.perf_counter() - t) * 1000.0 / iters
                 print(f"[env] matmul_1024x1024_fp32: {ms_per:.2f} ms/iter", file=sys.stderr, flush=True)

--- a/sorter/ui/dialog_training_config.py
+++ b/sorter/ui/dialog_training_config.py
@@ -54,23 +54,24 @@ class TrainingConfigDialog(tk.Toplevel):
         frm = ttk.Frame(self, padding=12)
         frm.pack(fill=tk.BOTH, expand=True)
 
+        # (label, settings key, Spinbox kwargs) — every row is a Spinbox, so
+        # there is no widget-kind column to carry.
         rows = [
-            ("Epochs", "epochs", "spin", {"from_": 1, "to": 200}),
-            ("Batch size", "batch_size", "spin", {"from_": 1, "to": 1024}),
-            ("Learning rate", "learning_rate", "spin", {"from_": 1e-6, "to": 1.0, "increment": 1e-5, "format": "%.6f"}),
-            ("Weight decay", "weight_decay", "spin", {"from_": 0.0, "to": 1.0, "increment": 1e-5, "format": "%.6f"}),
-            ("Dropout", "dropout_rate", "spin", {"from_": 0.0, "to": 1.0, "increment": 0.05, "format": "%.2f"}),
-            ("Validation split", "val_split", "spin", {"from_": 0.0, "to": 0.99, "increment": 0.05, "format": "%.2f"}),
-            ("Image size", "image_size", "spin", {"from_": 64, "to": 512}),
-            ("Max workers (-1 = auto)", "max_workers", "spin", {"from_": -1, "to": 64}),
+            ("Epochs", "epochs", {"from_": 1, "to": 200}),
+            ("Batch size", "batch_size", {"from_": 1, "to": 1024}),
+            ("Learning rate", "learning_rate", {"from_": 1e-6, "to": 1.0, "increment": 1e-5, "format": "%.6f"}),
+            ("Weight decay", "weight_decay", {"from_": 0.0, "to": 1.0, "increment": 1e-5, "format": "%.6f"}),
+            ("Dropout", "dropout_rate", {"from_": 0.0, "to": 1.0, "increment": 0.05, "format": "%.2f"}),
+            ("Validation split", "val_split", {"from_": 0.0, "to": 0.99, "increment": 0.05, "format": "%.2f"}),
+            ("Image size", "image_size", {"from_": 64, "to": 512}),
+            ("Max workers (-1 = auto)", "max_workers", {"from_": -1, "to": 64}),
             (
                 "Stochastic depth prob (-1 = default)",
                 "stochastic_depth_prob",
-                "spin",
                 {"from_": -1.0, "to": 0.5, "increment": 0.05, "format": "%.2f"},
             ),
         ]
-        for i, (lbl, key, kind, kwargs) in enumerate(rows):
+        for i, (lbl, key, kwargs) in enumerate(rows):
             ttk.Label(frm, text=lbl).grid(row=i, column=0, sticky="w", padx=4, pady=2)
             ttk.Spinbox(frm, textvariable=self.vars[key], width=12, **kwargs).grid(
                 row=i,

--- a/sorter/ui/tab_train.py
+++ b/sorter/ui/tab_train.py
@@ -360,7 +360,6 @@ class TrainTab(ttk.Frame):
         # Feeding the model the wrong resolution silently degrades
         # predictions, so pass the trained size through to local_inference.
         train_image_size = int(active.training_config.image_size) if active and active.training_config else None
-        api_cfg = dict(self.config.api)
 
         def _work():
             import time

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -127,12 +127,13 @@ def test_headstamps_cascade_on_model_delete(tmp_path: Path) -> None:
     db = _new_db(tmp_path)
     cart_id = CartridgeRepo(db).create("9x18").id
     model = ModelRepo(db).create(Model(name="m1", cartridge_id=cart_id, model_mode="convnext_tiny"))
-    # The row itself is the point — a second model keeps the cartridge
-    # non-empty when m1 is deleted below. Created, never referenced by name.
+    # The row itself is the point: ModelRepo.delete refuses to remove the last
+    # model in a cartridge, so the delete below needs a second model to get past
+    # that guard and reach the cascade. Created, never referenced by name.
     ModelRepo(db).create(Model(name="m2", cartridge_id=cart_id, model_mode="convnext_tiny"))
     HeadstampRepo(db).add(model.id, "X")
     HeadstampRepo(db).add(model.id, "Y")
-    ModelRepo(db).delete(model.id)  # sibling keeps cartridge non-empty
+    ModelRepo(db).delete(model.id)
     assert HeadstampRepo(db).list_for_model(model.id) == []
 
 

--- a/tests/unit/test_repository.py
+++ b/tests/unit/test_repository.py
@@ -127,7 +127,9 @@ def test_headstamps_cascade_on_model_delete(tmp_path: Path) -> None:
     db = _new_db(tmp_path)
     cart_id = CartridgeRepo(db).create("9x18").id
     model = ModelRepo(db).create(Model(name="m1", cartridge_id=cart_id, model_mode="convnext_tiny"))
-    sibling = ModelRepo(db).create(Model(name="m2", cartridge_id=cart_id, model_mode="convnext_tiny"))
+    # The row itself is the point — a second model keeps the cartridge
+    # non-empty when m1 is deleted below. Created, never referenced by name.
+    ModelRepo(db).create(Model(name="m2", cartridge_id=cart_id, model_mode="convnext_tiny"))
     HeadstampRepo(db).add(model.id, "X")
     HeadstampRepo(db).add(model.id, "Y")
     ModelRepo(db).delete(model.id)  # sibling keeps cartridge non-empty


### PR DESCRIPTION
Follow-up to #14 §9.6, which parked a batch of pre-existing findings in
`[tool.ruff.lint.per-file-ignores]` rather than fixing them inside a
formatting change. This clears the mechanical ones — B904, B007, F841 — and
removes exactly those entries from the table.

**No behavior changes.** This is a cleanup; each site is argued below.

## Before

`ruff check --isolated --select B904,B007,F841` bypasses the per-file-ignore
table, so it shows the findings as they really are rather than as the table
masks them. On `main`:

```
B904 Within an `except` clause, raise exceptions with `raise ... from err` ...
   --> sorter/community_api.py:528:13
B007 Loop control variable `t` not used within loop body
   --> sorter/evaluator.py:105:9
F841 Local variable `y` is assigned to but never used
   --> sorter/local_inference.py:206:21
B007 Loop control variable `kind` not used within loop body
  --> sorter/ui/dialog_training_config.py:73:27
F841 Local variable `api_cfg` is assigned to but never used
   --> sorter/ui/tab_train.py:363:9
F841 Local variable `sibling` is assigned to but never used
   --> tests/unit/test_repository.py:130:5
Found 6 errors.
```

## After

```
$ uv run ruff check --isolated --select B904,B007,F841
All checks passed!

$ uv run ruff check
All checks passed!

$ uv run ruff format --check
240 files already formatted

$ uv run pytest
594 passed, 16 skipped in 287.79s (0:04:47)
```

(The 16 skips are pre-existing: the integration tests that shell out to
`git-cliff` / `uv build`, self-skipping when the tool isn't installed.)

## B904 — `sorter/community_api.py`

One site, in `_request_upload_sas`: `resp.json()` raising `ValueError` is
re-raised as `CommunityApiError`. Chained with **`from exc`**.

`updater.py:290` is the identical situation — a JSON decode failure from a
server response re-raised as the module's own error type — and already
chains with `from exc`; every other `raise ... from` in `sorter/` does the
same. `from None` would be the call if the decoder's "Expecting value: line
1 column 1" were noise that misleads, but here it corroborates rather than
distracts: the raised message already quotes the raw body, and keeping the
cause makes a truncated/HTML-ish body debuggable from a traceback. Following
the house style rather than inventing a second convention for one site.

## B007 — unused loop control variables

**`sorter/evaluator.py`** (`_score_token_match`) — `for t, m in sorted(matches,
key=lambda x: x[0])` only reads `m`; `t` exists to define the sort order, not
to be used. Bound to `_`. The `key=` is untouched, so iteration order is
identical.

**`sorter/ui/dialog_training_config.py`** — restructured rather than renamed.
The `rows` table carried a widget-kind column whose value was `"spin"` on
every single row and which the loop never read — the body unconditionally
builds a `ttk.Label` + `ttk.Spinbox`. Renaming to `_kind` would have
preserved a column that means nothing; dropping it leaves `(label, key,
Spinbox kwargs)`, which is what the table actually is. Same widgets, same
grid positions, and `flags_row = len(rows)` is unaffected (the row *count*
didn't change, only the tuple width).

## F841 — unused locals

This is the rule where a careless "cleanup" changes behavior, so each RHS was
checked for side effects before anything was deleted:

**`sorter/local_inference.py`** — `y = x @ x` inside the timed benchmark loop.
The multiply **is** the benchmark; deleting the statement would have made the
reported `ms/iter` measure an empty loop. Kept the call, dropped only the
name: `_ = x @ x`, exactly what the warm-up loop three lines above already
does.

**`sorter/ui/tab_train.py`** — `api_cfg = dict(self.config.api)` was genuinely
dead, and not a hint of a missing feature. The RHS is a plain dict copy (no
side effect), `api_cfg` is never captured by the `_work` closure or read
anywhere in the module, and `_work` classifies only via
`local_inference.classify`. That's by design, not an omission: the Train tab
is mounted only for a local trainable model (CLAUDE.md §5), so an AI Config
path here would be unreachable. Statement removed.

**`tests/unit/test_repository.py`** — `sibling = ModelRepo(db).create(...)` in
`test_headstamps_cascade_on_model_delete`. The RHS **does** have a side
effect and it is the point of the test: that second row is what keeps the
cartridge non-empty when `m1` is deleted, so removing the statement would
have silently weakened the test into a different scenario. Kept the call,
dropped the binding, and left a comment saying why the call stands alone so
nobody "tidies" it away later.

## Left in the table on purpose

- **`sorter/model_io.py` = `["UP042"]`** — **stays deferred.** UP042 wants
  `str, Enum` → `StrEnum`, which changes comparison semantics against the
  WinForms-compatible PascalCase manifest keys. Legacy-app interop is
  intentional (CLAUDE.md §8) and not worth risking for a lint line. Entry and
  its comment kept verbatim.
- **`sorter/camera.py` = `["B023"]`** — untouched here; handled in a separate
  open PR.
- **`bootstrap.py` = `["UP"]`**, **`sorter/eval_report.py` = `["W291","W293"]`**,
  **`tests/unit/test_db.py` = `["B017"]`** — all deliberate, untouched.

Nothing was found that looked like a real bug hiding behind one of these
ignores, so nothing new was left ignored.

The prose above the table is updated to match: the remaining entries are kept
on purpose rather than "deferred", and the note now points at `--isolated` as
the way to prove a finding is fixed rather than still masked.
