### PR TITLE
fix(launcher): stop installing dev dependencies on user machines

### DIFF
--- a/bootstrap.py
+++ b/bootstrap.py
@@ -31,7 +31,7 @@ What it does, in order:
      only now there's no hash-based marker at all, because `uv sync`
      reconciles against the venv's actual contents rather than trusting a
      proxy for them.
-  4. `uv sync --frozen --no-install-project` -- --frozen takes the committed
+  4. `uv sync --frozen --no-dev --no-install-project` -- --frozen takes the committed
      uv.lock as-is and never re-resolves on a user's machine, so launches
      stay deterministic and offline-safe (CI uses `--locked` instead, which
      fails if the lock has drifted from pyproject.toml -- see
@@ -40,6 +40,8 @@ What it does, in order:
      tree, so it was never needed for that, and building it is actively
      harmful when there's no .git to derive a version from (see
      pyproject.toml's [tool.hatch.version] and sorter/__init__.py).
+     --no-dev keeps the `dev` group (pytest, ruff) out of a user's venv --
+     uv installs it by default, and it is pure CI tooling.
   5. Launch the app: `uv run --no-sync python main.py <forwarded args>`.
      --no-sync, not --frozen: `uv run` syncs implicitly by default even with
      --frozen, which would redo the very build step 4 skipped.
@@ -420,9 +422,17 @@ def main(argv: list[str] | None = None) -> int:
     # restart, and find it gone, with a multi-GB re-download to get back.
     # CI still syncs exactly (--locked in build.yml); being strict is the
     # whole point there. Here, a user-installed extra has to survive.
+    #
+    # --no-dev: uv installs the `dev` dependency group by default, so without
+    # this every end user was getting pytest and ruff -- CI tooling, useless
+    # on a sorting machine. CI asks for the group explicitly where it wants
+    # it (`--only-group dev` in lint.yml, the default sync in build.yml), so
+    # nothing there depends on the launcher's behavior. Note that --inexact
+    # means this doesn't *remove* the group from installs that already have
+    # it; it only stops new ones from acquiring it.
     try:
         subprocess.run(
-            [uv, "sync", "--frozen", "--inexact", "--no-install-project"],
+            [uv, "sync", "--frozen", "--inexact", "--no-dev", "--no-install-project"],
             cwd=ROOT,
             check=True,
         )

--- a/tests/unit/test_bootstrap.py
+++ b/tests/unit/test_bootstrap.py
@@ -162,6 +162,27 @@ def test_sync_is_inexact_so_the_ml_extra_survives(bootstrap, monkeypatch) -> Non
     assert "--inexact" in sync_cmd, f"launcher sync would prune the [ml] extra: {sync_cmd}"
 
 
+def test_sync_skips_the_dev_group(bootstrap, monkeypatch) -> None:
+    """uv installs the `dev` dependency group by default. That group is CI
+    tooling (pytest, ruff) and has no business in an end user's venv -- the
+    launcher must ask for it to be left out."""
+    monkeypatch.setattr(bootstrap, "find_uv", MagicMock(return_value="/fake/uv"))
+    monkeypatch.setattr(bootstrap, "apply_pending_update", MagicMock())
+    monkeypatch.setattr(bootstrap, "ensure_linux_runtime_libs", MagicMock())
+
+    sync_cmd = []
+
+    def tracking_run(cmd, *a, **kw):
+        if cmd[1:2] == ["sync"]:
+            sync_cmd.extend(cmd)
+        return MagicMock(returncode=0)
+
+    monkeypatch.setattr(bootstrap.subprocess, "run", tracking_run)
+
+    bootstrap.main([])
+    assert "--no-dev" in sync_cmd, f"launcher sync would install pytest and ruff: {sync_cmd}"
+
+
 def test_sync_failure_exits_with_a_readable_message(bootstrap, monkeypatch) -> None:
     """The audience for this script is a non-developer who downloaded a ZIP;
     a raw CalledProcessError traceback is not an actionable failure."""


### PR DESCRIPTION
## What & Why

`bootstrap.py` synced dependencies with `uv sync --frozen --inexact --no-install-project`. `uv sync` installs the `dev` dependency group **by default**, and this project's `dev` group is `pytest` + `ruff` — so every launch through `start.sh`/`start.bat`, and therefore every Windows install (`install-windows.ps1` hands off to `start.bat`), pulled CI tooling into the end user's venv.

Changes:

- `bootstrap.py` — pass `--no-dev` to `uv sync`, with a comment explaining why (and why CI is unaffected). Module docstring step 4 updated to match.
- `tests/unit/test_bootstrap.py` — `test_sync_skips_the_dev_group` asserts `--no-dev` is in the launcher's sync argv, alongside the existing `--inexact` guard.

CI is unaffected: `lint.yml` requests the group explicitly (`--only-group dev`) and `build.yml` runs its own `uv sync --locked`; neither goes through `bootstrap.py`.

Note that `--inexact` (needed so an on-demand PyTorch install survives a relaunch) means this does not *remove* pytest/ruff from installs that already have them — it only stops new installs from acquiring them.

Closes: #49

## Author Checklist

- [x] Verified the launcher still syncs and launches correctly on this branch

## Test Plan

### Before Deployment

**Author**
- [x] `pytest tests/unit/test_bootstrap.py` — 22 passed, including the new assertion
- [x] `ruff check` / `ruff format --check` on the changed files — clean
- [ ] Fresh install on Windows via `install-windows.bat`, confirm `.venv` has no `pytest`/`ruff`

**Reviewer**
- [ ] Confirm `--no-dev` doesn't regress the `[ml]`-extra survival behavior `--inexact` protects
- [ ] Confirm no CI job depends on `bootstrap.py` providing the dev group

