### PR TITLE
docs(installer): show how to run the validation tests without Windows

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -80,6 +80,24 @@ app. CI (`.github/workflows/build.yml`) runs the same suite across
 a Python version matrix on every push and PR — treat a red CI run the same as
 a local test failure, not as something to wait out.
 
+### The Windows installer's validation tests
+
+`installer/install-windows.ps1` checks archive entry names itself before
+letting `tar.exe` write a byte, and that check is the one part of this repo
+the Python suite cannot reach. It has its own tests, and they need neither
+Windows nor a local PowerShell:
+
+```bash
+docker run --rm -v "$PWD:/w" -w /w mcr.microsoft.com/powershell:7.4-ubuntu-22.04 \
+  pwsh -File installer/Test-ArchiveEntryValidation.ps1
+```
+
+Run them if you touch `installer/**` or `sorter/updater.py`'s `_safe_members`
+— the two extraction paths consume the *same* archives, so a shape one
+rejects and the other accepts is a bug in whichever accepts it. Everything
+else about the installer needs a real Windows machine; see
+[`installer/README.md`](installer/README.md).
+
 ## Coding guidelines
 
 - **Read [`CLAUDE.md`](CLAUDE.md) first** — it maps the architecture (event bus,

--- a/installer/README.md
+++ b/installer/README.md
@@ -83,6 +83,28 @@ explicitly.
 
 ## Testing the installer locally
 
+### Archive-entry validation — runs on any OS
+
+`Test-ArchiveEntryValidation.ps1` needs no Windows. It dot-sources this
+directory's script for its functions only (the guard on the main block stops
+it installing anything), so it runs under PowerShell on Linux or macOS:
+
+```bash
+docker run --rm -v "$PWD:/w" -w /w mcr.microsoft.com/powershell:7.4-ubuntu-22.04 \
+  pwsh -File installer/Test-ArchiveEntryValidation.ps1
+```
+
+Run it from the repo root; it takes a few seconds. There is no bare `7.4`
+tag on that registry — the tags are OS-qualified.
+
+Two things it does **not** prove. It runs PowerShell 7.4, whereas a real
+double-click through `install-windows.bat` runs **Windows PowerShell 5.1** —
+which is why CI uses `shell: powershell`, and why this file's header warns
+about BOM/codepage decoding. And it covers the entry-name checks only, not
+winget, `tar.exe`, the registry, or the python.org bundle.
+
+### The three provisioning paths — need a real Windows machine
+
 The installer has three Python-provisioning paths. CI exercises all three on
 every change to `installer/**` (the `installer-smoke` matrix:
 `preinstalled` / `winget` / `pythonorg`); this is how to run the same three by


### PR DESCRIPTION
## What & Why

`install-windows.ps1` validates archive entry names itself before letting `tar.exe` write a byte — and per `Test-ArchiveEntryValidation.ps1`'s own header, that is *"the half of this repo that CANNOT be exercised by the Python suite"*. Both `installer/README.md` and `CONTRIBUTING.md` implied you needed a Windows machine to exercise any of it.

You don't. The test script dot-sources the installer **for its functions only** (the guard on its main block stops it installing anything), so it runs under PowerShell on Linux:

```bash
docker run --rm -v "$PWD:/w" -w /w mcr.microsoft.com/powershell:7.4-ubuntu-22.04 \
  pwsh -File installer/Test-ArchiveEntryValidation.ps1
```

23 tests, a few seconds, no Windows and no local PowerShell install.

### The caveats are the point

Documented alongside the command, because a green run here is easy to over-read:

- It runs **PowerShell 7.4**, whereas a real double-click through `install-windows.bat` runs **Windows PowerShell 5.1** — which is exactly why `installer-smoke.yml` uses `shell: powershell` and why the script's header warns about BOM/codepage decoding. This proves the validation *logic*, not 5.1 behaviour.
- It covers **entry-name checks only** — not winget, `%LOCALAPPDATA%`, `tar.exe`, the registry, or the silent python.org install. Those still need a real Windows machine or CI.

### Why that tag

There is **no bare `7.4` tag** on `mcr.microsoft.com/powershell` — the tags are OS-qualified (`7.4-ubuntu-22.04`, `7.4-windowsservercore-ltsc2022`, …). Not obvious, and it costs a failed pull to find out, so the README says so.

A digest pin would match the repo's supply-chain stance (cf. #64), but this is a dev-only convenience command and MCR republishes tags, so a digest would need bumping for no security gain — the archive it validates is a local checkout, not a downloaded artifact.

Also flags in CONTRIBUTING that these tests are worth running when touching `sorter/updater.py`'s `_safe_members`, since the two extraction paths consume the same archives — a shape one rejects and the other accepts is a bug in whichever accepts it.

## Author Checklist

- [x] Docs-only — no code, no behaviour change
- [x] Conventional Commit type `docs` (no release)

## Test Plan

**Author**
- [x] Ran the command **exactly as documented**, from a clean checkout of this branch: `all 23 passed`
- [x] Confirmed `mcr.microsoft.com/powershell:7.4` does **not** resolve (manifest unknown) — hence the OS-qualified tag
- [x] Confirmed the image reports PowerShell 7.4.6

**Reviewer**
- [ ] Run the command yourself and confirm 23 passed
- [ ] Sanity-check the 5.1-vs-7.4 caveat reads clearly enough that nobody treats this as installer coverage