### PR TITLE
feat(release): publish release candidates

### DIFF
--- a/.github/scripts/next-prerelease.sh
+++ b/.github/scripts/next-prerelease.sh
@@ -4,15 +4,11 @@
 #
 #   next-prerelease.sh 0.5.0 rc   ->  0.5.0rc1, then 0.5.0rc2, ...
 #
-# git-cliff only ever emits final versions, so this is what turns its
-# --bumped-version into a release candidate. A separate file rather than
-# inline workflow bash because it decides a released tag, which is the one
-# category of logic in this repo that is always pinned by a test
-# (tests/unit/test_next_prerelease.py; cf. tests/integration/test_cliff_config.py).
+# git-cliff only emits final versions; this is what turns its
+# --bumped-version into a release candidate.
 #
-# No separator between base and suffix: that is PEP 440's canonical spelling,
-# and the only one that survives the round trip through hatchling's sdist name
-# that release.yml asserts on.
+# No separator before the suffix: PEP 440's canonical spelling, and the only
+# one that survives hatchling's sdist name, which release.yml asserts on.
 
 set -euo pipefail
 

--- a/.github/scripts/next-prerelease.sh
+++ b/.github/scripts/next-prerelease.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+#
+# Print the next unused PEP 440 prerelease version for a base version.
+#
+#   next-prerelease.sh 0.5.0 rc   ->  0.5.0rc1, then 0.5.0rc2, ...
+#
+# git-cliff only ever emits final versions, so this is what turns its
+# --bumped-version into a release candidate. A separate file rather than
+# inline workflow bash because it decides a released tag, which is the one
+# category of logic in this repo that is always pinned by a test
+# (tests/unit/test_next_prerelease.py; cf. tests/integration/test_cliff_config.py).
+#
+# No separator between base and suffix: that is PEP 440's canonical spelling,
+# and the only one that survives the round trip through hatchling's sdist name
+# that release.yml asserts on.
+
+set -euo pipefail
+
+BASE="${1:?usage: next-prerelease.sh <base-version> <a|b|rc>}"
+KIND="${2:?usage: next-prerelease.sh <base-version> <a|b|rc>}"
+
+highest=0
+while IFS= read -r tag; do
+  n="${tag#"$BASE$KIND"}"
+  # Numeric compare, so rc9 -> rc10 rather than rc9 -> rc2. The guard also
+  # drops anything the glob dragged in that isn't a plain number.
+  [[ "$n" =~ ^[0-9]+$ ]] || continue
+  ((n > highest)) && highest="$n"
+done < <(git tag --list "$BASE$KIND*")
+
+echo "$BASE$KIND$((highest + 1))"

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -90,7 +90,7 @@ jobs:
       # installer being broken but the release it resolved to not carrying an
       # sdist under the name the installer matches -- after a package rename
       # every release cut before it is in exactly that state, and the symptom
-      # is an unhelpful "sorter\_version.py is missing" three steps later.
+      # is an unhelpful "_version.py is missing" three steps later.
       - name: Show the release under test
         shell: bash
         env:
@@ -266,16 +266,19 @@ jobs:
             Write-Error "main.py is missing -- the app was not installed."
             exit 1
           }
-          $versionFile = "$dest\sorter\_version.py"
-          if (-not (Test-Path $versionFile)) {
-            Write-Error "sorter\_version.py is missing -- installed from the source archive, not the sdist."
+          # Searched, not pinned: an untagged run installs /releases/latest,
+          # whose layout is whatever that release shipped.
+          $versionFile = Get-ChildItem -Path $dest -Filter _version.py -Recurse -File -ErrorAction SilentlyContinue |
+                         Select-Object -First 1
+          if (-not $versionFile) {
+            Write-Error "_version.py is missing -- installed from the source archive, not the sdist."
             exit 1
           }
-          $content = Get-Content $versionFile -Raw
-          Write-Host "----- sorter/_version.py -----"
+          $content = Get-Content $versionFile.FullName -Raw
+          Write-Host "----- $($versionFile.FullName) -----"
           Write-Host $content
           if ($content -notmatch "__version__\s*=.*'([0-9][^']*)'") {
-            Write-Error "sorter/_version.py does not carry a real version."
+            Write-Error "$($versionFile.FullName) does not carry a real version."
             exit 1
           }
           $installed = $Matches[1]

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -27,6 +27,12 @@ name: Release
 # No draft anywhere. A draft would be invisible to the verification too --
 # /releases/tags/<tag> 404s for the unauthenticated fetch the installer does --
 # which is exactly why the release is a prerelease and not a draft.
+#
+# Publishing an actual release candidate then costs one thing: not taking the
+# promote step. The `prerelease` input stops there, so an rc is a normal
+# release that was built, asserted and installer-verified exactly like any
+# other -- it just never becomes /releases/latest. Testers reach it through
+# the update dialog's version picker ("Show prereleases").
 
 on:
   workflow_dispatch:
@@ -35,6 +41,12 @@ on:
         description: "Version to release (PEP 440, no v prefix), e.g. 0.2.0. Leave empty to auto-detect from Conventional Commits."
         required: false
         type: string
+      prerelease:
+        description: "Publish as a release candidate instead of a release: verified like any release, but never promoted to latest. The number is chosen for you (0.5.0 -> 0.5.0rc1, then rc2)."
+        required: false
+        type: choice
+        options: [none, rc, b, a]
+        default: none
       ref:
         description: "Branch, tag, or commit SHA to release from. Leave empty for the branch this workflow was dispatched on."
         required: false
@@ -69,6 +81,7 @@ jobs:
       auto: ${{ steps.resolve.outputs.auto }}
       source: ${{ steps.resolve.outputs.source }}
       previous: ${{ steps.previous.outputs.tag }}
+      prerelease: ${{ steps.resolve.outputs.prerelease }}
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
@@ -83,33 +96,43 @@ jobs:
         with:
           version: ${{ inputs.version }}
 
-      # Captured before the release job creates the new tag -- git describe run
+      # Captured before the release job creates the new tag -- a lookup run
       # after that would find the just-created tag instead.
+      #
+      # Selects tags the way git-cliff does, so this names the boundary the
+      # notes actually came from: the grep mirrors cliff.toml's tag_pattern,
+      # and there is no `--merged` because git-cliff does not require the tag
+      # to be an ancestor of HEAD.
       - name: Record previous tag
         id: previous
         run: |
-          echo "tag=$(git describe --tags --abbrev=0 2>/dev/null || echo "")" >> "$GITHUB_OUTPUT"
+          PREV="$(git tag --list --sort=-version:refname | grep -E '^[0-9]+\.[0-9]+\.[0-9]+$' | head -1)"
+          echo "tag=$PREV" >> "$GITHUB_OUTPUT"
 
       - name: Resolve version
         id: resolve
         env:
           REQUESTED: ${{ inputs.version }}
           FORCE: ${{ inputs.force }}
+          KIND: ${{ inputs.prerelease }}
         run: |
           AUTO="$(git-cliff --config cliff.toml --bumped-version)"
 
+          # The force check compares the *base*, not the suffixed version:
+          # git-cliff never proposes an rc, so the latter would demand `force`
+          # for every candidate.
           if [ -z "$REQUESTED" ]; then
-            VERSION="$AUTO"
+            BASE="$AUTO"
             SOURCE="auto-detected from Conventional Commits"
           else
             # Already validated by check-version above.
-            VERSION="$REQUESTED"
-            if [ "$VERSION" != "$AUTO" ]; then
+            BASE="$REQUESTED"
+            if [ "$BASE" != "$AUTO" ]; then
               if [ "$FORCE" != "true" ]; then
-                echo "::error::Version '$VERSION' disagrees with the auto-detected '$AUTO'. Re-run with force enabled if that is deliberate."
+                echo "::error::Version '$BASE' disagrees with the auto-detected '$AUTO'. Re-run with force enabled if that is deliberate."
                 exit 1
               fi
-              echo "::warning::Forcing '$VERSION' over the auto-detected '$AUTO'."
+              echo "::warning::Forcing '$BASE' over the auto-detected '$AUTO'."
               SOURCE="user-specified (forced over '$AUTO')"
             else
               SOURCE="user-specified (matches auto-detected)"
@@ -119,16 +142,43 @@ jobs:
           # Auto-detect can legitimately return nothing useful -- e.g. a repo
           # with no tags *and* no conventional commits to infer a bump from.
           # Better to fail here than to try tagging an empty string.
-          if [ -z "$VERSION" ]; then
+          if [ -z "$BASE" ]; then
             echo "::error::Could not determine a version to release. Pass one explicitly."
             exit 1
+          fi
+
+          VERSION="$BASE"
+          if [ "$KIND" != "none" ] && [ -n "$KIND" ]; then
+            # A version typed with its own segment is taken at face value --
+            # re-suffixing 0.5.0rc1 would produce nonsense.
+            if echo "$BASE" | grep -qE '(a|b|rc)[0-9]+$'; then
+              echo "::warning::'$BASE' already names a prerelease; using it as given rather than appending '$KIND'."
+            else
+              VERSION="$(.github/scripts/next-prerelease.sh "$BASE" "$KIND")"
+              SOURCE="$SOURCE, as $KIND"
+            fi
+          fi
+
+          # Read off the resolved version, not the input, so a hand-typed
+          # 0.5.0rc1 is treated as the prerelease it is.
+          if echo "$VERSION" | grep -qE '(a|b|rc)[0-9]+$'; then
+            PRERELEASE=true
+          else
+            PRERELEASE=false
           fi
 
           {
             echo "version=$VERSION"
             echo "auto=$AUTO"
             echo "source=$SOURCE"
+            echo "prerelease=$PRERELEASE"
           } >> "$GITHUB_OUTPUT"
+
+      # The input is validated above; this validates what was *computed* from
+      # it, which until now nothing did.
+      - uses: ./.github/actions/check-version
+        with:
+          version: ${{ steps.resolve.outputs.version }}
 
       # Also enforced in check-release.yml: this prevents before tagging, that
       # catches a release made by hand in the UI.
@@ -166,7 +216,13 @@ jobs:
           REF: ${{ inputs.ref || github.ref }}
           DRY_RUN: ${{ inputs.dry-run }}
           LATEST: ${{ steps.previous.outputs.tag }}
+          PRERELEASE: ${{ steps.resolve.outputs.prerelease }}
         run: |
+          if [ "$PRERELEASE" = "true" ]; then
+            FINISH="tag + prerelease + verify, then STOP -- not promoted to latest, no PyPI"
+          else
+            FINISH="tag + prerelease + verify + promote to latest + publish"
+          fi
           # Test the value: "false" is non-empty, so ${DRY_RUN:+...} would
           # expand for both.
           if [ "$DRY_RUN" = "true" ]; then
@@ -174,7 +230,7 @@ jobs:
             MODE="dry run -- nothing tagged, nothing published"
           else
             HEADING="Release"
-            MODE="awaiting approval, then tag + prerelease + verify + publish"
+            MODE="awaiting approval, then $FINISH"
           fi
           {
             echo "### $HEADING"
@@ -286,9 +342,12 @@ jobs:
         env:
           VERSION: ${{ needs.prepare.outputs.version }}
         run: |
-          BUILT="$(grep -oP "(?<=^__version__ = version = ')[^']+" sorter/_version.py)"
+          # Path tracks `version-file` in pyproject.toml's [tool.hatch.build.hooks.vcs].
+          # `head -1` keeps the exit status at 0 when the file is missing, so the
+          # error below is what a reader sees rather than a bare `set -e` abort.
+          BUILT="$(grep -hoP "(?<=^__version__ = version = ')[^']+" src/sorter/_version.py 2>/dev/null | head -1)"
           if [ "$BUILT" != "$VERSION" ]; then
-            echo "::error::Built version '$BUILT' does not match '$VERSION' -- refusing to release."
+            echo "::error::Built version '${BUILT:-<src/sorter/_version.py not found>}' does not match '$VERSION' -- refusing to release."
             exit 1
           fi
 
@@ -339,6 +398,7 @@ jobs:
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.prepare.outputs.version }}
+          PRERELEASE: ${{ needs.prepare.outputs.prerelease }}
         run: |
           URL=$(gh release create "$VERSION" \
             --title "$VERSION" \
@@ -351,8 +411,12 @@ jobs:
             echo ""
             echo "\`$VERSION\` -- $URL"
             echo ""
-            echo "Not visible to updaters yet: \`/releases/latest\` excludes prereleases."
-            echo "It is promoted only if the installer verification below passes."
+            echo "Not visible to updaters: \`/releases/latest\` excludes prereleases."
+            if [ "$PRERELEASE" = "true" ]; then
+              echo "This is a release candidate, so it stays that way -- it is verified below but never promoted."
+            else
+              echo "It is promoted only if the installer verification below passes."
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
 
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
@@ -375,6 +439,10 @@ jobs:
   # The moment the release becomes real. One flag flip, with the assets already
   # in place -- so there is no window where /releases/latest returns a release
   # whose sdist has not landed yet.
+  #
+  # A release candidate skips the flip and nothing else. Gated per *step*, not
+  # by skipping the job: a skipped job cascades through `needs: promote` and
+  # would take TestPyPI with it.
   promote:
     name: promote to latest
     needs: [prepare, verify-installer]
@@ -383,6 +451,7 @@ jobs:
       contents: write
     steps:
       - name: Promote the prerelease
+        if: ${{ needs.prepare.outputs.prerelease != 'true' }}
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           VERSION: ${{ needs.prepare.outputs.version }}
@@ -393,6 +462,25 @@ jobs:
             echo "### Released"
             echo ""
             echo "\`$VERSION\` is now the latest release. Updaters will pick it up."
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Leave it as a prerelease
+        if: ${{ needs.prepare.outputs.prerelease == 'true' }}
+        env:
+          VERSION: ${{ needs.prepare.outputs.version }}
+        run: |
+          {
+            echo "### Release candidate published"
+            echo ""
+            echo "\`$VERSION\` stays a prerelease. \`/releases/latest\` is unchanged, so no"
+            echo "existing install is offered it by the startup check."
+            echo ""
+            echo "To install it:"
+            echo ""
+            echo "- **In the app** -- \"Check for updates\" -> \"Choose a different version…\" -> tick \"Show prereleases\"."
+            echo "- **Fresh Windows install** -- \`install-windows.ps1 -Version $VERSION\`."
+            echo ""
+            echo "Cut the real release by running this workflow again with \`prerelease: none\`."
           } >> "$GITHUB_STEP_SUMMARY"
 
   # Gated behind a repo variable, unset = off, so this changes nothing until a
@@ -421,11 +509,12 @@ jobs:
 
   # Last, because it is the only step that cannot be undone: a PyPI version can
   # be yanked but never replaced. Everything before it -- the tag, the release,
-  # even the promotion -- can be deleted and redone.
+  # even the promotion -- can be deleted and redone. A release candidate
+  # therefore stops at TestPyPI; pip needs --pre to see a prerelease anyway.
   publish-to-pypi:
     name: publish to PyPI
-    needs: [promote, publish-to-testpypi]
-    if: vars.PYPI_PUBLISH_ENABLED == 'true'
+    needs: [prepare, promote, publish-to-testpypi]
+    if: vars.PYPI_PUBLISH_ENABLED == 'true' && needs.prepare.outputs.prerelease != 'true'
     runs-on: ubuntu-latest
     environment:
       name: stable

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -99,10 +99,9 @@ jobs:
       # Captured before the release job creates the new tag -- a lookup run
       # after that would find the just-created tag instead.
       #
-      # Selects tags the way git-cliff does, so this names the boundary the
-      # notes actually came from: the grep mirrors cliff.toml's tag_pattern,
-      # and there is no `--merged` because git-cliff does not require the tag
-      # to be an ancestor of HEAD.
+      # Selects tags as git-cliff does, so this names the boundary the notes
+      # came from: cliff.toml's tag_pattern, and no `--merged` because
+      # git-cliff does not require an ancestor of HEAD.
       - name: Record previous tag
         id: previous
         run: |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -786,7 +786,25 @@ flowchart TD
   currently offered, and even when the plain check said there was nothing
   newer — replaces what "Download & Install" targets and the notes/detail
   text update to match; the detail text says explicitly when the selection
-  isn't the newest release available.
+  isn't the newest release available. **This picker is the only route to a
+  release candidate** — the startup check hits `/releases/latest`, which
+  excludes prereleases, so an rc is never announced.
+- **Release candidates.** `release.yml`'s `prerelease` input (`none`/`rc`/`b`/
+  `a`) cuts one: everything a release does, minus the `promote` step, so the
+  GitHub release stays a prerelease permanently instead of as a staging state.
+  Three things hold it together, and each is pinned by a test:
+  - **`.github/scripts/next-prerelease.sh`** picks the number, because
+    git-cliff only emits final versions. `0.5.0` → `0.5.0rc1` → `0.5.0rc2`,
+    compared numerically so `rc9` → `rc10`.
+  - **`cliff.toml`'s `tag_pattern` is anchored at both ends**, making rc tags
+    invisible to git-cliff — otherwise `--bumped-version` hands back the rc
+    tag *itself* as the next version, and the release's notes would start at
+    the candidate rather than the last stable tag.
+  - **PEP 440's canonical spelling, no separator** (`0.5.0rc1`). hatchling
+    names the sdist from the normalized version and `release.yml` asserts the
+    two match, so `0.5.0-rc1` fails the release by design. `updater.is_newer`
+    ranks the same segments, which is what lets an rc install see the eventual
+    release as newer.
 - **`installer/`** — `install-windows.ps1` (+ `.bat` wrapper) provisions Python
   via winget or a silent python.org install, lays the app down in
   `%LOCALAPPDATA%\Programs\CaseSorter`, and hands off to `start.bat` (which just
@@ -862,8 +880,9 @@ flowchart TD
   edit that file. The backend itself is a separate service, not in this repo.
 - **Releases drive the updater.** There is no version string to edit — tagging
   *is* the bump (§7), and the release workflow derives the tag from the commit
-  types since the last one. `/releases/latest` excludes pre-releases, so
-  tagging an rc won't reach stable users. See `RELEASING.md`.
+  types since the last one. `/releases/latest` excludes pre-releases, which is
+  exactly what makes the `prerelease` input safe: an rc reaches testers who go
+  looking for it and nobody else. See `RELEASING.md`.
 - **The distribution path assumes a public repo.** The installer and updater
   both fetch anonymously over HTTPS; against a private repo every request
   404s and there is no in-band way to tell that apart from "no releases yet"

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -26,6 +26,8 @@
    - `force`: only needed when you pass a `version` that **disagrees** with the auto-detected
      one. Without it, a mismatch is a hard error naming both numbers -- that's the guard that
      catches "meant 0.3.0, typed 0.2.0" before it becomes a tag.
+   - `prerelease`: leave at `none` for a real release. See
+     [Cutting a release candidate](#cutting-a-release-candidate) below.
    - `dry-run`: **defaults to on.** Shows the resolved version and generated notes in the job
      summary without pushing a tag or creating anything. Uncheck it to actually release.
 4. The workflow resolves the version and generates changelog notes from commits since the last
@@ -41,9 +43,10 @@
 8. The Windows installer is run for real against that exact tag, and the resulting install has
    to carry that exact version.
 9. Only then is the prerelease promoted to the latest release -- one flag flip, assets already
-   in place.
+   in place. **A release candidate stops here instead**, staying a prerelease.
 10. Finally TestPyPI, then PyPI. Both are gated on the repo variable `PYPI_PUBLISH_ENABLED`,
-    unset by default, and each waits on its environment's reviewer.
+    unset by default, and each waits on its environment's reviewer. A release candidate reaches
+    TestPyPI but not PyPI.
 
 ### Why a prerelease rather than a draft
 
@@ -63,6 +66,38 @@ This also closes a window that used to exist: artifacts were attached *after* pu
 for a short time (26 seconds, measured on 1.0.0) `/releases/latest` returned a release with no
 matching sdist, and clients silently fell back to the source archive and installed something
 reporting `0.0.0+unknown`.
+
+## Cutting a release candidate
+
+Set `prerelease` to `rc` (or `b`/`a`) and run the workflow as normal. It does everything a real
+release does -- tags, builds, asserts the artifacts, publishes with assets attached, and installs
+the result on Windows for real -- and then **stops before step 9**. The release stays a
+prerelease permanently rather than as a staging state.
+
+- **The number is chosen for you.** git-cliff only ever emits final versions, so the workflow
+  appends the next unused suffix to whatever it resolved: `0.5.0` becomes `0.5.0rc1`, and running
+  it again gives `0.5.0rc2`. You don't pass `version`, and you don't need `force` -- the guard
+  that catches a mistyped version compares the *base*, which is unchanged.
+- **It's PEP 440, so there's no separator**: `0.5.0rc1`, never `0.5.0-rc1`. hatchling names the
+  sdist from the normalized version, and the workflow asserts the name matches the tag -- a
+  hyphenated tag fails the release on purpose (see `_expected_asset_name` in
+  `src/sorter/update/updater.py`).
+- **Candidates are invisible to versioning.** `cliff.toml`'s `tag_pattern` is anchored at both
+  ends, so an rc tag is not a release boundary: the eventual `0.5.0` is still computed from the
+  last stable tag, and its notes still span everything since that tag rather than starting at the
+  last candidate. Without that anchor git-cliff hands back the rc tag itself as the "next"
+  version -- pinned in `tests/integration/test_cliff_config.py`.
+- **TestPyPI yes, PyPI no.** PyPI is the one irreversible step and a candidate doesn't earn it;
+  `pip` needs `--pre` to see a prerelease anyway.
+
+**How a tester installs one.** `/releases/latest` still points at the last stable release, so
+nothing is offered automatically -- that's the point. In the app: the status-bar **Check for
+updates** button opens the dialog even when there's nothing new, then **"Choose a different
+version…"** → tick **"Show prereleases"** → pick the rc. For a fresh Windows machine,
+`install-windows.ps1 -Version 0.5.0rc1`.
+
+**Shipping the real release afterwards** is just the workflow again with `prerelease: none`. The
+candidates' tags stay where they are; nothing needs deleting.
 
 ## Versioning
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -49,17 +49,9 @@ commit_parsers = [
 protect_breaking_commits = true
 
 filter_commits = false
-# PEP 440, no `v` prefix -- see RELEASING.md. Anchored at both ends, and each
-# anchor earns its place:
-#
-# `^` -- unanchored, the obvious "[0-9].*" also matches a stray `v1.0.0` tag
-# (which check-release.yml rejects), silently making it a release boundary.
-#
-# `$` -- without it a release candidate (`0.5.0rc1`) is a boundary too, so the
-# final `0.5.0`'s notes would start at the rc and omit everything the rc was
-# cut to test, and --bumped-version would be computed relative to it. Release
-# candidates are deliberately invisible here: they carry the same notes as the
-# release they precede, spanning back to the last *stable* tag.
+# PEP 440, no `v` prefix -- see RELEASING.md. Anchored at both ends: without
+# `^` a stray `v1.0.0` tag becomes a release boundary, and without `$` so does
+# a release candidate, which would then base the next version on itself.
 tag_pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+$"
 sort_commits = "newest"
 

--- a/cliff.toml
+++ b/cliff.toml
@@ -49,10 +49,18 @@ commit_parsers = [
 protect_breaking_commits = true
 
 filter_commits = false
-# PEP 440, no `v` prefix -- see RELEASING.md. Anchored: unanchored, the
-# obvious "[0-9].*" also matches a stray `v1.0.0` tag (which check-release.yml
-# rejects), silently making it a release boundary.
-tag_pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+"
+# PEP 440, no `v` prefix -- see RELEASING.md. Anchored at both ends, and each
+# anchor earns its place:
+#
+# `^` -- unanchored, the obvious "[0-9].*" also matches a stray `v1.0.0` tag
+# (which check-release.yml rejects), silently making it a release boundary.
+#
+# `$` -- without it a release candidate (`0.5.0rc1`) is a boundary too, so the
+# final `0.5.0`'s notes would start at the rc and omit everything the rc was
+# cut to test, and --bumped-version would be computed relative to it. Release
+# candidates are deliberately invisible here: they carry the same notes as the
+# release they precede, spanning back to the last *stable* tag.
+tag_pattern = "^[0-9]+\\.[0-9]+\\.[0-9]+$"
 sort_commits = "newest"
 
 [bump]

--- a/tests/integration/test_cliff_config.py
+++ b/tests/integration/test_cliff_config.py
@@ -134,6 +134,27 @@ def test_tag_pattern_ignores_a_v_prefixed_tag(tmp_path: Path) -> None:
     assert _bumped_version(repo) == "0.2.0"
 
 
+def test_a_release_candidate_is_not_a_release_boundary(tmp_path: Path) -> None:
+    """tag_pattern is anchored at *both* ends so `0.5.0rc1` is invisible to
+    git-cliff. Two things follow, and both are the reason the `$` is there.
+
+    The bump is computed from the last stable tag, so cutting rc1, rc2 and
+    then the release all resolve the same 0.5.0. Without the anchor git-cliff
+    2.13.1 hands back `0.5.0rc1` verbatim -- not the rc's successor, the rc
+    itself -- so the release would try to tag a name that already exists, and
+    every further candidate would too.
+
+    And the changelog window spans back past the rc, so the release ships
+    notes covering everything the candidates were cut to test instead of only
+    what changed after the last one.
+    """
+    repo = _repo(tmp_path, "0.4.0", ["feat: a feature"])
+    subprocess.run(["git", "tag", "0.5.0rc1"], cwd=repo, check=True, capture_output=True)
+
+    assert _bumped_version(repo) == "0.5.0"
+    assert "A feature" in _changelog(repo)
+
+
 def test_changelog_line_degrades_gracefully_without_a_github_remote(tmp_path: Path) -> None:
     """The `by @user in #N` attribution suffix reads commit.remote.username /
     commit.remote.pr_number, both populated only by git-cliff's GitHub

--- a/tests/unit/test_next_prerelease.py
+++ b/tests/unit/test_next_prerelease.py
@@ -1,0 +1,148 @@
+"""Guards on .github/scripts/next-prerelease.sh -- the script that decides a
+release candidate's tag.
+
+Same reasoning as tests/integration/test_cliff_config.py: nothing else in the
+repo encodes a version, so a wrong answer here ships a wrong release
+(CLAUDE.md §8). The number it picks is also load-bearing in a way that fails
+quietly -- a repeat of an existing rc number is caught by the workflow's "tag
+already exists" check, but *skipping* one is not caught by anything.
+
+The script itself only ever runs on ubuntu-latest, but these run wherever a
+real bash can be found -- Git Bash included, which is what makes them mean
+something on the Windows leg of the matrix.
+"""
+
+from __future__ import annotations
+
+import shutil
+import subprocess
+from pathlib import Path
+
+import pytest
+
+ROOT = Path(__file__).resolve().parent.parent.parent
+SCRIPT = ROOT / ".github" / "scripts" / "next-prerelease.sh"
+
+
+def _find_bash() -> str | None:
+    """The bash to run, resolved to a full path, or None if there isn't one.
+
+    Resolving matters on Windows, where two different binaries answer to the
+    name. `shutil.which` searches PATH and finds Git Bash; `subprocess.run(["bash",
+    ...])` goes through CreateProcess, which looks in System32 *before* PATH and
+    finds `bash.exe` -- the WSL launcher. On a GitHub runner that launcher has no
+    distribution installed, so it ignores the script, prints "Use `wsl.exe --install
+    <Distro>` to install." to **stdout in UTF-16**, and exits 1. Passing the
+    resolved path is what keeps the thing probed and the thing run the same binary.
+
+    The probe demands output rather than a zero exit, because the launcher
+    exits 0 for `bash -c 'exit 0'` -- a returncode check calls it a working shell.
+    """
+    exe = shutil.which("bash")
+    if exe is None:
+        return None
+    try:
+        probe = subprocess.run([exe, "-c", "printf ok"], capture_output=True, timeout=30)
+    except (OSError, subprocess.SubprocessError):
+        return None
+    return exe if probe.returncode == 0 and probe.stdout.strip() == b"ok" else None
+
+
+BASH = _find_bash()
+
+pytestmark = pytest.mark.skipif(
+    BASH is None or shutil.which("git") is None,
+    reason="needs a working bash and git",
+)
+
+
+def _repo(tmp_path: Path, tags: list[str]) -> Path:
+    """A throwaway git repo carrying ``tags`` on a single commit."""
+    repo = tmp_path / "repo"
+    repo.mkdir()
+    run = lambda *a: subprocess.run(a, cwd=repo, check=True, capture_output=True)  # noqa: E731
+    run("git", "init", "-q", "-b", "main", ".")
+    run("git", "config", "user.email", "t@example.com")
+    run("git", "config", "user.name", "T")
+    # Never inherit the developer's signing config -- it makes commits fail here.
+    run("git", "config", "commit.gpgsign", "false")
+    run("git", "config", "tag.gpgsign", "false")
+
+    (repo / "base.txt").write_text("base\n", encoding="utf-8")
+    run("git", "add", "-A")
+    run("git", "commit", "-q", "-m", "chore: base")
+    for tag in tags:
+        run("git", "tag", tag)
+    return repo
+
+
+def _next(repo: Path, base: str, kind: str) -> str:
+    result = subprocess.run(
+        [str(BASH), str(SCRIPT), base, kind],
+        cwd=repo,
+        capture_output=True,
+        text=True,
+    )
+    # check=True would report only the exit status. Both streams, because the
+    # one failure this has actually had wrote its explanation to *stdout*.
+    assert result.returncode == 0, (
+        f"exit {result.returncode}\n--- stdout ---\n{result.stdout}\n--- stderr ---\n{result.stderr}"
+    )
+    return result.stdout.strip()
+
+
+def test_first_candidate_is_rc1(tmp_path: Path) -> None:
+    assert _next(_repo(tmp_path, []), "0.5.0", "rc") == "0.5.0rc1"
+
+
+def test_it_continues_an_existing_series(tmp_path: Path) -> None:
+    repo = _repo(tmp_path, ["0.4.0", "0.5.0rc1"])
+    assert _next(repo, "0.5.0", "rc") == "0.5.0rc2"
+
+
+def test_the_number_is_compared_numerically(tmp_path: Path) -> None:
+    """The bug this exists to catch: a lexicographic max makes rc9 the highest
+    of nine candidates, so rc10 would be issued as rc2 -- a tag that already
+    exists, failing the release, or worse a gap in the series.
+    """
+    repo = _repo(tmp_path, [f"0.5.0rc{n}" for n in range(1, 10)])
+    assert _next(repo, "0.5.0", "rc") == "0.5.0rc10"
+
+
+@pytest.mark.parametrize(("kind", "expected"), [("rc", "0.5.0rc1"), ("b", "0.5.0b4"), ("a", "0.5.0a1")])
+def test_each_kind_counts_its_own_series(tmp_path: Path, kind: str, expected: str) -> None:
+    """Counted per kind: with 0.5.0b3 out there, another beta is b4, but
+    promoting to a release candidate starts at rc1 rather than inheriting the
+    beta's number.
+    """
+    assert _next(_repo(tmp_path, ["0.5.0b3"]), "0.5.0", kind) == expected
+
+
+def test_a_longer_base_version_does_not_leak_in(tmp_path: Path) -> None:
+    """`git tag --list "0.5.1rc*"` must not see 0.5.10rc3. It doesn't -- the
+    glob requires a literal "rc" straight after the base -- but the failure
+    would be a silently wrong version number, so pin it.
+    """
+    repo = _repo(tmp_path, ["0.5.10rc3"])
+    assert _next(repo, "0.5.1", "rc") == "0.5.1rc1"
+
+
+def test_a_non_numeric_suffix_is_ignored(tmp_path: Path) -> None:
+    """A hand-made tag in the same namespace must not derail the count."""
+    repo = _repo(tmp_path, ["0.5.0rc1", "0.5.0rc-broken"])
+    assert _next(repo, "0.5.0", "rc") == "0.5.0rc2"
+
+
+def test_it_refuses_to_guess_without_arguments(tmp_path: Path) -> None:
+    """Both arguments are required. An empty base would print a bare "rc1",
+    which check-version would then reject -- but failing here names the
+    actual problem.
+    """
+    result = subprocess.run(
+        [str(BASH), str(SCRIPT)],
+        cwd=_repo(tmp_path, []),
+        capture_output=True,
+        text=True,
+    )
+    assert result.returncode != 0
+    assert "usage" in result.stderr.lower()


### PR DESCRIPTION
## Description

> Stacked on #72, which fixes the client-side ranking a release candidate depends on.

The pipeline already created every release as a prerelease, verified the Windows installer
against it, then flipped it to latest with `gh release edit --prerelease=false --latest`. The
prerelease was a *staging state*, not a destination — there was no way to deliberately stop
there and hand testers a `0.5.0rc1`.

A new `prerelease` input (`none`/`rc`/`b`/`a`) does exactly that: everything a release does,
minus the promote step. A candidate is tagged, built, asserted and installer-verified like any
other release; it just never becomes `/releases/latest`, so no stable user is offered it and no
default installer run can reach it. Testers get it through the update dialog's existing version
picker ("Choose a different version…" → "Show prereleases"), or `install-windows.ps1 -Version`.

Two supporting changes, both of which turned out to be load-bearing:

**The version number.** git-cliff only ever emits final versions, so `--bumped-version` can't
produce a candidate. `.github/scripts/next-prerelease.sh` appends the next unused suffix to
whatever it resolved (`0.5.0` → `0.5.0rc1` → `0.5.0rc2`), compared numerically so `rc9` is
followed by `rc10` and not `rc2`. You don't pass `version` and you don't need `force` — the
guard that catches a mistyped version compares the *base*, which choosing `rc` leaves untouched.
It's a script rather than inline workflow bash because it decides a released tag, which in this
repo is the one category of logic that's always pinned by a test.

**`cliff.toml`'s `tag_pattern` is now anchored at both ends**, making candidate tags invisible to
git-cliff. This is not tidiness. Verified against the pinned git-cliff 2.13.1: with `0.4.0`
tagged, a `feat:`, and a `0.5.0rc1` tag, `--bumped-version` hands back **`0.5.0rc1` itself** —
not its successor. The release would try to tag a name that already exists, and every further
candidate would too. The anchor also keeps the eventual release's notes spanning back to the last
*stable* tag, so `0.5.0` ships notes covering everything the candidates were cut to test rather
than only what changed after the last one.

**Why the promote job is gated per step** rather than skipped outright: `needs: promote` carries
the rest of the pipeline, and a skipped job cascades — TestPyPI, which a candidate *should*
still reach, would be skipped with it. So the job always runs and the flip step is conditional,
with an else-branch that writes install instructions into the run summary. PyPI is gated off for
candidates: it's the one irreversible step, and `pip` needs `--pre` to see a prerelease anyway.

The resolved version (not the input) is what decides all of this, so a version typed by hand as
`0.5.0rc1` with the input left at `none` is still correctly never promoted.

`installer-smoke.yml` and `check-release.yml` needed no changes — both already handle a PEP 440
candidate tag exactly (`$TAG -replace '^v',''` matches, and `check-version`'s regex already
accepts `rc1`/`b1`/`a1`).

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#contributions--licensing-dco)
- [x] Tests pass locally
- [x] I have updated `CLAUDE.md` if this changes architecture, a module boundary, or a
      subsystem described there
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)

## Test plan

**New:** `tests/unit/test_next_prerelease.py` (9 cases) runs the script against throwaway git
repos — first candidate is `rc1`, an existing series continues, `rc9` → `rc10` numerically, each
kind counts its own series, `0.5.10rc3` doesn't leak into base `0.5.1`, a non-numeric suffix in
the namespace is ignored, and missing arguments fail loudly.

**New:** `test_cliff_config.py::test_a_release_candidate_is_not_a_release_boundary`, run against
the real pinned binary. Confirmed it **fails without the anchor** (`assert '0.5.0rc1' ==
'0.5.0'`) — it isn't a test that passes either way.

**Two bashes answer to the name on Windows, and the tests must run the one they probe.**
`shutil.which("bash")` searches PATH and finds Git Bash; `subprocess.run(["bash", ...])` goes
through CreateProcess, which searches System32 *first* and finds `bash.exe` — the WSL launcher.
With no distribution installed that launcher ignores the script entirely, prints "Use
`wsl.exe --install <Distro>` to install." **to stdout, in UTF-16**, and exits 1 — which is how
this presented: nine tests failing with an opaque exit 1 and an empty stderr.

Two consequences, both handled by resolving bash to a full path and passing that:

- The binary probed and the binary run are the same one.
- The tests **run** on the Windows leg of the matrix, through Git Bash, rather than skipping.
  They only skip where no working bash exists at all.

The probe demands output (`printf ok`) rather than a zero exit, because the launcher exits 0 for
`bash -c 'exit 0'` — a returncode check calls it a working shell. The assertion helper reports
both streams for the same reason: this failure explained itself on stdout, not stderr.

**Workflow logic**, driven end to end in a throwaway repo by extracting the "Resolve version"
step verbatim:

```
from 0.4.0 + one feat:
  no prerelease                 version=0.5.0     prerelease=false
  prerelease: rc                version=0.5.0rc1  prerelease=true
  prerelease: rc (again)        version=0.5.0rc2  prerelease=true
  prerelease: rc (third)        version=0.5.0rc3  prerelease=true
  prerelease: b                 version=0.5.0b1   prerelease=true
  back to a real release        version=0.5.0     prerelease=false   <- rc tags don't shift it
explicit versions:
  1.0.0 + force, as rc          version=1.0.0rc1  prerelease=true
  hand-typed 0.5.0rc7, none     version=0.5.0rc7  prerelease=true    <- detected by shape
  hand-typed 0.5.0rc7, rc       version=0.5.0rc7  prerelease=true    <- warns, doesn't re-suffix
force guard:
  1.0.0 as rc without force     ::error:: disagrees with the auto-detected '0.5.0'
```

Full suite: `756 passed` locally. `ruff check`, `ruff format --check`, `ty check` clean.

**Not verifiable locally** — the first real run is the proof: that an rc leaves
`/releases/latest` pointing at the previous stable, that the `promote` job shows the flip step
skipped, and that TestPyPI runs while PyPI doesn't. Recommend a `dry-run` with `prerelease: rc`
first; it stops after `prepare` and shows the resolved version and notes.
