### PR TITLE
chore(installer): move the PowerShell tests into installer/tests

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -100,7 +100,7 @@ jobs:
       - name: start.bat interpreter probe (Windows)
         if: runner.os == 'Windows'
         shell: powershell
-        run: .\installer\Test-StartBatProbe.ps1
+        run: .\installer\tests\Test-StartBatProbe.ps1
 
       # xvfb only -- deliberately NOT libgl1/glib. Pre-installing those would
       # test a runner that already has them, not bootstrap.py's own

--- a/.github/workflows/installer-smoke.yml
+++ b/.github/workflows/installer-smoke.yml
@@ -74,7 +74,7 @@ jobs:
       # never that it rejects bad ones -- that half is only tested here.
       - name: Archive-entry validation
         shell: powershell
-        run: .\installer\Test-ArchiveEntryValidation.ps1
+        run: .\installer\tests\Test-ArchiveEntryValidation.ps1
 
       # -Repo $env:GITHUB_REPOSITORY, not the script's own hardcoded default:
       # makes this self-adapting to wherever it runs -- the fork's own real

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -142,7 +142,7 @@ Windows nor a local PowerShell:
 
 ```bash
 docker run --rm -v "$PWD:/w" -w /w mcr.microsoft.com/powershell:7.4-ubuntu-22.04 \
-  pwsh -File installer/Test-ArchiveEntryValidation.ps1
+  pwsh -File installer/tests/Test-ArchiveEntryValidation.ps1
 ```
 
 Run them if you touch `installer/**` or `sorter/updater.py`'s `_safe_members`

--- a/installer/README.md
+++ b/installer/README.md
@@ -85,13 +85,13 @@ explicitly.
 
 ### Archive-entry validation — runs on any OS
 
-`Test-ArchiveEntryValidation.ps1` needs no Windows. It dot-sources this
-directory's script for its functions only (the guard on the main block stops
+`tests/Test-ArchiveEntryValidation.ps1` needs no Windows. It dot-sources this
+parent directory's script for its functions only (the guard on the main block stops
 it installing anything), so it runs under PowerShell on Linux or macOS:
 
 ```bash
 docker run --rm -v "$PWD:/w" -w /w mcr.microsoft.com/powershell:7.4-ubuntu-22.04 \
-  pwsh -File installer/Test-ArchiveEntryValidation.ps1
+  pwsh -File installer/tests/Test-ArchiveEntryValidation.ps1
 ```
 
 Run it from the repo root; it takes a few seconds. There is no bare `7.4`

--- a/installer/install-windows.ps1
+++ b/installer/install-windows.ps1
@@ -263,7 +263,7 @@ function Assert-SafeArchiveEntries {
        the same mistake sorter/update/updater.py's Python-side extraction had (it
        tested name[1] of the whole name) and was fixed for; the two paths
        consume the same archives and must reject the same shapes. See
-       Test-ArchiveEntryValidation.ps1, and _safe_members in updater.py. #>
+       tests/Test-ArchiveEntryValidation.ps1, and _safe_members in updater.py. #>
     param([string[]]$EntryNames)
 
     foreach ($entryName in $EntryNames) {
@@ -558,7 +558,7 @@ function New-Shortcuts {
 # ---------------------------------------------------------------------------
 
 # Skipped when the file is dot-sourced (`. install-windows.ps1`), which is how
-# Test-ArchiveEntryValidation.ps1 gets at the functions above. Without this,
+# tests/Test-ArchiveEntryValidation.ps1 gets at the functions above. Without this,
 # loading the script to test one function runs a real install.
 if ($MyInvocation.InvocationName -eq '.') { return }
 

--- a/installer/tests/Test-ArchiveEntryValidation.ps1
+++ b/installer/tests/Test-ArchiveEntryValidation.ps1
@@ -16,7 +16,7 @@
 
     Plain PowerShell rather than Pester: the Windows runners ship an ancient
     Pester 3.x whose syntax differs sharply from 5.x, and this needs no
-    fixtures or mocking. Run:  pwsh -File installer/Test-ArchiveEntryValidation.ps1
+    fixtures or mocking. Run:  pwsh -File installer/tests/Test-ArchiveEntryValidation.ps1
 #>
 
 Set-StrictMode -Version Latest
@@ -24,7 +24,7 @@ $ErrorActionPreference = 'Stop'
 
 # Dot-source the installer for its functions only; the guard on its main
 # block keeps it from trying to install anything.
-. (Join-Path $PSScriptRoot 'install-windows.ps1')
+. (Join-Path (Split-Path $PSScriptRoot -Parent) 'install-windows.ps1')
 
 $script:Failures = 0
 $script:Passes = 0

--- a/installer/tests/Test-StartBatProbe.ps1
+++ b/installer/tests/Test-StartBatProbe.ps1
@@ -24,7 +24,7 @@
     covered and a shim is not.
 
     Plain PowerShell rather than Pester, matching Test-ArchiveEntryValidation.ps1.
-    Run:  powershell -File installer/Test-StartBatProbe.ps1
+    Run:  powershell -File installer/tests/Test-StartBatProbe.ps1
 #>
 [CmdletBinding()]
 param()
@@ -33,7 +33,8 @@ Set-StrictMode -Version Latest
 $ErrorActionPreference = 'Stop'
 $LASTEXITCODE = 0
 
-$repo    = Split-Path $PSScriptRoot -Parent
+# installer/tests -> installer -> repo root.
+$repo    = Split-Path (Split-Path $PSScriptRoot -Parent) -Parent
 $startBat = Join-Path $repo 'start.bat'
 if (-not (Test-Path $startBat)) { throw "start.bat not found at $startBat" }
 

--- a/tests/unit/test_installer_scripts.py
+++ b/tests/unit/test_installer_scripts.py
@@ -2,7 +2,7 @@
 
 These can't be executed here (no Windows), so the suite enforces the two
 properties that silently broke them once already. What the scripts actually
-*do* is covered where it can be: installer/Test-ArchiveEntryValidation.ps1
+*do* is covered where it can be: installer/tests/Test-ArchiveEntryValidation.ps1
 runs the real entry validation under Windows PowerShell in the Verify
 Installer workflow.
 
@@ -22,9 +22,10 @@ import pytest
 
 ROOT = Path(__file__).resolve().parent.parent.parent
 INSTALLER = ROOT / "installer"
-# Test-ArchiveEntryValidation.ps1 is held to the same rules: it is executed by
-# the same Windows PowerShell 5.1 that the encoding rule below exists for.
-SCRIPTS = ("install-windows.ps1", "install-windows.bat", "Test-ArchiveEntryValidation.ps1")
+# Paths relative to installer/. tests/Test-ArchiveEntryValidation.ps1 is held to
+# the same rules: it is executed by the same Windows PowerShell 5.1 that the
+# encoding rule below exists for.
+SCRIPTS = ("install-windows.ps1", "install-windows.bat", "tests/Test-ArchiveEntryValidation.ps1")
 
 
 @pytest.mark.parametrize("name", SCRIPTS)


### PR DESCRIPTION
## Description

`installer/` held four files, two of which are tests that never run on a user's machine:

```
installer/
  README.md
  install-windows.bat
  install-windows.ps1
  Test-ArchiveEntryValidation.ps1     <- test
  Test-StartBatProbe.ps1              <- test
```

So "what does an install actually involve?" wasn't answerable by looking. They now live in
`installer/tests/`.

Both scripts resolve their paths from `$PSScriptRoot`, so both needed one more level:

- `Test-ArchiveEntryValidation.ps1` dot-sources `install-windows.ps1` — now from the parent
  directory.
- `Test-StartBatProbe.ps1` walks up to the repo root to find `start.bat` — now twice.

That's the part of this that could silently break, so it was verified by running rather than by
reading (see the test plan).

Callers updated: `CONTRIBUTING.md`, `installer/README.md`, `installer/install-windows.ps1`
(two comments), `tests/unit/test_installer_scripts.py`, `.github/workflows/build.yml`, and
`.github/workflows/installer-smoke.yml`.

`.github/labeler.yml` needs no change — its `installer/**` glob already covers a subdirectory.

Pure move plus path fixes; no behaviour change.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#contributions--licensing-dco)
- [x] Tests pass locally
- [x] I have updated `CLAUDE.md` if this changes architecture, a module boundary, or a
      subsystem described there
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)

## Test plan

**The moved script was actually run**, in the exact container `installer/README.md` documents,
which is what proves the corrected dot-source path:

```
$ docker run --rm -v "$PWD:/w" -w /w mcr.microsoft.com/powershell:7.4-ubuntu-22.04 \
    pwsh -File installer/tests/Test-ArchiveEntryValidation.ps1
== must reject: drive letter in any component ==
== must reject: absolute and UNC paths ==
== must reject: traversal ==
== must accept: real sdist entries ==

all 23 passed
```

`tests/unit/test_installer_scripts.py` (10 cases: existence, CRLF endings, ASCII-only, quote
pairing) passes against the new locations — its `SCRIPTS` tuple now carries paths relative to
`installer/` rather than bare filenames.

Full suite: `728 passed` locally. `ruff check`, `ruff format --check`, `ty check` clean.

`Test-StartBatProbe.ps1` needs a real Windows `py.exe` and skips elsewhere, so its corrected
repo-root walk is exercised by the `verify launcher bootstrap (windows-latest)` job on this PR
rather than locally.
