### PR TITLE
feat(ui): add a detachable serial monitor reachable from the status bar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -296,6 +296,13 @@ between them from the Run tab's template dropdown.
   by a non-alphanumeric delimiter — so `error: broken sensor` routes as the
   error it is and `undone` doesn't satisfy a pending feed. Everything else
   falls through to `on_response`.
+  `try_open()` talks to the port directly rather than through the reader
+  thread, so it **fires `on_received`/`on_sent` by hand** for the banner and
+  the `version` exchange — without that the serial monitor is blank for
+  exactly the connection that failed. `send_raw` writes a string verbatim (no
+  newline added or stripped) for the monitor's line-ending selector; every
+  protocol helper still goes through `send_command`, which owns the `\n` the
+  firmware expects.
   **The authority on what the board actually prints is the firmware, which
   lives upstream — not here and not the emulator** (the emulator only ever
   emits the clean tokens the parser wants, so it can never disprove a parser
@@ -453,7 +460,11 @@ between them from the Run tab's template dropdown.
 `MainWindow` (`app.py`) is the shell: gradient title bar (with the theme picker
 parked at its right edge), a `ttk.Notebook` of tabs (each wrapped in a
 `ScrollableFrame` for small displays, and hosted on a backdrop canvas that owns
-the margin around it), and a status bar with connection indicators + sign-in. It owns the `EventBus`, `SerialBroker`,
+the margin around it), and a status bar with connection indicators + sign-in.
+Both indicators are links (hand cursor, underline on hover): serial opens the
+serial monitor, camera selects the Camera tab. The transient message shares
+that bar and is packed **last**, so a crowded bar truncates it rather than the
+standing connection state. It owns the `EventBus`, `SerialBroker`,
 `Camera`, `RunController`, and `AuthManager`, auto-connects serial/camera on
 startup, and runs the bus drain loop. `run_worker(fn, on_done, on_error)` is the
 standard helper for offloading blocking work to a thread and marshaling the
@@ -508,7 +519,7 @@ modal), and never gate on `is_available()`.
 | **Train** | `tab_train.py` | Feed→capture→classify→label→save loop; "Sort While Training"; launches training (Install-PyTorch dialog if needed → progress dialog). |
 | **AI Config** | `tab_ai.py` | HTTP server config (endpoint/key/model/prompt/encoding), headstamp manager, single-shot test. Visible only in AI Config mode. |
 | **Camera** | `tab_camera.py` | Device + resolution detection and live preview. |
-| **Serial** | `tab_serial.py` | Connection, 14 board init settings, sort-arm test, airdrop config, raw serial monitor. |
+| **Serial** | `tab_serial.py` | Connection, 14 board init settings, sort-arm test, airdrop config, in-tab traffic log + "Open monitor ↗" (see `serial_monitor.py`). |
 | **Image Proc** | `tab_imageproc.py` | Tune Hough params + primer mask + LED brightness against a captured frame (before/after preview). |
 | **Community** | `tab_community.py` | Browse/search/download community models; share entry point. Auth-gated. |
 
@@ -592,6 +603,19 @@ a separate one, so a built-in is never the thing being written to),
   `NumericField`, labeled-entry/button-row helpers.
 - **`monitor.py`** — detachable history window: ring buffer of recent
   classifications with a color "snake" trailing the latest. Subscribes `run/history`.
+- **`serial_monitor.py`** — detachable Arduino-IDE-style serial monitor,
+  opened by clicking the status bar's `● Serial: …` indicator (or the Serial
+  tab's button); `app.open_serial_monitor()` keeps it to one instance.
+  Autoscroll / timestamps / pause (held lines flush on resume, they are not
+  dropped), Clear, Save…, a line-ending selector that sends through
+  `broker.send_raw`, command history, and a baud picker that persists to
+  `config.serial["baud"]` and reconnects. Subscribes `serial/rx`, `serial/tx`,
+  `serial/note` (probe commentary) and `serial/state` (indicator mirror).
+  **On open it replays `MainWindow.serial_backlog`** — the rolling deque the
+  bus subscriptions fill — because the traffic worth reading (a failed
+  auto-connect probe) happens seconds before anyone can click. Text tags bake
+  their colours in and `retheme_widgets` can't reach them, so `set_theme`
+  calls the window's `apply_palette()`.
 - **`torch_gate.py`** — `ensure_torch(parent, proceed, reason=…)`: the only
   sanctioned way to front a local-model action with the PyTorch install dialog.
   See *The PyTorch install gate* above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -609,7 +609,16 @@ a separate one, so a built-in is never the thing being written to),
   Autoscroll / timestamps / pause (held lines flush on resume, they are not
   dropped), Clear, Save…, a line-ending selector that sends through
   `broker.send_raw`, command history, and a baud picker that persists to
-  `config.serial["baud"]` and reconnects. Subscribes `serial/rx`, `serial/tx`,
+  `config.serial["baud"]` and reconnects. A case-insensitive substring filter
+  and per-direction (RX/TX/notes) toggles narrow the view: `matches()` is the
+  single predicate, applied by `_render` as lines arrive, by `_rerender` when
+  the filter changes, and by `dump()` so Save… writes what's on screen. It
+  matches the board's text, **not** the rendered line, so the `<-`/`->`
+  prefixes and timestamps can't be filtered against. `_lines` always keeps
+  everything — the filter hides, never deletes. **The log is never re-ordered**
+  (no column sort): serial traffic only reads correctly in the order it
+  happened, since a command and its reply are one exchange. Subscribes
+  `serial/rx`, `serial/tx`,
   `serial/note` (probe commentary) and `serial/state` (indicator mirror).
   **On open it replays `MainWindow.serial_backlog`** — the rolling deque the
   bus subscriptions fill — because the traffic worth reading (a failed

--- a/src/sorter/hardware/serial_broker.py
+++ b/src/sorter/hardware/serial_broker.py
@@ -118,7 +118,11 @@ class SerialBroker:
                 self.is_connected = False
                 return False
 
-        # Handshake: read banner, write "version", inspect reply.
+        # Handshake: read banner, write "version", inspect reply. It talks to
+        # the port directly rather than through send_command/_reader_loop, so
+        # it has to report itself to the callbacks by hand — otherwise a probe
+        # that never handshakes leaves the serial monitor blank, which is
+        # exactly when its contents matter (issue #76).
         try:
             banner = self._sp.readline().decode("ascii", errors="ignore")
         except Exception:
@@ -127,12 +131,19 @@ class SerialBroker:
             banner += self._sp.read_all().decode("ascii", errors="ignore")
         except Exception:
             pass
+        for line in banner.splitlines():
+            line = line.strip("\r\n\t ")
+            if line:
+                self._fire(self.on_received, line)
 
         try:
             self._sp.write(b"version\n")
+            self._fire(self.on_sent, "version")
             version_line = self._sp.readline().decode("ascii", errors="ignore").strip()
         except Exception:
             version_line = ""
+        if version_line:
+            self._fire(self.on_received, version_line)
 
         self.firmware_version = version_line or "Unknown"
         normalized = version_line.lower()
@@ -201,6 +212,25 @@ class SerialBroker:
                 cb(stripped)
             except Exception:
                 pass
+
+    def send_raw(self, text: str) -> None:
+        """Write `text` byte-for-byte — nothing appended, nothing normalised.
+
+        For the serial monitor's line-ending selector. Every protocol helper
+        goes through `send_command`, which owns the trailing newline the
+        firmware expects; keep it that way.
+        """
+        with self._write_lock:
+            if self._sp is None or not self._sp.is_open:
+                return
+            try:
+                self._sp.write(text.encode("ascii", errors="ignore"))
+                self._sp.flush()
+            except (serial.SerialException, OSError):
+                self.is_connected = False
+                return
+            self._last_activity = time.monotonic()
+        self._fire(self.on_sent, text.rstrip("\r\n"))
 
     def purge_responses(self) -> None:
         time.sleep(0.2)

--- a/src/sorter/hardware/serial_emulator.py
+++ b/src/sorter/hardware/serial_emulator.py
@@ -62,6 +62,10 @@ class EmulatorBroker:
         timer.daemon = True
         timer.start()
 
+    def send_raw(self, text: str) -> None:
+        """Parity with SerialBroker.send_raw — the terminator is the caller's."""
+        self.send_command(text.rstrip("\r\n"))
+
     def _fire_response_for(self, cmd: str) -> None:
         lower = cmd.lower()
         if lower in ("ping", "version"):

--- a/src/sorter/ui/app.py
+++ b/src/sorter/ui/app.py
@@ -3,9 +3,12 @@
 from __future__ import annotations
 
 import threading
+import time
 import tkinter as tk
 import traceback
+from collections import deque
 from collections.abc import Callable
+from tkinter import font as tkfont
 from tkinter import ttk
 from typing import Any
 
@@ -51,6 +54,9 @@ PAGE_MARGIN_SCREENED = 20
 # Resting label of the status-bar update button, i.e. what it says when there
 # is nothing waiting. Clicking it in that state runs an explicit check.
 CHECK_FOR_UPDATES_LABEL = "Check for updates"
+# Serial lines kept for a monitor window opened later. The interesting traffic
+# is a failed auto-connect, which happens seconds before anyone can click.
+SERIAL_BACKLOG_LINES = 2000
 
 
 class MainWindow:
@@ -68,6 +74,9 @@ class MainWindow:
         self.fonts = apply_theme(self.root, theme=self.theme_name)
 
         self.broker: Any | None = None
+        # (kind, epoch seconds, line) — see SERIAL_BACKLOG_LINES.
+        self.serial_backlog: deque[tuple[str, float, str]] = deque(maxlen=SERIAL_BACKLOG_LINES)
+        self._serial_monitor: Any | None = None
         self.camera = Camera(
             device_index=int(config.camera.get("device_index", 0)),
             width=int(config.camera.get("width", 640)),
@@ -128,12 +137,6 @@ class MainWindow:
         status_bar = ttk.Frame(self.root, style="StatusBar.TFrame")
         status_bar.pack(side=tk.BOTTOM, fill=tk.X)
         ttk.Separator(status_bar, orient=tk.HORIZONTAL).pack(side=tk.TOP, fill=tk.X)
-        ttk.Label(
-            status_bar,
-            textvariable=self.status_var,
-            anchor=tk.W,
-            style="Status.TLabel",
-        ).pack(side=tk.LEFT, padx=12, pady=6)
         # Sign-in / sign-out button on the right side of the status bar.
         self.signin_var = tk.StringVar(value="Sign in")
         self.signin_button = ttk.Button(
@@ -168,8 +171,25 @@ class MainWindow:
         # dot stays glued to its label when the bar resizes.
         self._serial_connected = False
         self._camera_connected = False
-        self.serial_dot = self._build_status_indicator(status_bar, self.serial_status_var)
-        self.camera_dot = self._build_status_indicator(status_bar, self.camera_status_var)
+        self.serial_dot = self._build_status_indicator(
+            status_bar,
+            self.serial_status_var,
+            on_click=self.open_serial_monitor,
+        )
+        self.camera_dot = self._build_status_indicator(
+            status_bar,
+            self.camera_status_var,
+            on_click=lambda: self.select_tab("Camera"),
+        )
+        # Packed last on purpose: when the bar runs out of room, pack starves
+        # whatever was packed last, and a truncated transient message costs
+        # less than a truncated connection state.
+        ttk.Label(
+            status_bar,
+            textvariable=self.status_var,
+            anchor=tk.W,
+            style="Status.TLabel",
+        ).pack(side=tk.LEFT, padx=12, pady=6)
 
         # The notebook rides on a backdrop canvas rather than being packed
         # straight into the root: the canvas owns the margin around it, which
@@ -489,11 +509,15 @@ class MainWindow:
         self,
         parent: tk.Misc,
         text_var: tk.StringVar,
+        *,
+        on_click: Callable[[], None] | None = None,
     ) -> tk.Label:
         """[●][text] pair on the right side of the status bar.
 
         Returns the dot Label so callers can recolour it (green/red) when
-        the underlying connection state flips.
+        the underlying connection state flips. With `on_click` the whole pair
+        becomes a link — underlined on hover, since a bare label gives no hint
+        that it does anything.
         """
         frame = ttk.Frame(parent, style="StatusBar.TFrame")
         frame.pack(side=tk.RIGHT, padx=12, pady=6)
@@ -505,10 +529,59 @@ class MainWindow:
             font=self.fonts["small"],
         )
         dot.pack(side=tk.LEFT, padx=(0, 6))
-        ttk.Label(frame, textvariable=text_var, style="Status.TLabel").pack(
-            side=tk.LEFT,
-        )
+        label = ttk.Label(frame, textvariable=text_var, style="Status.TLabel")
+        label.pack(side=tk.LEFT)
+        if on_click is not None:
+            self._make_clickable(frame, dot, label, on_click)
         return dot
+
+    def _make_clickable(
+        self,
+        frame: ttk.Frame,
+        dot: tk.Label,
+        label: ttk.Label,
+        on_click: Callable[[], None],
+    ) -> None:
+        """Turn a status indicator into a link: hand cursor + hover underline."""
+        rest_font = ttk.Style(self.root).lookup("Status.TLabel", "font") or self.fonts["small"]
+        hover_font = tkfont.Font(root=self.root, font=rest_font)
+        hover_font.configure(underline=True)
+        for widget in (frame, dot, label):
+            widget.configure(cursor="hand2")
+            # Every part of the pair has to answer the click — the dot and the
+            # gap between them are as clickable-looking as the text.
+            widget.bind("<Button-1>", lambda _e: on_click())
+            widget.bind("<Enter>", lambda _e: label.configure(font=hover_font))
+            # Clear the override rather than restoring the captured font, so
+            # the label goes back to following Status.TLabel — a widget-level
+            # font would outlive the next theme switch.
+            widget.bind("<Leave>", lambda _e: label.configure(font=""))
+
+    def select_tab(self, title: str) -> None:
+        """Bring the named notebook tab to the front (no-op if it isn't there)."""
+        try:
+            for tab_id in self.notebook.tabs():
+                if self.notebook.tab(tab_id, "text") == title:
+                    self.notebook.select(tab_id)
+                    return
+        except tk.TclError:
+            pass
+
+    def open_serial_monitor(self) -> None:
+        """Open (or re-focus) the detachable serial monitor."""
+        from .serial_monitor import SerialMonitorWindow
+
+        window = self._serial_monitor
+        if window is not None:
+            try:
+                if window.winfo_exists():
+                    window.deiconify()
+                    window.lift()
+                    window.focus_set()
+                    return
+            except tk.TclError:
+                pass
+        self._serial_monitor = SerialMonitorWindow(self.root, app=self)
 
     def _set_camera_indicator(self, message: str, *, connected: bool) -> None:
         self.camera_status_var.set(message)
@@ -523,6 +596,8 @@ class MainWindow:
         self.serial_dot.config(
             foreground=PALETTE["success" if connected else "error"],
         )
+        # The monitor window mirrors this indicator; it may not be open.
+        self.bus.post("serial/state", {"connected": connected, "message": message})
 
     def _refresh_status_indicators(self) -> None:
         """Re-apply the dot colors from the live palette (after a theme switch).
@@ -685,6 +760,14 @@ class MainWindow:
         self._repaint_header()
         self._layout_page(force=True)
         self._refresh_status_indicators()
+        # Text tags aren't in retheme_widgets' reach; the monitor repaints its own.
+        window = self._serial_monitor
+        if window is not None:
+            try:
+                if window.winfo_exists():
+                    window.apply_palette()
+            except tk.TclError:
+                pass
         self._save_setting(SETTING_THEME, resolved)
 
     def _save_setting(self, key: str, value) -> None:
@@ -788,7 +871,8 @@ class MainWindow:
                 candidates.append(port)
 
         if not candidates:
-            self.set_status("Serial: no serial ports detected.")
+            self.set_status("No serial ports detected.")
+            self._set_serial_indicator("Serial: no ports", connected=False)
             return
 
         baud = int(self.config.serial.get("baud", 9600))
@@ -797,6 +881,7 @@ class MainWindow:
         def _probe() -> tuple[object, str] | tuple[None, None]:
             for port in candidates:
                 self.bus.post("status", f"Auto-connect: probing {port}…")
+                self.bus.post("serial/note", f"probing {port} @ {baud}…")
                 # Opening the port asserts DTR which resets the Arduino, and
                 # the board needs ~1-2 s to boot before it can answer
                 # `version`. Probe timeout is configurable in Serial Config.
@@ -806,9 +891,13 @@ class MainWindow:
                     require_serial_ready=True,
                     handshake_timeout_s=probe_timeout,
                 )
+                # Listen *before* the handshake: whatever the board says to a
+                # probe that fails is the only evidence of why it failed.
+                self._attach_serial_listeners(broker)
                 if broker.try_open():
                     broker.start()
                     return broker, port
+                self.bus.post("serial/note", f"{port} did not handshake")
             return None, None
 
         self.set_status(f"Auto-connecting to serial — {len(candidates)} port(s) to try…")
@@ -821,24 +910,36 @@ class MainWindow:
     def _finalize_auto_connect(self, result) -> None:
         broker, port = result
         if broker is None:
-            self.set_status("Serial: no board responded on any port.")
-            self._set_serial_indicator("Serial: disconnected", connected=False)
+            self.set_status("No board responded on any port.")
+            self._set_serial_indicator("Serial: no board found", connected=False)
             return
         self._after_connect(broker, port, source="auto")
+
+    def _attach_serial_listeners(self, broker: Any) -> None:
+        """Fan a broker's traffic onto the bus, once.
+
+        The auto-connect probe wires each candidate before its handshake, so
+        the winner reaches `_after_connect` already listening — attaching a
+        second time would double every line.
+        """
+        if getattr(broker, "_bus_listeners_attached", False):
+            return
+        broker.on_received.append(lambda line: self.bus.post("serial/rx", line))
+        broker.on_sent.append(lambda line: self.bus.post("serial/tx", line))
+        broker._bus_listeners_attached = True
 
     def _after_connect(self, broker, port: str, *, source: str) -> None:
         """Wire callbacks, persist the port, optionally push init settings.
 
         Shared by auto-connect and the manual Connect button.
         """
-        broker.on_received.append(lambda line: self.bus.post("serial/rx", line))
-        broker.on_sent.append(lambda line: self.bus.post("serial/tx", line))
+        self._attach_serial_listeners(broker)
         self.broker = broker
         if port != (self.config.serial.get("port") or ""):
             self.config.serial["port"] = port
             self.config.save()
         self._set_serial_indicator(
-            f"Serial: connected ({port}) — {broker.firmware_version}",
+            f"Serial: connected ({port} @ {getattr(broker, 'baud', '?')}) — {broker.firmware_version}",
             connected=True,
         )
         self.set_status(f"{'Auto-connected' if source == 'auto' else 'Connected'} to {port}.")
@@ -869,8 +970,8 @@ class MainWindow:
         if port is None:
             port = (self.config.serial.get("port") or "").strip()
         if not port:
-            self.set_status("Serial: no port selected.")
-            self._set_serial_indicator("Serial: disconnected", connected=False)
+            self.set_status("No port selected.")
+            self._set_serial_indicator("Serial: no port selected", connected=False)
             return
 
         if port == EMULATED_PORT:
@@ -882,9 +983,11 @@ class MainWindow:
                 baud=int(self.config.serial.get("baud", 9600)),
                 require_serial_ready=True,
             )
+            # Same reason as the probe: a failed open should still leave a trace.
+            self._attach_serial_listeners(broker)
             if not broker.try_open():
-                self.set_status(f"Serial: failed to open {port}.")
-                self._set_serial_indicator("Serial: disconnected", connected=False)
+                self.set_status(f"Failed to open {port}.")
+                self._set_serial_indicator(f"Serial: failed to open {port}", connected=False)
                 return
             broker.start()
 
@@ -951,9 +1054,15 @@ class MainWindow:
 
     def run(self) -> None:
         # Wire serial-log topics to the Serial tab now that the bus is alive.
-        self.bus.subscribe("serial/rx", lambda line: self.serial_tab.append_log(f"<- {line}"))
-        self.bus.subscribe("serial/tx", lambda line: self.serial_tab.append_log(f"-> {line}"))
+        self.bus.subscribe("serial/rx", lambda line: self._log_serial("rx", f"<- {line}", line))
+        self.bus.subscribe("serial/tx", lambda line: self._log_serial("tx", f"-> {line}", line))
+        self.bus.subscribe("serial/note", lambda line: self._log_serial("note", f"-- {line}", line))
         self.root.mainloop()
+
+    def _log_serial(self, kind: str, tab_line: str, line: str) -> None:
+        """Fan one serial line out to the in-tab log and the replay backlog."""
+        self.serial_backlog.append((kind, time.time(), str(line)))
+        self.serial_tab.append_log(tab_line)
 
     def _on_close(self) -> None:
         try:

--- a/src/sorter/ui/serial_monitor.py
+++ b/src/sorter/ui/serial_monitor.py
@@ -1,0 +1,384 @@
+"""Detachable serial monitor — the Arduino IDE's, for this board.
+
+Opened from the status-bar serial indicator (and from the Serial Config tab),
+so it is reachable exactly when the connection is the thing that's broken. It
+replays the app's rolling backlog on open, which is what makes a failed
+auto-connect diagnosable after the fact.
+
+Everything arrives over the EventBus (`serial/rx`, `serial/tx`, `serial/note`)
+and is therefore delivered on the Tk main thread — nothing here may be called
+from the reader thread. See CLAUDE.md §3.
+"""
+
+from __future__ import annotations
+
+import time
+import tkinter as tk
+from collections import deque
+from tkinter import filedialog, ttk
+from typing import Any
+
+from .theme import PALETTE, get_fonts
+
+# The Arduino IDE's ladder, and its default.
+BAUD_RATES = (300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 250000)
+DEFAULT_BAUD = 9600
+
+# Label → what actually goes on the wire after the typed text.
+LINE_ENDINGS: dict[str, str] = {
+    "No line ending": "",
+    "New Line": "\n",
+    "Carriage Return": "\r",
+    "Both NL & CR": "\r\n",
+}
+DEFAULT_LINE_ENDING = "New Line"
+
+MAX_LINES = 4000  # scrollback cap; the oldest are dropped, not the newest
+MAX_HISTORY = 100
+
+# Line kinds → the palette role they print in and the prefix they carry.
+KIND_ROLE = {"rx": "text", "tx": "update", "note": "text_muted"}
+KIND_PREFIX = {"rx": "<- ", "tx": "-> ", "note": "-- "}
+
+
+class SerialMonitorWindow(tk.Toplevel):
+    """Live serial traffic: filtered, timestamped, pausable, saveable."""
+
+    def __init__(self, parent: tk.Misc, *, app: Any) -> None:
+        super().__init__(parent)
+        self.app = app
+        self.bus = app.bus
+        self.title("Serial Monitor")
+        self.geometry("900x560")
+        # Below this the send row's fixed controls start eating the entry.
+        self.minsize(820, 380)
+        self.configure(bg=PALETTE["bg_window"])
+
+        self._fonts = getattr(app, "fonts", None) or get_fonts(self)
+        # (kind, epoch seconds, text) — the rendered scrollback, kept so a
+        # timestamp toggle can re-render and Save… can dump exactly what's on
+        # screen.
+        self._lines: deque[tuple[str, float, str]] = deque(maxlen=MAX_LINES)
+        self._held: deque[tuple[str, float, str]] = deque(maxlen=MAX_LINES)
+        self._history: list[str] = []
+        self._history_pos = 0
+
+        self._build_header()
+        # The send row is packed against the bottom before the output claims
+        # the rest, or a window smaller than the Text's natural size clips it.
+        self._build_send_row()
+        self._build_output()
+
+        self.bus.subscribe("serial/rx", self._on_rx)
+        self.bus.subscribe("serial/tx", self._on_tx)
+        self.bus.subscribe("serial/note", self._on_note)
+        self.bus.subscribe("serial/state", self._on_state)
+        self.protocol("WM_DELETE_WINDOW", self.close)
+
+        self._replay_backlog()
+        self.refresh_connection()
+
+    # ----- construction -------------------------------------------------------
+
+    def _build_header(self) -> None:
+        header = ttk.Frame(self, padding=(10, 8))
+        header.pack(side=tk.TOP, fill=tk.X)
+
+        self._dot = tk.Label(
+            header,
+            text="●",  # BLACK CIRCLE — mirrors the status-bar indicator
+            background=PALETTE["bg_surface"],
+            foreground=PALETTE["error"],
+            font=self._fonts["small"],
+        )
+        self._dot.pack(side=tk.LEFT, padx=(0, 6))
+        self._header_var = tk.StringVar(value="disconnected")
+        ttk.Label(header, textvariable=self._header_var).pack(side=tk.LEFT)
+
+        controls = ttk.Frame(self, padding=(10, 0))
+        controls.pack(side=tk.TOP, fill=tk.X)
+        self.autoscroll_var = tk.BooleanVar(value=True)
+        self.timestamps_var = tk.BooleanVar(value=False)
+        self.paused_var = tk.BooleanVar(value=False)
+        ttk.Checkbutton(controls, text="Autoscroll", variable=self.autoscroll_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(
+            controls,
+            text="Timestamps",
+            variable=self.timestamps_var,
+            command=self._rerender,
+        ).pack(side=tk.LEFT, padx=(12, 0))
+        ttk.Checkbutton(
+            controls,
+            text="Pause",
+            variable=self.paused_var,
+            command=self._on_pause_toggled,
+        ).pack(side=tk.LEFT, padx=(12, 0))
+        ttk.Button(controls, text="Save…", command=self.save_to_file).pack(side=tk.RIGHT)
+        ttk.Button(controls, text="Clear", command=self.clear).pack(side=tk.RIGHT, padx=(0, 6))
+
+    def _build_output(self) -> None:
+        box = ttk.Frame(self, padding=(10, 8))
+        box.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        self.text = tk.Text(
+            box,
+            height=12,
+            wrap=tk.NONE,
+            state=tk.DISABLED,
+            font=self._fonts["mono"],
+            background=PALETTE["bg_input"],
+            foreground=PALETTE["text"],
+        )
+        scroll = ttk.Scrollbar(box, orient=tk.VERTICAL, command=self.text.yview)
+        self.text.configure(yscrollcommand=scroll.set)
+        scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        self.text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        for kind, role in KIND_ROLE.items():
+            self.text.tag_configure(kind, foreground=PALETTE[role])
+        self.text.tag_configure("stamp", foreground=PALETTE["text_subtle"])
+
+    def apply_palette(self) -> None:
+        """Re-read the palette after a theme switch.
+
+        `retheme_widgets` translates the colours baked into widgets, but not
+        the ones baked into Text *tags* — those are ours to refresh.
+        """
+        self.configure(bg=PALETTE["bg_window"])
+        self.text.configure(background=PALETTE["bg_input"], foreground=PALETTE["text"])
+        for kind, role in KIND_ROLE.items():
+            self.text.tag_configure(kind, foreground=PALETTE[role])
+        self.text.tag_configure("stamp", foreground=PALETTE["text_subtle"])
+        self.refresh_connection()
+
+    def _build_send_row(self) -> None:
+        row = ttk.Frame(self, padding=(10, 0, 10, 10))
+        row.pack(side=tk.BOTTOM, fill=tk.X)
+
+        # Right-hand controls claim their width first; the entry then absorbs
+        # whatever is left, so nothing falls off the edge on a narrow window.
+        self.baud_var = tk.StringVar(value=str(self._configured_baud()))
+        baud = ttk.Combobox(
+            row,
+            textvariable=self.baud_var,
+            values=[str(b) for b in BAUD_RATES],
+            state="readonly",
+            width=8,
+        )
+        baud.pack(side=tk.RIGHT)
+        baud.bind("<<ComboboxSelected>>", self._on_baud_selected)
+        ttk.Label(row, text="Baud").pack(side=tk.RIGHT, padx=(16, 4))
+
+        ttk.Button(row, text="Send", style="Accent.TButton", command=self.send_command).pack(side=tk.RIGHT)
+        self.ending_var = tk.StringVar(value=DEFAULT_LINE_ENDING)
+        ttk.Combobox(
+            row,
+            textvariable=self.ending_var,
+            values=list(LINE_ENDINGS),
+            state="readonly",
+            width=15,
+        ).pack(side=tk.RIGHT, padx=6)
+
+        self.entry_var = tk.StringVar()
+        # A small request, not a small field: the entry takes the row's slack.
+        entry = ttk.Entry(row, textvariable=self.entry_var, width=10)
+        entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        entry.bind("<Return>", lambda _e: self.send_command())
+        entry.bind("<Up>", lambda _e: self._history_step(-1))
+        entry.bind("<Down>", lambda _e: self._history_step(1))
+        self.entry = entry
+
+    # ----- connection state ---------------------------------------------------
+
+    def _configured_baud(self) -> int:
+        try:
+            return int(self.app.config.serial.get("baud", DEFAULT_BAUD))
+        except (AttributeError, TypeError, ValueError):
+            return DEFAULT_BAUD
+
+    def _current_port(self) -> str:
+        broker = getattr(self.app, "broker", None)
+        port = getattr(broker, "port", "") if broker is not None else ""
+        if port:
+            return str(port)
+        try:
+            return str(self.app.config.serial.get("port", "") or "")
+        except AttributeError:
+            return ""
+
+    def refresh_connection(self) -> None:
+        """Repaint the header from the app's live broker."""
+        broker = getattr(self.app, "broker", None)
+        connected = bool(broker is not None and getattr(broker, "is_connected", False))
+        port = self._current_port() or "no port"
+        baud = int(getattr(broker, "baud", 0) or self._configured_baud())
+        if connected:
+            firmware = getattr(broker, "firmware_version", "") or "Unknown"
+            self._header_var.set(f"{port} @ {baud} — {firmware}")
+        else:
+            self._header_var.set(f"{port} @ {baud} — disconnected")
+        self._dot.config(foreground=PALETTE["success" if connected else "error"])
+
+    def _on_state(self, _payload: Any = None) -> None:
+        self.refresh_connection()
+
+    def _on_baud_selected(self, _event: Any = None) -> None:
+        """Persist the new speed and re-open the port at it, IDE-style."""
+        try:
+            baud = int(self.baud_var.get())
+        except (TypeError, ValueError):
+            return
+        if baud == self._configured_baud() and getattr(getattr(self.app, "broker", None), "baud", None) == baud:
+            return
+        try:
+            self.app.config.serial["baud"] = baud
+            self.app.config.save()
+        except Exception as exc:
+            self.note(f"could not save baud: {exc}")
+        port = self._current_port()
+        self.note(f"baud set to {baud}")
+        if port:
+            self.app.connect_serial(port=port)
+        self.refresh_connection()
+
+    # ----- inbound ------------------------------------------------------------
+
+    def _on_rx(self, line: Any) -> None:
+        self.append("rx", str(line))
+
+    def _on_tx(self, line: Any) -> None:
+        self.append("tx", str(line))
+
+    def _on_note(self, line: Any) -> None:
+        self.append("note", str(line))
+
+    def note(self, line: str) -> None:
+        """Record a monitor-local remark (not board traffic)."""
+        self.append("note", line)
+
+    def append(self, kind: str, line: str, *, stamp: float | None = None) -> None:
+        record = (kind, time.time() if stamp is None else stamp, line)
+        if self.paused_var.get():
+            self._held.append(record)
+            return
+        self._lines.append(record)
+        self._render(record)
+
+    def _on_pause_toggled(self) -> None:
+        if self.paused_var.get():
+            return
+        held, self._held = list(self._held), deque(maxlen=MAX_LINES)
+        for record in held:
+            self._lines.append(record)
+            self._render(record)
+
+    def _replay_backlog(self) -> None:
+        """Show what the app captured before this window existed."""
+        backlog = list(getattr(self.app, "serial_backlog", ()))
+        if not backlog:
+            return
+        for kind, stamp, line in backlog:
+            self._lines.append((kind, stamp, line))
+        self._rerender()
+        self._lines.append(("note", time.time(), f"end of replay ({len(backlog)} earlier line(s))"))
+        self._render(self._lines[-1])
+
+    # ----- rendering ----------------------------------------------------------
+
+    def _render(self, record: tuple[str, float, str]) -> None:
+        kind, stamp, line = record
+        self.text.configure(state=tk.NORMAL)
+        if self.timestamps_var.get():
+            self.text.insert(tk.END, f"{time.strftime('%H:%M:%S', time.localtime(stamp))} ", ("stamp",))
+        self.text.insert(tk.END, f"{KIND_PREFIX.get(kind, '')}{line}\n", (kind,))
+        self._trim()
+        if self.autoscroll_var.get():
+            self.text.see(tk.END)
+        self.text.configure(state=tk.DISABLED)
+
+    def _rerender(self) -> None:
+        self.text.configure(state=tk.NORMAL)
+        self.text.delete("1.0", tk.END)
+        self.text.configure(state=tk.DISABLED)
+        for record in list(self._lines):
+            self._render(record)
+
+    def _trim(self) -> None:
+        """Keep the widget's line count in step with the deque's cap."""
+        count = int(self.text.index("end-1c").split(".")[0])
+        if count > MAX_LINES:
+            self.text.delete("1.0", f"{count - MAX_LINES}.0")
+
+    def clear(self) -> None:
+        self._lines.clear()
+        self.text.configure(state=tk.NORMAL)
+        self.text.delete("1.0", tk.END)
+        self.text.configure(state=tk.DISABLED)
+
+    def dump(self) -> str:
+        """The scrollback as plain text, timestamped as currently displayed."""
+        stamps = self.timestamps_var.get()
+        out = []
+        for kind, stamp, line in self._lines:
+            prefix = f"{time.strftime('%H:%M:%S', time.localtime(stamp))} " if stamps else ""
+            out.append(f"{prefix}{KIND_PREFIX.get(kind, '')}{line}")
+        return "\n".join(out) + ("\n" if out else "")
+
+    def save_to_file(self) -> None:
+        path = filedialog.asksaveasfilename(
+            parent=self,
+            title="Save serial log",
+            defaultextension=".txt",
+            filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
+        )
+        if not path:
+            return
+        try:
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(self.dump())
+        except OSError as exc:
+            self.note(f"save failed: {exc}")
+            return
+        self.note(f"saved to {path}")
+
+    # ----- outbound -----------------------------------------------------------
+
+    def send_command(self) -> None:
+        text = self.entry_var.get()
+        if not text:
+            return
+        broker = getattr(self.app, "broker", None)
+        if broker is None or not getattr(broker, "is_connected", False):
+            self.note("not connected — nothing sent")
+            return
+        # The broker echoes the write through on_sent → serial/tx, so the line
+        # lands in the log the same way an auto-connect probe's does.
+        broker.send_raw(text + LINE_ENDINGS.get(self.ending_var.get(), "\n"))
+        if not self._history or self._history[-1] != text:
+            self._history.append(text)
+            del self._history[:-MAX_HISTORY]
+        self._history_pos = len(self._history)
+        self.entry_var.set("")
+
+    def _history_step(self, delta: int) -> str:
+        """Walk the command history; past the newest entry the field clears."""
+        if not self._history:
+            return "break"
+        self._history_pos = max(0, min(len(self._history), self._history_pos + delta))
+        value = "" if self._history_pos >= len(self._history) else self._history[self._history_pos]
+        self.entry_var.set(value)
+        self.entry.icursor(tk.END)
+        return "break"
+
+    # ----- lifecycle ----------------------------------------------------------
+
+    def close(self) -> None:
+        for topic, handler in (
+            ("serial/rx", self._on_rx),
+            ("serial/tx", self._on_tx),
+            ("serial/note", self._on_note),
+            ("serial/state", self._on_state),
+        ):
+            try:
+                self.bus.unsubscribe(topic, handler)
+            except Exception:
+                pass
+        self.destroy()

--- a/src/sorter/ui/serial_monitor.py
+++ b/src/sorter/ui/serial_monitor.py
@@ -8,6 +8,11 @@ auto-connect diagnosable after the fact.
 Everything arrives over the EventBus (`serial/rx`, `serial/tx`, `serial/note`)
 and is therefore delivered on the Tk main thread — nothing here may be called
 from the reader thread. See CLAUDE.md §3.
+
+The log is deliberately never re-ordered. Serial traffic only means anything
+in the order it happened — a command and the reply it drew are one exchange —
+so the way to narrow it down is the filter box and the direction toggles,
+which hide lines without moving the ones that remain.
 """
 
 from __future__ import annotations
@@ -35,6 +40,9 @@ DEFAULT_LINE_ENDING = "New Line"
 
 MAX_LINES = 4000  # scrollback cap; the oldest are dropped, not the newest
 MAX_HISTORY = 100
+# Typing in the filter box re-renders the whole scrollback, so coalesce
+# keystrokes instead of doing it per character.
+FILTER_DEBOUNCE_MS = 120
 
 # Line kinds → the palette role they print in and the prefix they carry.
 KIND_ROLE = {"rx": "text", "tx": "update", "note": "text_muted"}
@@ -62,8 +70,10 @@ class SerialMonitorWindow(tk.Toplevel):
         self._held: deque[tuple[str, float, str]] = deque(maxlen=MAX_LINES)
         self._history: list[str] = []
         self._history_pos = 0
+        self._filter_job: str | None = None
 
         self._build_header()
+        self._build_filter_row()
         # The send row is packed against the bottom before the output claims
         # the rest, or a window smaller than the Text's natural size clips it.
         self._build_send_row()
@@ -115,6 +125,32 @@ class SerialMonitorWindow(tk.Toplevel):
         ).pack(side=tk.LEFT, padx=(12, 0))
         ttk.Button(controls, text="Save…", command=self.save_to_file).pack(side=tk.RIGHT)
         ttk.Button(controls, text="Clear", command=self.clear).pack(side=tk.RIGHT, padx=(0, 6))
+
+    def _build_filter_row(self) -> None:
+        """Substring filter + per-direction toggles, over the whole scrollback.
+
+        Filtering is a view, not a deletion: `_lines` keeps everything, so
+        clearing the box brings the hidden traffic straight back.
+        """
+        row = ttk.Frame(self, padding=(10, 6, 10, 0))
+        row.pack(side=tk.TOP, fill=tk.X)
+
+        ttk.Label(row, text="Filter").pack(side=tk.LEFT, padx=(0, 6))
+        self.filter_var = tk.StringVar()
+        self.filter_var.trace_add("write", lambda *_a: self._schedule_rerender())
+        entry = ttk.Entry(row, textvariable=self.filter_var, width=10)
+        entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        entry.bind("<Escape>", lambda _e: self.clear_filter())
+        ttk.Button(row, text="✕", width=3, command=self.clear_filter).pack(side=tk.LEFT, padx=(4, 0))
+
+        self.show_kind_vars: dict[str, tk.BooleanVar] = {}
+        for kind, label in (("rx", "RX"), ("tx", "TX"), ("note", "Notes")):
+            var = tk.BooleanVar(value=True)
+            self.show_kind_vars[kind] = var
+            ttk.Checkbutton(row, text=label, variable=var, command=self._rerender).pack(side=tk.LEFT, padx=(12, 0))
+
+        self._count_var = tk.StringVar(value="0 lines")
+        ttk.Label(row, textvariable=self._count_var, style="Muted.TLabel").pack(side=tk.LEFT, padx=(16, 0))
 
     def _build_output(self) -> None:
         box = ttk.Frame(self, padding=(10, 8))
@@ -261,6 +297,7 @@ class SerialMonitorWindow(tk.Toplevel):
             return
         self._lines.append(record)
         self._render(record)
+        self._update_count()
 
     def _on_pause_toggled(self) -> None:
         if self.paused_var.get():
@@ -269,6 +306,7 @@ class SerialMonitorWindow(tk.Toplevel):
         for record in held:
             self._lines.append(record)
             self._render(record)
+        self._update_count()
 
     def _replay_backlog(self) -> None:
         """Show what the app captured before this window existed."""
@@ -280,11 +318,55 @@ class SerialMonitorWindow(tk.Toplevel):
         self._rerender()
         self._lines.append(("note", time.time(), f"end of replay ({len(backlog)} earlier line(s))"))
         self._render(self._lines[-1])
+        self._update_count()
+
+    # ----- filtering ----------------------------------------------------------
+
+    def clear_filter(self) -> None:
+        self.filter_var.set("")
+
+    def _schedule_rerender(self) -> None:
+        if self._filter_job is not None:
+            self.after_cancel(self._filter_job)
+        self._filter_job = self.after(FILTER_DEBOUNCE_MS, self._run_scheduled_rerender)
+
+    def _run_scheduled_rerender(self) -> None:
+        self._filter_job = None
+        self._rerender()
+
+    def matches(self, record: tuple[str, float, str]) -> bool:
+        """Does this line survive the direction toggles and the filter box?
+
+        Case-insensitive substring, matched against the text as the board sent
+        it — not the rendered line, so a filter can't accidentally key off the
+        `<-`/`->` prefix or a timestamp that is only sometimes shown.
+        """
+        kind, _stamp, line = record
+        var = self.show_kind_vars.get(kind)
+        if var is not None and not var.get():
+            return False
+        needle = self.filter_var.get().strip().lower()
+        return not needle or needle in line.lower()
+
+    def _shown_line_count(self) -> int:
+        """How many lines the widget is actually displaying.
+
+        Every rendered record ends in a newline, so the insertion point sits at
+        the start of an empty trailing line that isn't output — hence the -1.
+        """
+        return max(0, int(self.text.index("end-1c").split(".")[0]) - 1)
+
+    def _update_count(self) -> None:
+        total = len(self._lines)
+        shown = self._shown_line_count()
+        self._count_var.set(f"{total} lines" if shown == total else f"{shown} of {total} lines")
 
     # ----- rendering ----------------------------------------------------------
 
     def _render(self, record: tuple[str, float, str]) -> None:
         kind, stamp, line = record
+        if not self.matches(record):
+            return
         self.text.configure(state=tk.NORMAL)
         if self.timestamps_var.get():
             self.text.insert(tk.END, f"{time.strftime('%H:%M:%S', time.localtime(stamp))} ", ("stamp",))
@@ -300,24 +382,29 @@ class SerialMonitorWindow(tk.Toplevel):
         self.text.configure(state=tk.DISABLED)
         for record in list(self._lines):
             self._render(record)
+        self._update_count()
 
     def _trim(self) -> None:
         """Keep the widget's line count in step with the deque's cap."""
-        count = int(self.text.index("end-1c").split(".")[0])
-        if count > MAX_LINES:
-            self.text.delete("1.0", f"{count - MAX_LINES}.0")
+        shown = self._shown_line_count()
+        if shown > MAX_LINES:
+            self.text.delete("1.0", f"{shown - MAX_LINES + 1}.0")
 
     def clear(self) -> None:
         self._lines.clear()
         self.text.configure(state=tk.NORMAL)
         self.text.delete("1.0", tk.END)
         self.text.configure(state=tk.DISABLED)
+        self._update_count()
 
     def dump(self) -> str:
-        """The scrollback as plain text, timestamped as currently displayed."""
+        """The scrollback as plain text — what's on screen, filter included."""
         stamps = self.timestamps_var.get()
         out = []
-        for kind, stamp, line in self._lines:
+        for record in self._lines:
+            if not self.matches(record):
+                continue
+            kind, stamp, line = record
             prefix = f"{time.strftime('%H:%M:%S', time.localtime(stamp))} " if stamps else ""
             out.append(f"{prefix}{KIND_PREFIX.get(kind, '')}{line}")
         return "\n".join(out) + ("\n" if out else "")
@@ -371,6 +458,13 @@ class SerialMonitorWindow(tk.Toplevel):
     # ----- lifecycle ----------------------------------------------------------
 
     def close(self) -> None:
+        # A debounced re-render still in flight would fire against a dead widget.
+        if self._filter_job is not None:
+            try:
+                self.after_cancel(self._filter_job)
+            except tk.TclError:
+                pass
+            self._filter_job = None
         for topic, handler in (
             ("serial/rx", self._on_rx),
             ("serial/tx", self._on_tx),

--- a/src/sorter/ui/tab_serial.py
+++ b/src/sorter/ui/tab_serial.py
@@ -179,6 +179,9 @@ class SerialTab(ttk.Frame):
         entry.pack(side=tk.LEFT, padx=4)
         entry.bind("<Return>", lambda _e: self.send_command())
         ttk.Button(cmd_row, text="Send", command=self.send_command).pack(side=tk.LEFT)
+        ttk.Button(cmd_row, text="Open monitor ↗", command=self.app.open_serial_monitor).pack(
+            side=tk.LEFT, padx=(12, 0)
+        )
 
         self.log = tk.Text(monitor, height=10, wrap=tk.NONE, state=tk.DISABLED)
         self.log.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=4, pady=4)

--- a/tests/unit/hardware/test_serial_broker.py
+++ b/tests/unit/hardware/test_serial_broker.py
@@ -621,3 +621,85 @@ def test_try_open_returns_false_when_the_port_cannot_be_opened(
     monkeypatch.setattr(serial_broker.serial, "Serial", _boom)
     assert broker.try_open() is False
     assert broker.is_connected is False
+
+
+# ----- handshake visibility (issue #76) --------------------------------------
+
+
+def test_try_open_reports_the_handshake_through_the_callbacks(
+    broker: SerialBroker, sink: _Sink, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The probe talks to the port directly, so it has to narrate itself.
+
+    Without this the serial monitor is blank for exactly the connection that
+    failed — the one worth reading.
+    """
+    fake = _FakeSerial(lines=["Ready\n", "7.2.260128.7.1\n"])
+    _patch_serial(monkeypatch, fake)
+    sent: list[str] = []
+    broker.on_sent.append(sent.append)
+    try:
+        assert broker.try_open() is True
+    finally:
+        broker.close()
+    assert sink.received == ["Ready", "7.2.260128.7.1"]
+    assert sent == ["version"]
+
+
+def test_try_open_reports_a_multi_line_banner_and_a_failed_handshake(
+    broker: SerialBroker, sink: _Sink, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    fake = _FakeSerial(lines=["booting...\n", "3.2.1\n"], read_all_text="init ok\n\n")
+    _patch_serial(monkeypatch, fake)
+    assert broker.try_open() is False
+    # Blank lines are dropped; everything the board actually printed survives.
+    assert sink.received == ["booting...", "init ok", "3.2.1"]
+
+
+def test_try_open_survives_a_callback_that_raises(broker: SerialBroker, monkeypatch: pytest.MonkeyPatch) -> None:
+    def _boom(_line: str) -> None:
+        raise RuntimeError("subscriber bug")
+
+    broker.on_received.append(_boom)
+    broker.on_sent.append(_boom)
+    fake = _FakeSerial(lines=["Ready\n", "7.4.1\n"])
+    _patch_serial(monkeypatch, fake)
+    try:
+        assert broker.try_open() is True
+    finally:
+        broker.close()
+
+
+# ----- send_raw ---------------------------------------------------------------
+
+
+def test_send_raw_writes_the_text_verbatim(broker: SerialBroker, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The monitor's line-ending selector owns the terminator; send_raw must
+    # neither add one (as send_command does) nor drop the one it was given.
+    fake = _WritableSerial()
+    monkeypatch.setattr(broker, "_sp", fake)
+    sent: list[str] = []
+    broker.on_sent.append(sent.append)
+
+    broker.send_raw("version\r\n")
+    broker.send_raw("getconfig")
+
+    assert fake.written == [b"version\r\n", b"getconfig"]
+    # The echo is for display, so it carries no line ending either way.
+    assert sent == ["version", "getconfig"]
+
+
+def test_send_raw_is_a_noop_without_an_open_port(broker: SerialBroker) -> None:
+    sent: list[str] = []
+    broker.on_sent.append(sent.append)
+    broker.send_raw("version\n")
+    assert sent == []
+
+
+def test_send_command_still_owns_its_newline(broker: SerialBroker, monkeypatch: pytest.MonkeyPatch) -> None:
+    # The protocol helpers are pinned to the firmware's vocabulary; send_raw
+    # landing next to them must not have changed what they put on the wire.
+    fake = _WritableSerial()
+    monkeypatch.setattr(broker, "_sp", fake)
+    broker.send_command("xf:0")
+    assert fake.written == [b"xf:0\n"]

--- a/tests/unit/ui/test_serial_monitor.py
+++ b/tests/unit/ui/test_serial_monitor.py
@@ -253,3 +253,125 @@ def test_apply_palette_repaints_the_text_tags(root) -> None:
     finally:
         _apply(root, theme="Dark")
         win.close()
+
+
+def _flush_filter(win: SerialMonitorWindow) -> None:
+    """Run the debounced re-render now rather than waiting out the timer."""
+    if win._filter_job is not None:
+        win.after_cancel(win._filter_job)
+        win._filter_job = None
+    win._rerender()
+
+
+def _post(app: _FakeApp, *pairs: tuple[str, str]) -> None:
+    for topic, line in pairs:
+        app.bus.post(topic, line)
+    app.bus.drain()
+
+
+def test_typing_a_filter_debounces_instead_of_rerendering_per_keystroke(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        win.filter_var.set("do")
+        assert win._filter_job is not None, "no re-render was scheduled"
+    finally:
+        win.close()
+
+
+def test_filter_hides_non_matching_lines_but_keeps_them_for_later(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        _post(app, ("serial/tx", "xf:0"), ("serial/rx", "done"), ("serial/rx", "waiting"))
+        win.filter_var.set("done")
+        _flush_filter(win)
+        body = _body(win)
+        assert "done" in body
+        assert "xf:0" not in body
+        assert "waiting" not in body
+
+        # Filtering is a view, not a deletion.
+        win.clear_filter()
+        _flush_filter(win)
+        body = _body(win)
+        assert "xf:0" in body and "waiting" in body
+    finally:
+        win.close()
+
+
+def test_filter_is_case_insensitive_and_matches_the_board_text_only(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        _post(app, ("serial/rx", "Done"))
+        win.filter_var.set("dOnE")
+        _flush_filter(win)
+        assert "Done" in _body(win)
+
+        # The `<-`/`->` prefixes are rendering, not content — a filter must not
+        # key off them or "->" would silently mean "everything I sent".
+        win.filter_var.set("<-")
+        _flush_filter(win)
+        assert "Done" not in _body(win)
+    finally:
+        win.close()
+
+
+def test_direction_toggles_hide_a_whole_kind(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        _post(app, ("serial/tx", "version"), ("serial/rx", "7.2.1"), ("serial/note", "probing"))
+        win.show_kind_vars["tx"].set(False)
+        win._rerender()
+        body = _body(win)
+        assert "version" not in body
+        assert "7.2.1" in body and "probing" in body
+    finally:
+        win.close()
+
+
+def test_lines_arriving_while_a_filter_is_active_respect_it(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        win.filter_var.set("done")
+        _flush_filter(win)
+        _post(app, ("serial/rx", "waiting"), ("serial/rx", "done"))
+        body = _body(win)
+        assert "done" in body
+        assert "waiting" not in body
+        # …and are still there once the filter goes away.
+        win.clear_filter()
+        _flush_filter(win)
+        assert "waiting" in _body(win)
+    finally:
+        win.close()
+
+
+def test_dump_follows_the_filter_so_save_writes_what_is_shown(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        _post(app, ("serial/rx", "done"), ("serial/rx", "waiting"))
+        win.filter_var.set("done")
+        _flush_filter(win)
+        dumped = win.dump()
+        assert "done" in dumped
+        assert "waiting" not in dumped
+    finally:
+        win.close()
+
+
+def test_count_reports_shown_against_total_only_while_filtering(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        _post(app, ("serial/rx", "done"), ("serial/rx", "waiting"), ("serial/tx", "xf:0"))
+        assert win._count_var.get() == "3 lines"
+        win.filter_var.set("done")
+        _flush_filter(win)
+        assert win._count_var.get() == "1 of 3 lines"
+    finally:
+        win.close()

--- a/tests/unit/ui/test_serial_monitor.py
+++ b/tests/unit/ui/test_serial_monitor.py
@@ -1,0 +1,255 @@
+"""Serial monitor window — backlog replay, pause/resume, history, send path.
+
+Needs a real Tk display (uses xvfb in CI); skipped where tkinter isn't
+importable, matching the other UI tests.
+"""
+
+from __future__ import annotations
+
+import time
+from typing import Any
+
+import pytest
+
+pytest.importorskip("tkinter")
+
+import tkinter as tk
+
+from sorter.control.events import EventBus
+from sorter.ui.serial_monitor import LINE_ENDINGS, SerialMonitorWindow
+from sorter.ui.theme import apply_theme
+
+
+class _FakeBroker:
+    def __init__(self, *, connected: bool = True) -> None:
+        self.port = "/dev/ttyFAKE"
+        self.baud = 9600
+        self.firmware_version = "7.2.1"
+        self.is_connected = connected
+        self.raw: list[str] = []
+
+    def send_raw(self, text: str) -> None:
+        self.raw.append(text)
+
+
+class _FakeConfig:
+    def __init__(self) -> None:
+        self.serial: dict[str, Any] = {"port": "/dev/ttyFAKE", "baud": 9600}
+        self.saved = 0
+
+    def save(self) -> None:
+        self.saved += 1
+
+
+class _FakeApp:
+    def __init__(self, *, broker: Any = None, backlog: list | None = None) -> None:
+        self.bus = EventBus()
+        self.config = _FakeConfig()
+        self.broker = broker
+        self.serial_backlog = backlog or []
+        self.reconnects: list[str] = []
+
+    def connect_serial(self, port: str | None = None) -> None:
+        self.reconnects.append(port or "")
+
+
+@pytest.fixture
+def root():
+    try:
+        r = tk.Tk()
+    except tk.TclError:
+        pytest.skip("no display")
+    r.withdraw()
+    apply_theme(r)
+    yield r
+    r.destroy()
+
+
+def _open(root, app: _FakeApp) -> SerialMonitorWindow:
+    win = SerialMonitorWindow(root, app=app)
+    win.withdraw()
+    return win
+
+
+def _body(win: SerialMonitorWindow) -> str:
+    return win.text.get("1.0", tk.END)
+
+
+def test_bus_lines_land_in_the_log_with_direction_tags(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        app.bus.post("serial/rx", "done")
+        app.bus.post("serial/tx", "xf:0")
+        app.bus.drain()
+        body = _body(win)
+        assert "<- done" in body
+        assert "-> xf:0" in body
+        # RX and TX print in different palette roles, which is the whole point
+        # of tagging them.
+        assert win.text.tag_cget("rx", "foreground") != win.text.tag_cget("tx", "foreground")
+    finally:
+        win.close()
+
+
+def test_backlog_is_replayed_so_a_failed_probe_is_still_readable(root) -> None:
+    stamp = time.time()
+    backlog = [
+        ("note", stamp, "probing /dev/ttyUSB0 @ 9600…"),
+        ("rx", stamp, "\x00garbage"),
+        ("note", stamp, "/dev/ttyUSB0 did not handshake"),
+    ]
+    app = _FakeApp(backlog=backlog)
+    win = _open(root, app)
+    try:
+        body = _body(win)
+        assert "probing /dev/ttyUSB0 @ 9600…" in body
+        assert "garbage" in body
+        assert "did not handshake" in body
+        assert "end of replay (3 earlier line(s))" in body
+    finally:
+        win.close()
+
+
+def test_pause_holds_lines_and_resume_flushes_them_in_order(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        win.paused_var.set(True)
+        app.bus.post("serial/rx", "first")
+        app.bus.post("serial/rx", "second")
+        app.bus.drain()
+        assert "first" not in _body(win)
+
+        win.paused_var.set(False)
+        win._on_pause_toggled()
+        body = _body(win)
+        assert body.index("first") < body.index("second"), "held lines flush in arrival order"
+    finally:
+        win.close()
+
+
+def test_timestamp_toggle_rerenders_what_is_already_there(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        win.append("rx", "done", stamp=time.mktime((2026, 8, 12, 13, 45, 7, 0, 0, -1)))
+        assert "13:45:07" not in _body(win)
+        win.timestamps_var.set(True)
+        win._rerender()
+        assert "13:45:07 <- done" in _body(win)
+    finally:
+        win.close()
+
+
+def test_clear_empties_both_the_widget_and_the_dump(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        win.append("rx", "done")
+        win.clear()
+        assert _body(win).strip() == ""
+        assert win.dump() == ""
+    finally:
+        win.close()
+
+
+@pytest.mark.parametrize(
+    ("label", "ending"),
+    [("No line ending", ""), ("New Line", "\n"), ("Carriage Return", "\r"), ("Both NL & CR", "\r\n")],
+)
+def test_send_applies_the_selected_line_ending(root, label: str, ending: str) -> None:
+    broker = _FakeBroker()
+    app = _FakeApp(broker=broker)
+    win = _open(root, app)
+    try:
+        assert LINE_ENDINGS[label] == ending
+        win.ending_var.set(label)
+        win.entry_var.set("getconfig")
+        win.send_command()
+        assert broker.raw == [f"getconfig{ending}"]
+        assert win.entry_var.get() == ""
+    finally:
+        win.close()
+
+
+def test_send_without_a_connection_says_so_instead_of_raising(root) -> None:
+    app = _FakeApp(broker=_FakeBroker(connected=False))
+    win = _open(root, app)
+    try:
+        win.entry_var.set("version")
+        win.send_command()
+        assert app.broker.raw == []
+        assert "not connected" in _body(win)
+    finally:
+        win.close()
+
+
+def test_up_and_down_walk_the_command_history(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        for cmd in ("version", "getconfig"):
+            win.entry_var.set(cmd)
+            win.send_command()
+        win._history_step(-1)
+        assert win.entry_var.get() == "getconfig"
+        win._history_step(-1)
+        assert win.entry_var.get() == "version"
+        win._history_step(1)
+        assert win.entry_var.get() == "getconfig"
+        win._history_step(1)
+        assert win.entry_var.get() == "", "past the newest entry the field clears"
+    finally:
+        win.close()
+
+
+def test_changing_the_baud_persists_it_and_reconnects(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        win.baud_var.set("115200")
+        win._on_baud_selected()
+        assert app.config.serial["baud"] == 115200
+        assert app.config.saved == 1
+        assert app.reconnects == ["/dev/ttyFAKE"]
+    finally:
+        win.close()
+
+
+def test_header_tracks_the_connection_state(root) -> None:
+    broker = _FakeBroker()
+    app = _FakeApp(broker=broker)
+    win = _open(root, app)
+    try:
+        assert win._header_var.get() == "/dev/ttyFAKE @ 9600 — 7.2.1"
+        broker.is_connected = False
+        app.bus.post("serial/state", {"connected": False, "message": "Serial: disconnected"})
+        app.bus.drain()
+        assert "disconnected" in win._header_var.get()
+    finally:
+        win.close()
+
+
+def test_unsubscribes_on_close(root) -> None:
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    assert win._on_rx in app.bus._subs.get("serial/rx", [])
+    win.close()
+    for topic in ("serial/rx", "serial/tx", "serial/note", "serial/state"):
+        assert not app.bus._subs.get(topic), f"{topic} still has a subscriber"
+
+
+def test_apply_palette_repaints_the_text_tags(root) -> None:
+    from sorter.ui.theme import apply_theme as _apply
+
+    app = _FakeApp(broker=_FakeBroker())
+    win = _open(root, app)
+    try:
+        before = win.text.tag_cget("rx", "foreground")
+        _apply(root, theme="Light")
+        win.apply_palette()
+        assert win.text.tag_cget("rx", "foreground") != before
+    finally:
+        _apply(root, theme="Dark")
+        win.close()

--- a/tests/unit/ui/test_theme.py
+++ b/tests/unit/ui/test_theme.py
@@ -382,6 +382,8 @@ def _stub_window(root, db=None):
             )
             self._camera_connected = False
             self._serial_connected = True
+            # set_theme repaints an open serial monitor's Text tags.
+            self._serial_monitor = None
             self.camera_dot = tk.Label(
                 root,
                 text="●",


### PR DESCRIPTION
## What & Why

The status bar showed what read as two contradicting `Serial:` readouts, never
said what speed the link was running at, and gave no way into a serial monitor
when the connection was the thing that was broken. The monitor that did exist
(in the Serial tab) was blind exactly when it mattered: `try_open()` runs the
whole handshake directly on the port and fired no callbacks, and the
auto-connect probe attached no listeners to its throwaway brokers — so after
"no board responded on any port" there was nothing to read.

**`hardware/serial_broker.py`**
- `try_open()` now narrates the handshake through the existing callbacks:
  `on_received` per non-empty banner line and for the version reply, `on_sent`
  for `version`. Connection logic is unchanged; the notifications go through
  `_fire`, so a subscriber that raises can't break a handshake.
- New `send_raw(text)` writes a string verbatim — nothing appended, nothing
  stripped — for the monitor's line-ending selector. `send_command` and every
  protocol helper are untouched: the wire vocabulary stays pinned to the
  firmware (CLAUDE.md §4).
- `serial_emulator.EmulatorBroker` mirrors `send_raw`.

**New `ui/serial_monitor.py`** — a detachable, Arduino-IDE-style window:
- header with port, **baud** and firmware version behind a connection dot that
  mirrors the status bar's;
- read-only monospace log, RX/TX/notes in distinct palette roles (read from
  `PALETTE` at call time; no new roles added);
- Autoscroll, Timestamps (re-renders the existing scrollback, not just new
  lines), Pause that **holds** incoming lines and flushes them on resume;
- Clear and Save… (plain-text dump of exactly what's displayed);
- send row: entry + line-ending combobox (No line ending / New Line / Carriage
  Return / Both NL & CR) + Send, `<Return>` to send, `<Up>`/`<Down>` for
  command history, routed through `send_raw`;
- baud combobox on the standard ladder (300…250000) that persists to
  `config.serial["baud"]` and reconnects on the current port;
- a **case-insensitive substring filter** plus **RX / TX / Notes toggles**, with
  a `N of M lines` count. `matches()` is the single predicate — `_render`
  applies it as lines arrive, `_rerender` when the filter changes, and `dump()`
  so Save… writes what's on screen. It matches the board's text rather than the
  rendered line, so the `<-`/`->` prefixes and the optional timestamp can't be
  filtered against, and `_lines` keeps everything: clearing the box brings the
  hidden traffic straight back. Typing is debounced (re-rendering 4000 lines
  per keystroke isn't free) and the pending job is cancelled on close;
- 4000-line bounded scrollback, single instance, unsubscribes on close.

**No column sort, deliberately.** A serial log is a sequence, not a table: a
command and the reply it drew are one exchange, and re-ordering by any other
key destroys the only structure the log has. Narrowing is the useful operation,
which is what the filter and the direction toggles do — they hide lines without
moving the ones that remain. (The Arduino IDE doesn't sort either.)

**`ui/app.py`**
- The connected indicator carries the baud:
  `Serial: connected (/dev/ttyUSB0 @ 9600) — 7.2.1`.
- Each failure path names itself — `no ports`, `no board found`,
  `failed to open <port>`, `no port selected`, `disconnected` (user) — and the
  transient messages lose their `Serial: ` prefix, which is what made the
  left-hand line read as a second, contradicting indicator.
- Both indicators are links (hand cursor + underline on hover, click anywhere
  on the dot/label pair): serial opens the monitor, camera selects the Camera
  tab. The transient message is now packed **last** in the status bar, so a
  crowded bar truncates it rather than the standing connection state.
- The auto-connect probe attaches bus-posting `on_received`/`on_sent`
  listeners to every candidate broker *before* `try_open()` (worker thread —
  they only `bus.post`), and posts `serial/note` commentary per port. A
  `_bus_listeners_attached` marker keeps `_after_connect` from double-wiring
  the winner.
- `MainWindow.serial_backlog` (a 2000-entry deque filled by the existing
  `serial/rx`/`serial/tx` subscriptions) is replayed when a monitor opens, so a
  window opened *after* a failed probe still shows what happened.
- `open_serial_monitor()` / `select_tab()` are the public entry points;
  `set_theme` repaints the open monitor's Text tags (`retheme_widgets` can't
  reach them).

**`ui/tab_serial.py`** — the in-tab log and command row are unchanged; the
command row gains an "Open monitor ↗" button.

**CLAUDE.md** updated in the same change: §4 serial_broker (handshake
callbacks, `send_raw`), §5 shell paragraph (clickable indicators, status-bar
packing priority), shared-UI list (`serial_monitor.py`) and the tab table.

Closes: #76

## Screenshots

Both columns are the real app, same window size and theme, running the **same
session**: a genuine failed auto-connect (`list_serial_ports` pointed at
`/dev/ttyUSB0` and `/dev/ttyACM0`, which don't exist on the capture machine, so
`try_open()` really fails), then a connection to the bundled `SerialEmulator`
and six real protocol commands. Every line of traffic is the emulator's reply
through `on_received` — none of it is text typed by the harness. The camera
indicator is whatever the camera actually did.

**Status bar.** Before, the transient message and the indicator both say
"Serial", contradict each other, and the camera indicator is the thing that
gets truncated. After, the failure names itself, the prefix is gone, and the
message is what loses room instead of the connection state:

| Before | After |
|---|---|
| ![before statusbar](https://github.com/user-attachments/assets/eb5db416-2f96-44c8-a352-19156dde1b33) | ![after statusbar](https://github.com/user-attachments/assets/9b0fce85-7eaf-4dea-8c3d-d049ebae6529) |

**Reading serial traffic** — the same session, seen both ways. Before: the
in-tab panel at the bottom of the Serial Config tab, one colour, no timestamps,
no filter. After: the detachable monitor opened from the status bar.

The load-bearing difference is the top four lines of the "after" — `probing
/dev/ttyUSB0 @ 9600… / did not handshake`. That traffic happened in both runs;
today's build throws it away, which is the complaint behind #76.

| Before — in-tab panel | After — detached monitor |
|---|---|
| ![before inline log](https://github.com/user-attachments/assets/b6fed917-f0f8-498c-b5d5-03e5a254671c) | ![after monitor](https://github.com/user-attachments/assets/1f38b43f-40e7-489f-8193-ea6ca78b2c62) |

**Filtering** — `done` typed in the filter box, with the count reporting how
much is hidden:

![after monitor filtered](https://github.com/user-attachments/assets/230db073-fc6c-494d-82da-1db2bbe9d1e8)

## Author Checklist

- [x] CLAUDE.md updated in the same change (§4, §5)
- [x] No new `theme.PALETTE` roles introduced; colours read at call time
- [x] Threading rule respected — worker threads only `bus.post(...)`, no
      `widget.after()` off the main thread
- [ ] Ran `/quality:full-pr-review` and addressed findings

## Test Plan

### Before Deployment

**Author**
- [x] `pytest -p no:randomly --ignore=tests/unit/ui/test_theme_editor.py` — 776
      passed, 17 skipped
- [x] `uv run ruff check`, `uv run ruff format --check`, `uv run ty check` — all
      clean
- [x] New tests: `tests/unit/ui/test_serial_monitor.py` (15 cases: bus wiring,
      backlog replay, pause/resume ordering, timestamp re-render, line endings,
      history, baud reconnect, teardown) and four cases in
      `tests/unit/hardware/test_serial_broker.py` for the handshake callbacks
      and `send_raw`
- [x] Drove a real `MainWindow` end to end: simulated a failed probe, confirmed
      the monitor opened later replays it, that reconnecting to the emulator
      shows `Serial: connected (Emulated @ 9600) — Emulator-1.0`, that sending
      from the monitor echoes exactly once (no double-wired listeners), and
      that the camera indicator selects the Camera tab

**Reviewer**
- [ ] With real hardware: pull the USB cable, restart, and confirm the monitor
      opened from the status bar shows the probe attempts and whatever the
      board printed
- [ ] Change the baud in the monitor and confirm it reconnects and persists
- [ ] Switch themes with the monitor open and confirm RX/TX colours follow

