### PR TITLE
fix(camera): skip V4L2 metadata nodes when enumerating cameras

### DIFF
--- a/src/sorter/hardware/camera.py
+++ b/src/sorter/hardware/camera.py
@@ -10,6 +10,7 @@ when available) and the resolutions the device accepts.
 
 from __future__ import annotations
 
+import ctypes
 import os
 import sys
 import threading
@@ -214,19 +215,74 @@ def _windows_dshow_device_count() -> int | None:
 
 # ----- enumeration ------------------------------------------------------------
 
+# VIDIOC_QUERYCAP is _IOR('V', 0, struct v4l2_capability) from linux/videodev2.h,
+# which encodes as (read=2 << 30) | (sizeof << 16) | (ord('V') << 8) | 0.
+_VIDIOC_QUERYCAP = 0x80685600
+_V4L2_CAP_VIDEO_CAPTURE = 0x00000001
+_V4L2_CAP_DEVICE_CAPS = 0x80000000
+
+
+class _V4l2Capability(ctypes.Structure):
+    """`struct v4l2_capability` — the reply VIDIOC_QUERYCAP fills in.
+
+    Sized to match the kernel's 104-byte struct exactly; `_VIDIOC_QUERYCAP`
+    above bakes that size into the request number.
+    """
+
+    _fields_ = (
+        ("driver", ctypes.c_char * 16),
+        ("card", ctypes.c_char * 32),
+        ("bus_info", ctypes.c_char * 32),
+        ("version", ctypes.c_uint32),
+        ("capabilities", ctypes.c_uint32),
+        ("device_caps", ctypes.c_uint32),
+        ("reserved", ctypes.c_uint32 * 3),
+    )
+
+
+def _is_v4l2_capture_node(path: str) -> bool:
+    """Whether `path` is a capture node, defaulting to True when unknowable.
+
+    A UVC camera claims *two* /dev/videoN nodes: the capture node and a
+    metadata node that OpenCV can only ever fail to open, loudly. Nothing in
+    /sys tells them apart — the capability bits are only reachable by ioctl.
+    Anything that stops us asking (permissions, a non-V4L2 driver) returns
+    True so the device still gets probed; this narrows the candidate list, it
+    is not authoritative about what will open.
+    """
+    import fcntl  # POSIX-only, and this function is Linux-only
+
+    try:
+        # O_NONBLOCK so a wedged device can't stall enumeration on open().
+        fd = os.open(path, os.O_RDWR | os.O_NONBLOCK)
+    except OSError:
+        return True
+    cap = _V4l2Capability()
+    try:
+        fcntl.ioctl(fd, _VIDIOC_QUERYCAP, cap)
+    except OSError:
+        return True
+    finally:
+        os.close(fd)
+    # device_caps describes this node; capabilities describes the whole
+    # physical device, so on a metadata node it still advertises capture.
+    caps = cap.device_caps if cap.capabilities & _V4L2_CAP_DEVICE_CAPS else cap.capabilities
+    return bool(caps & _V4L2_CAP_VIDEO_CAPTURE)
+
 
 def _candidate_indices(max_index: int) -> list[int]:
     """Indices worth probing.
 
-    On Linux, skip indices with no /dev/videoN node at all — probing them
-    just produces OpenCV's noisy "can't open camera by index" V4L2 warnings.
-    On Windows, ask DirectShow how many capture devices are attached so
-    we don't fire OpenCV at indices 1-9 when only camera 0 exists (each
-    miss prints "VIDEOIO(DSHOW): backend is generally available but can't
-    be used to capture by index").
+    On Linux, skip indices with no /dev/videoN node, and those whose node is
+    not a capture node — probing either just produces OpenCV's noisy "can't
+    open camera by index" V4L2 warnings. On Windows, ask DirectShow how many
+    capture devices are attached so we don't fire OpenCV at indices 1-9 when
+    only camera 0 exists (each miss prints "VIDEOIO(DSHOW): backend is
+    generally available but can't be used to capture by index").
     """
     if sys.platform.startswith("linux"):
-        return [i for i in range(max_index) if os.path.exists(f"/dev/video{i}")]
+        nodes = ((i, f"/dev/video{i}") for i in range(max_index))
+        return [i for i, path in nodes if os.path.exists(path) and _is_v4l2_capture_node(path)]
     if sys.platform.startswith("win"):
         count = _windows_dshow_device_count()
         if count is not None:

--- a/tests/unit/hardware/test_camera.py
+++ b/tests/unit/hardware/test_camera.py
@@ -1,0 +1,135 @@
+"""Unit tests for camera device enumeration — which /dev/videoN nodes get probed.
+
+A UVC camera claims two nodes, only one of which can capture. Everything here
+is monkeypatched rather than pointed at real hardware, so it runs the same on a
+CI box with no camera at all.
+"""
+
+from __future__ import annotations
+
+import os
+import sys
+from typing import Any
+
+import pytest
+
+from sorter.hardware import camera
+
+# `capabilities` as a real UVC device reports it: the whole physical device,
+# so both its nodes advertise capture. Only `device_caps` distinguishes them.
+_DEVICE_CAPS_VALID = 0x84A00001
+_CAPTURE_NODE_CAPS = 0x04200001  # VIDEO_CAPTURE | STREAMING | EXT_PIX_FORMAT
+_METADATA_NODE_CAPS = 0x04A00000  # META_CAPTURE | STREAMING | EXT_PIX_FORMAT
+
+pytestmark = pytest.mark.skipif(
+    not sys.platform.startswith("linux"),
+    reason="V4L2 node filtering is Linux-only (fcntl/ioctl)",
+)
+
+
+def _fake_v4l2(
+    monkeypatch: pytest.MonkeyPatch,
+    *,
+    nodes: dict[str, tuple[int, int]],
+    open_error: OSError | None = None,
+    ioctl_error: OSError | None = None,
+) -> None:
+    """Patch os.open/os.close/fcntl.ioctl to serve `nodes` as fake V4L2 devices.
+
+    `nodes` maps a /dev path to its (capabilities, device_caps) pair.
+    """
+    import fcntl
+
+    fds: dict[int, str] = {}
+    next_fd = [1000]
+
+    def fake_open(path: Any, flags: int, *args: Any) -> int:
+        if open_error is not None:
+            raise open_error
+        next_fd[0] += 1
+        fds[next_fd[0]] = str(path)
+        return next_fd[0]
+
+    def fake_close(fd: int) -> None:
+        fds.pop(fd, None)
+
+    def fake_ioctl(fd: int, request: int, arg: Any = 0, mutate: bool = True) -> int:
+        if ioctl_error is not None:
+            raise ioctl_error
+        assert request == camera._VIDIOC_QUERYCAP
+        arg.capabilities, arg.device_caps = nodes[fds[fd]]
+        return 0
+
+    monkeypatch.setattr(os, "open", fake_open)
+    monkeypatch.setattr(os, "close", fake_close)
+    monkeypatch.setattr(fcntl, "ioctl", fake_ioctl)
+
+
+def test_querycap_struct_matches_the_kernels_layout() -> None:
+    """The ioctl request number encodes the struct size; the two must agree."""
+    import ctypes
+
+    assert ctypes.sizeof(camera._V4l2Capability) == 104
+    assert camera._VIDIOC_QUERYCAP == (2 << 30) | (104 << 16) | (ord("V") << 8) | 0
+
+
+def test_capture_node_is_a_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    _fake_v4l2(monkeypatch, nodes={"/dev/video0": (_DEVICE_CAPS_VALID, _CAPTURE_NODE_CAPS)})
+    assert camera._is_v4l2_capture_node("/dev/video0") is True
+
+
+def test_metadata_node_is_not_a_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The bug this guards: OpenCV can only fail to open a metadata node, loudly."""
+    _fake_v4l2(monkeypatch, nodes={"/dev/video1": (_DEVICE_CAPS_VALID, _METADATA_NODE_CAPS)})
+    assert camera._is_v4l2_capture_node("/dev/video1") is False
+
+
+def test_device_caps_is_ignored_when_the_driver_does_not_set_it(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Without the DEVICE_CAPS bit, `capabilities` is all a pre-3.3 driver offers."""
+    _fake_v4l2(monkeypatch, nodes={"/dev/video0": (0x04200001, 0)})
+    assert camera._is_v4l2_capture_node("/dev/video0") is True
+
+
+@pytest.mark.parametrize(
+    ("kwargs", "why"),
+    [
+        ({"open_error": PermissionError("not in the video group")}, "cannot open"),
+        ({"ioctl_error": OSError(25, "Inappropriate ioctl for device")}, "not a V4L2 driver"),
+    ],
+)
+def test_an_unanswerable_probe_keeps_the_device(
+    monkeypatch: pytest.MonkeyPatch, kwargs: dict[str, Any], why: str
+) -> None:
+    """This filter narrows the list; it is never the reason a real camera vanishes."""
+    _fake_v4l2(monkeypatch, nodes={}, **kwargs)
+    assert camera._is_v4l2_capture_node("/dev/video0") is True, why
+
+
+def test_candidate_indices_keeps_only_capture_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Two cameras, four nodes — the shape a real UVC pair presents."""
+    monkeypatch.setattr(camera.sys, "platform", "linux")
+    present = {"/dev/video0", "/dev/video1", "/dev/video2", "/dev/video3"}
+    monkeypatch.setattr(os.path, "exists", lambda p: p in present)
+    _fake_v4l2(
+        monkeypatch,
+        nodes={
+            "/dev/video0": (_DEVICE_CAPS_VALID, _CAPTURE_NODE_CAPS),
+            "/dev/video1": (_DEVICE_CAPS_VALID, _METADATA_NODE_CAPS),
+            "/dev/video2": (_DEVICE_CAPS_VALID, _CAPTURE_NODE_CAPS),
+            "/dev/video3": (_DEVICE_CAPS_VALID, _METADATA_NODE_CAPS),
+        },
+    )
+    assert camera._candidate_indices(10) == [0, 2]
+
+
+def test_candidate_indices_skips_missing_nodes_without_probing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """The existence check stays load-bearing: os.open on a missing path raises,
+    and an unanswerable probe deliberately answers True."""
+    monkeypatch.setattr(camera.sys, "platform", "linux")
+    monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/video0")
+    _fake_v4l2(monkeypatch, nodes={"/dev/video0": (_DEVICE_CAPS_VALID, _CAPTURE_NODE_CAPS)})
+    assert camera._candidate_indices(10) == [0]


### PR DESCRIPTION
## Description

Bottom of a three-PR stack fixing camera enumeration. This one is the cosmetic
half: six OpenCV warnings written into every `launch.log`.

A UVC camera claims two `/dev/videoN` nodes — the capture node and a metadata
node OpenCV can only ever fail to open, loudly. `_candidate_indices` already
meant to filter these (its docstring says exactly that), but the existence check
it used cannot tell them apart: both nodes exist. Only `VIDIOC_QUERYCAP`'s
`device_caps` separates them, and sysfs exposes no equivalent attribute.

So probe that ioctl, via a small `ctypes` struct + `fcntl.ioctl` — stdlib only,
no new dependency. The existence check stays in front of it and stays
load-bearing.

**An unanswerable probe returns `True`.** Permissions, a non-V4L2 driver,
anything unexpected — the device still gets probed. This filter only ever
narrows the candidate list, and must never be the reason a real camera goes
missing. That is the failure mode of the very bug stacked on top of this one
(#80), so it is pinned by tests rather than left to reading.

Verified on hardware with three cameras and three metadata nodes:
`_candidate_indices(10)` returns `[0, 2, 4]` instead of `[0, 1, 2, 3, 4, 5]`,
and `launch.log` went from 18 warnings to 0.

Fixes #85

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#contributions--licensing-dco)
- [x] Tests pass locally
- [x] I have updated `CLAUDE.md` if this changes architecture, a module boundary, or a
      subsystem described there
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)

### Notes on the checklist

- **Tests**: new `tests/unit/hardware/test_camera.py` (the module had none).
  Covers the capture/metadata split, the `device_caps` vs `capabilities`
  selection, the fail-open cases, and that the struct size matches the size
  baked into the ioctl request number. Full suite: 777 passed.
- **CLAUDE.md**: updated in the next PR up, where the enumeration paragraph is
  rewritten once for both fixes rather than twice.
