### PR TITLE
fix(camera): give a slow camera long enough to answer the probe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -318,6 +318,11 @@ between them from the Run tab's template dropdown.
   keeping the latest frame; platform backends (CAP_DSHOW on Windows w/ optional
   pygrabber for friendly names + resolution probing, CAP_V4L2 on Linux, MJPG for
   ≥1080p). `enumerate_devices` / `list_cameras_with_metadata` for the Camera tab.
+  Enumeration is deliberately noisy about what it *rejects*: only real V4L2
+  capture nodes are probed (a UVC camera also exposes a metadata node, which
+  OpenCV can only fail to open, loudly), and a device that overruns
+  `PROBE_TIMEOUT_S` is dropped **with a note on stderr** — silence there once
+  cost a hardware investigation to explain a camera missing from the list.
 
 ### The sort loop (`sorter/control/run_controller.py`)
 - **`run_controller.py`** — `RunController`: the production loop on a daemon

--- a/src/sorter/hardware/camera.py
+++ b/src/sorter/hardware/camera.py
@@ -36,6 +36,13 @@ COMMON_RESOLUTIONS: list[tuple[int, int]] = [
     (3840, 2160),
 ]
 
+# How long `list_cameras_with_metadata` waits for one device to open, report its
+# resolutions and hand over a frame. Sized off the slowest camera seen so far, an
+# autofocus USB webcam that needs ~2.6 s for all three, having previously been
+# dropped by a 2.5 s budget. The cost of a generous value is bounded because only
+# genuine capture nodes are ever probed (see `_candidate_indices`).
+PROBE_TIMEOUT_S = 6.0
+
 
 class CameraInfo(TypedDict):
     """One entry in `list_cameras_with_metadata`'s result."""
@@ -355,7 +362,7 @@ def _probe_resolutions(cap: cv2.VideoCapture) -> list[tuple[int, int]]:
     return sorted(supported, key=lambda wh: wh[0] * wh[1])
 
 
-def list_cameras_with_metadata(max_index: int = 10, probe_timeout_s: float = 2.5) -> list[CameraInfo]:
+def list_cameras_with_metadata(max_index: int = 10, probe_timeout_s: float = PROBE_TIMEOUT_S) -> list[CameraInfo]:
     """Enumerate cameras and return [{'index': int, 'name': str, 'resolutions': [(w,h), ...]}].
 
     Resolutions are sorted ascending by pixel count, so `resolutions[-1]` is the
@@ -405,6 +412,16 @@ def list_cameras_with_metadata(max_index: int = 10, probe_timeout_s: float = 2.5
         t = threading.Thread(target=_probe, daemon=True)
         t.start()
         t.join(probe_timeout_s)
+        if t.is_alive():
+            # A device that opens and then times out used to vanish from the
+            # list in silence, which is exactly what made a camera 60 ms over
+            # budget so hard to account for. bootstrap.py pipes stderr into
+            # launch.log, so this lands where someone would go looking.
+            print(
+                f"[camera] index {idx} ({names.get(idx, 'unnamed')}) did not finish "
+                f"probing within {probe_timeout_s:g}s — not listing it",
+                file=sys.stderr,
+            )
         if result["opened"]:
             out.append(
                 {

--- a/tests/unit/hardware/test_camera.py
+++ b/tests/unit/hardware/test_camera.py
@@ -1,14 +1,17 @@
-"""Unit tests for camera device enumeration — which /dev/videoN nodes get probed.
+"""Unit tests for camera device enumeration — which devices survive to the list.
 
-A UVC camera claims two nodes, only one of which can capture. Everything here
-is monkeypatched rather than pointed at real hardware, so it runs the same on a
-CI box with no camera at all.
+Two ways a real camera used to go missing: a UVC camera claims two nodes and
+only one of them can capture, and a slow camera could exceed the probe budget.
+Everything here is monkeypatched rather than pointed at real hardware, so it
+runs the same on a CI box with no camera at all.
 """
 
 from __future__ import annotations
 
+import inspect
 import os
 import sys
+import time
 from typing import Any
 
 import pytest
@@ -21,7 +24,7 @@ _DEVICE_CAPS_VALID = 0x84A00001
 _CAPTURE_NODE_CAPS = 0x04200001  # VIDEO_CAPTURE | STREAMING | EXT_PIX_FORMAT
 _METADATA_NODE_CAPS = 0x04A00000  # META_CAPTURE | STREAMING | EXT_PIX_FORMAT
 
-pytestmark = pytest.mark.skipif(
+linux_only = pytest.mark.skipif(
     not sys.platform.startswith("linux"),
     reason="V4L2 node filtering is Linux-only (fcntl/ioctl)",
 )
@@ -65,6 +68,7 @@ def _fake_v4l2(
     monkeypatch.setattr(fcntl, "ioctl", fake_ioctl)
 
 
+@linux_only
 def test_querycap_struct_matches_the_kernels_layout() -> None:
     """The ioctl request number encodes the struct size; the two must agree."""
     import ctypes
@@ -73,17 +77,20 @@ def test_querycap_struct_matches_the_kernels_layout() -> None:
     assert camera._VIDIOC_QUERYCAP == (2 << 30) | (104 << 16) | (ord("V") << 8) | 0
 
 
+@linux_only
 def test_capture_node_is_a_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
     _fake_v4l2(monkeypatch, nodes={"/dev/video0": (_DEVICE_CAPS_VALID, _CAPTURE_NODE_CAPS)})
     assert camera._is_v4l2_capture_node("/dev/video0") is True
 
 
+@linux_only
 def test_metadata_node_is_not_a_candidate(monkeypatch: pytest.MonkeyPatch) -> None:
     """The bug this guards: OpenCV can only fail to open a metadata node, loudly."""
     _fake_v4l2(monkeypatch, nodes={"/dev/video1": (_DEVICE_CAPS_VALID, _METADATA_NODE_CAPS)})
     assert camera._is_v4l2_capture_node("/dev/video1") is False
 
 
+@linux_only
 def test_device_caps_is_ignored_when_the_driver_does_not_set_it(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -92,6 +99,7 @@ def test_device_caps_is_ignored_when_the_driver_does_not_set_it(
     assert camera._is_v4l2_capture_node("/dev/video0") is True
 
 
+@linux_only
 @pytest.mark.parametrize(
     ("kwargs", "why"),
     [
@@ -107,6 +115,7 @@ def test_an_unanswerable_probe_keeps_the_device(
     assert camera._is_v4l2_capture_node("/dev/video0") is True, why
 
 
+@linux_only
 def test_candidate_indices_keeps_only_capture_nodes(monkeypatch: pytest.MonkeyPatch) -> None:
     """Two cameras, four nodes — the shape a real UVC pair presents."""
     monkeypatch.setattr(camera.sys, "platform", "linux")
@@ -124,6 +133,7 @@ def test_candidate_indices_keeps_only_capture_nodes(monkeypatch: pytest.MonkeyPa
     assert camera._candidate_indices(10) == [0, 2]
 
 
+@linux_only
 def test_candidate_indices_skips_missing_nodes_without_probing(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
@@ -133,3 +143,71 @@ def test_candidate_indices_skips_missing_nodes_without_probing(
     monkeypatch.setattr(os.path, "exists", lambda p: p == "/dev/video0")
     _fake_v4l2(monkeypatch, nodes={"/dev/video0": (_DEVICE_CAPS_VALID, _CAPTURE_NODE_CAPS)})
     assert camera._candidate_indices(10) == [0]
+
+
+# ----- the probe budget -------------------------------------------------------
+#
+# Platform-independent: every branch below is reached through stubs, so these
+# run on Windows and macOS too.
+
+
+def _fake_captures(monkeypatch: pytest.MonkeyPatch, first_frame_delay_s: dict[int, float]) -> None:
+    """Stub cv2.VideoCapture with devices that take a given time to serve a frame."""
+
+    class _FakeCapture:
+        def __init__(self, index: int, _backend: int) -> None:
+            self.index = index
+
+        def isOpened(self) -> bool:
+            return True
+
+        def read(self) -> tuple[bool, Any]:
+            time.sleep(first_frame_delay_s[self.index])
+            return True, object()
+
+        def release(self) -> None:
+            pass
+
+    monkeypatch.setattr(camera.cv2, "VideoCapture", _FakeCapture)
+    monkeypatch.setattr(camera, "_probe_resolutions", lambda cap: [(640, 480)])
+
+
+def test_the_probe_budget_default_is_the_module_constant() -> None:
+    """The literal default this replaced was the whole bug; keep them in one place."""
+    default = inspect.signature(camera.list_cameras_with_metadata).parameters["probe_timeout_s"]
+    assert default.default == camera.PROBE_TIMEOUT_S
+    # The slowest camera measured needs ~2.6 s; anything near the old 2.5 s is
+    # a regression even if it technically still passes for a faster device.
+    assert camera.PROBE_TIMEOUT_S >= 4.0
+
+
+def test_a_device_that_answers_in_time_is_listed_without_comment(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    monkeypatch.setattr(camera, "_candidate_indices", lambda _max: [0])
+    monkeypatch.setattr(camera, "camera_names", lambda: {0: "Webcam"})
+    _fake_captures(monkeypatch, {0: 0.0})
+
+    found = camera.list_cameras_with_metadata(probe_timeout_s=2.0)
+
+    assert [c["index"] for c in found] == [0]
+    assert found[0]["name"] == "Webcam"
+    assert capsys.readouterr().err == "", "a healthy device should say nothing"
+
+
+def test_a_device_that_blows_the_budget_is_dropped_but_reported(
+    monkeypatch: pytest.MonkeyPatch, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """The silence here is what made a camera 60 ms over budget so hard to explain."""
+    monkeypatch.setattr(camera, "_candidate_indices", lambda _max: [0, 4])
+    monkeypatch.setattr(camera, "camera_names", lambda: {0: "Built-in", 4: "Vitade AF"})
+    _fake_captures(monkeypatch, {0: 0.0, 4: 1.0})
+
+    found = camera.list_cameras_with_metadata(probe_timeout_s=0.2)
+
+    assert [c["index"] for c in found] == [0]
+    err = capsys.readouterr().err
+    assert "index 4" in err
+    assert "Vitade AF" in err, "name it, so the reader knows which camera went missing"
+    assert "0.2" in err, "quote the budget it missed"
+    assert "index 0" not in err


### PR DESCRIPTION
## Description

The user-visible half of the stack: a working USB camera was missing from the
Camera tab entirely, so there was no image to sort with.

`list_cameras_with_metadata` gave each device 2.5 s to open, report its
resolutions and hand over a frame. Measured on the camera that triggered this,
an autofocus Microdia Vitade AF:

| step | time |
|---|---|
| `cv2.VideoCapture(4, CAP_V4L2)` | 0.26 s |
| `_probe_resolutions` | 0.81 s |
| first `cap.read()` | 1.49 s |
| **total** | **2.56 s** vs. a 2.50 s budget |

It missed by about 60 ms. Reproduced identically three runs in a row, so it is
not jitter — but a margin that thin is exactly the kind that behaves
intermittently on someone else's machine.

Two changes:

**Raise the budget to 6 s**, as `PROBE_TIMEOUT_S` next to `COMMON_RESOLUTIONS`
rather than a literal default, with the measurement recorded as the reason. The
generosity is affordable because of the PR below this one: only genuine capture
nodes are probed at all now, so on the machine that found this it is 3 devices
instead of 6.

**Say something when a device is dropped.** This is the part I would argue for
keeping even if the timeout were left alone. The probe thread was joined with a
timeout and the device simply not appended — no log line, no event. The Camera
tab just showed a shorter list, and finding out why took `lsusb`, sysfs walking
and hand-timing OpenCV calls. `bootstrap.py` already pipes the app's stderr into
`launch.log`, so a one-line note lands where someone would actually look.

Verified on hardware — index 4 now enumerates, and the whole sweep takes 5.68 s:

```
  index  0  'Integrated RGB Camera: Integrat'  max (1920, 1080)
  index  2  'Integrated RGB Camera: Integrat'  max (640, 360)
  index  4  'Webcam: Webcam'                   max (2048, 1536)   <- the rig
```

Also confirmed in the running app: the camera appears in the tab and gives a
live image.

Fixes #80

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#contributions--licensing-dco)
- [x] Tests pass locally
- [x] I have updated `CLAUDE.md` if this changes architecture, a module boundary, or a
      subsystem described there
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)

### Notes on the checklist

- **Tests**: three added to `tests/unit/hardware/test_camera.py`, all
  platform-independent (the V4L2 ones from the PR below are marked Linux-only,
  which is why the module-level skip becomes a per-test decorator here). They
  pin that the default comes from the constant, that a healthy device is listed
  silently, and that a slow one is dropped *and* named. Full suite: 777 passed.
- **CLAUDE.md**: the `camera.py` entry in §4 now records both the capture-node
  filter and that an overrun is reported rather than swallowed.
