### PR TITLE
refactor(camera): drop the unused enumerate_devices

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -317,7 +317,7 @@ between them from the Run tab's template dropdown.
 - **`camera.py`** — `Camera`: `cv2.VideoCapture` with a background **grab thread**
   keeping the latest frame; platform backends (CAP_DSHOW on Windows w/ optional
   pygrabber for friendly names + resolution probing, CAP_V4L2 on Linux, MJPG for
-  ≥1080p). `enumerate_devices` / `list_cameras_with_metadata` for the Camera tab.
+  ≥1080p). `list_cameras_with_metadata` enumerates for the Camera tab.
   Enumeration is deliberately noisy about what it *rejects*: only real V4L2
   capture nodes are probed (a UVC camera also exposes a metadata node, which
   OpenCV can only fail to open, loudly), and a device that overruns

--- a/src/sorter/hardware/camera.py
+++ b/src/sorter/hardware/camera.py
@@ -297,35 +297,6 @@ def _candidate_indices(max_index: int) -> list[int]:
     return list(range(max_index))
 
 
-def enumerate_devices(max_index: int = 10, probe_timeout_s: float = 1.5) -> list[int]:
-    """Return camera indices that successfully opened and returned a frame.
-
-    Each probe runs in a worker thread; we move on if it exceeds probe_timeout_s
-    (some V4L2 devices hang indefinitely on open).
-    """
-    backend = _preferred_backend()
-    found: list[int] = []
-    for idx in _candidate_indices(max_index):
-        result: list[bool] = [False]
-
-        def _probe(i: int = idx, res: list[bool] = result) -> None:
-            cap = cv2.VideoCapture(i, backend)
-            try:
-                if cap.isOpened():
-                    ok, _ = cap.read()
-                    if ok:
-                        res[0] = True
-            finally:
-                cap.release()
-
-        t = threading.Thread(target=_probe, daemon=True)
-        t.start()
-        t.join(probe_timeout_s)
-        if result[0]:
-            found.append(idx)
-    return found
-
-
 def _probe_resolutions(cap: cv2.VideoCapture) -> list[tuple[int, int]]:
     """Try each resolution in COMMON_RESOLUTIONS; collect what the device actually serves.
 


### PR DESCRIPTION
## Description

Top of the stack, and the only part with no bug behind it: `enumerate_devices`
has no callers. A repo-wide search finds its own definition and one mention in
`CLAUDE.md`, nothing else. The Camera tab enumerates through
`list_cameras_with_metadata`, which returns names and resolutions alongside the
index, so this thinner variant has been redundant for some time.

What made it worth deleting now rather than leaving alone: it is a second copy
of the probe loop that no user path exercises, and it had drifted. It still
carried the old 1.5 s budget and never set FOURCC, so on the same webcam #80 was
about — 6.62 s to first frame under YUYV — it would have needed ~6.9 s to
succeed. Fixing the live copy while a stale copy sits beside it is how the two
get further apart, and a future caller would have reached for whichever name
read better.

No behaviour change; nothing calls it.

No issue for this one — it surfaced while fixing #80 and #85 rather than being
reported.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#contributions--licensing-dco)
- [x] Tests pass locally
- [x] I have updated `CLAUDE.md` if this changes architecture, a module boundary, or a
      subsystem described there
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)

### Notes on the checklist

- **Tests**: none added — this only removes code, and the removed function had
  no tests and no callers. Full suite still 777 passed.
- **CLAUDE.md**: §4's `camera.py` entry no longer names `enumerate_devices`.
