### PR TITLE
refactor(ui): make the Serial tab's log and the detachable monitor the same widget

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -623,13 +623,16 @@ a separate one, so a built-in is never the thing being written to),
   **replays `MainWindow.serial_backlog`** on construction — the rolling deque
   `app._log_serial` fills — because the traffic worth reading (a failed
   auto-connect probe) happens seconds before anyone can open a window. Two
-  constructor options mark what differs between the two hosts: `show_baud`
-  (the window's speed picker, which persists to `config.serial["baud"]` and
-  reconnects — the tab's Connection panel already owns that setting;
-  `BAUD_RATES` is what a 16 MHz AVR can generate inside 8N1's ±2% tolerance,
-  **not** the Arduino IDE's ladder, so don't re-add 230400) and
-  `detach_command` (the tab's "Open monitor ↗", on the control row rather
-  than a row of its own). Text tags bake their colours in and
+  **speed picker is part of the component**, not something a host bolts on:
+  it persists to `config.serial["baud"]` and reconnects, and `BAUD_RATES` is
+  what a 16 MHz AVR can generate inside 8N1's ±2% tolerance — **not** the
+  Arduino IDE's ladder, so don't re-add 230400. The Serial tab shows baud in
+  its Connection panel as well, and the two are kept from disagreeing at both
+  ends: `_sync_baud` re-reads the setting on `serial/state`, and the
+  `on_baud_changed` callback tells the host to refresh after a pick here. The
+  one host-specific option left is `detach_command` (the tab's
+  "Open monitor ↗", on the control row rather than a row of its own).
+  Text tags bake their colours in and
   `retheme_widgets` can't reach them, so `set_theme` calls `apply_palette()`
   on every live console.
 - **`serial_monitor.py`** — `SerialMonitorWindow`: a `SerialConsole` in its own

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -622,19 +622,21 @@ a separate one, so a built-in is never the thing being written to),
   `serial/rx`, `serial/tx` and `serial/note` (probe commentary) itself, and
   **replays `MainWindow.serial_backlog`** on construction — the rolling deque
   `app._log_serial` fills — because the traffic worth reading (a failed
-  auto-connect probe) happens seconds before anyone can open a window. Two
-  **speed picker is part of the component**, not something a host bolts on:
-  it persists to `config.serial["baud"]` and reconnects, and `BAUD_RATES` is
+  auto-connect probe) happens seconds before anyone can open a window.
+  The **speed picker is part of the component**, not something a host bolts
+  on, and it is the *only* baud control in the app — the Serial tab's
+  Connection panel deliberately has none, so one widget owns
+  `config.serial["baud"]`, persisting and reconnecting as it is picked (which
+  is also why `SerialTab.save()` does not write that key). `BAUD_RATES` is
   what a 16 MHz AVR can generate inside 8N1's ±2% tolerance — **not** the
-  Arduino IDE's ladder, so don't re-add 230400. The Serial tab shows baud in
-  its Connection panel as well, and the two are kept from disagreeing at both
-  ends: `_sync_baud` re-reads the setting on `serial/state`, and the
-  `on_baud_changed` callback tells the host to refresh after a pick here. The
-  one host-specific option left is `detach_command` (the tab's
-  "Open monitor ↗", on the control row rather than a row of its own).
-  Text tags bake their colours in and
-  `retheme_widgets` can't reach them, so `set_theme` calls `apply_palette()`
-  on every live console.
+  Arduino IDE's ladder, so don't re-add 230400. Two consoles can still be
+  live at once (the tab's and an open window's), so `_sync_baud` re-reads the
+  setting on `serial/state` and they can't drift apart; `on_baud_changed`
+  tells a host that wants to react (the window repaints its header). The one
+  host-specific option is `detach_command` (the tab's "Open monitor ↗", on
+  the control row rather than a row of its own). Text tags bake their colours
+  in and `retheme_widgets` can't reach them, so `set_theme` calls
+  `apply_palette()` on every live console.
 - **`serial_monitor.py`** — `SerialMonitorWindow`: a `SerialConsole` in its own
   window, under a connection header (port, baud, firmware behind a dot
   mirroring the status bar's — it subscribes `serial/state` for that). Opened

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -519,7 +519,7 @@ modal), and never gate on `is_available()`.
 | **Train** | `tab_train.py` | Feed→capture→classify→label→save loop; "Sort While Training"; launches training (Install-PyTorch dialog if needed → progress dialog). |
 | **AI Config** | `tab_ai.py` | HTTP server config (endpoint/key/model/prompt/encoding), headstamp manager, single-shot test. Visible only in AI Config mode. |
 | **Camera** | `tab_camera.py` | Device + resolution detection and live preview. |
-| **Serial** | `tab_serial.py` | Connection, 14 board init settings, sort-arm test, airdrop config, in-tab traffic log + "Open monitor ↗" (see `serial_monitor.py`). |
+| **Serial** | `tab_serial.py` | Connection, 14 board init settings, sort-arm test, airdrop config, and a `SerialConsole` + "Open monitor ↗" (see `serial_console.py`). |
 | **Image Proc** | `tab_imageproc.py` | Tune Hough params + primer mask + LED brightness against a captured frame (before/after preview). |
 | **Community** | `tab_community.py` | Browse/search/download community models; share entry point. Auth-gated. |
 
@@ -603,13 +603,14 @@ a separate one, so a built-in is never the thing being written to),
   `NumericField`, labeled-entry/button-row helpers.
 - **`monitor.py`** — detachable history window: ring buffer of recent
   classifications with a color "snake" trailing the latest. Subscribes `run/history`.
-- **`serial_monitor.py`** — detachable Arduino-IDE-style serial monitor,
-  opened by clicking the status bar's `● Serial: …` indicator (or the Serial
-  tab's button); `app.open_serial_monitor()` keeps it to one instance.
+- **`serial_console.py`** — `SerialConsole`, the Arduino-IDE-style traffic log.
+  **The Serial Config tab's "Serial monitor / debug" panel and the detached
+  monitor window are the same widget**, embedded twice, so neither can grow a
+  feature the other lacks — which is exactly how they had already drifted (the
+  tab log was one colour, uncoloured, unfilterable and capped at 500 lines).
   Autoscroll / timestamps / pause (held lines flush on resume, they are not
   dropped), Clear, Save…, a line-ending selector that sends through
-  `broker.send_raw`, command history, and a baud picker that persists to
-  `config.serial["baud"]` and reconnects. A case-insensitive substring filter
+  `broker.send_raw`, and command history. A case-insensitive substring filter
   and per-direction (RX/TX/notes) toggles narrow the view: `matches()` is the
   single predicate, applied by `_render` as lines arrive, by `_rerender` when
   the filter changes, and by `dump()` so Save… writes what's on screen. It
@@ -618,13 +619,22 @@ a separate one, so a built-in is never the thing being written to),
   everything — the filter hides, never deletes. **The log is never re-ordered**
   (no column sort): serial traffic only reads correctly in the order it
   happened, since a command and its reply are one exchange. Subscribes
-  `serial/rx`, `serial/tx`,
-  `serial/note` (probe commentary) and `serial/state` (indicator mirror).
-  **On open it replays `MainWindow.serial_backlog`** — the rolling deque the
-  bus subscriptions fill — because the traffic worth reading (a failed
-  auto-connect probe) happens seconds before anyone can click. Text tags bake
-  their colours in and `retheme_widgets` can't reach them, so `set_theme`
-  calls the window's `apply_palette()`.
+  `serial/rx`, `serial/tx` and `serial/note` (probe commentary) itself, and
+  **replays `MainWindow.serial_backlog`** on construction — the rolling deque
+  `app._log_serial` fills — because the traffic worth reading (a failed
+  auto-connect probe) happens seconds before anyone can open a window. Two
+  constructor options mark what differs between the two hosts: `show_baud`
+  (the window's speed picker, which persists to `config.serial["baud"]` and
+  reconnects — the tab's Connection panel already owns that setting) and
+  `detach_command` (the tab's "Open monitor ↗", on the control row rather
+  than a row of its own). Text tags bake their colours in and
+  `retheme_widgets` can't reach them, so `set_theme` calls `apply_palette()`
+  on every live console.
+- **`serial_monitor.py`** — `SerialMonitorWindow`: a `SerialConsole` in its own
+  window, under a connection header (port, baud, firmware behind a dot
+  mirroring the status bar's — it subscribes `serial/state` for that). Opened
+  by clicking the status bar's `● Serial: …` indicator or the Serial tab's
+  button; `app.open_serial_monitor()` keeps it to one instance.
 - **`torch_gate.py`** — `ensure_torch(parent, proceed, reason=…)`: the only
   sanctioned way to front a local-model action with the PyTorch install dialog.
   See *The PyTorch install gate* above.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -625,7 +625,9 @@ a separate one, so a built-in is never the thing being written to),
   auto-connect probe) happens seconds before anyone can open a window. Two
   constructor options mark what differs between the two hosts: `show_baud`
   (the window's speed picker, which persists to `config.serial["baud"]` and
-  reconnects — the tab's Connection panel already owns that setting) and
+  reconnects — the tab's Connection panel already owns that setting;
+  `BAUD_RATES` is what a 16 MHz AVR can generate inside 8N1's ±2% tolerance,
+  **not** the Arduino IDE's ladder, so don't re-add 230400) and
   `detach_command` (the tab's "Open monitor ↗", on the control row rather
   than a row of its own). Text tags bake their colours in and
   `retheme_widgets` can't reach them, so `set_theme` calls `apply_palette()`

--- a/src/sorter/ui/app.py
+++ b/src/sorter/ui/app.py
@@ -760,12 +760,14 @@ class MainWindow:
         self._repaint_header()
         self._layout_page(force=True)
         self._refresh_status_indicators()
-        # Text tags aren't in retheme_widgets' reach; the monitor repaints its own.
-        window = self._serial_monitor
-        if window is not None:
+        # Text tags aren't in retheme_widgets' reach, so every serial console
+        # repaints its own — the Serial tab's, and the monitor window's if open.
+        for widget in (getattr(self.serial_tab, "console", None), self._serial_monitor):
+            if widget is None:
+                continue
             try:
-                if window.winfo_exists():
-                    window.apply_palette()
+                if widget.winfo_exists():
+                    widget.apply_palette()
             except tk.TclError:
                 pass
         self._save_setting(SETTING_THEME, resolved)
@@ -1053,16 +1055,15 @@ class MainWindow:
     # ----- lifecycle ----------------------------------------------------------
 
     def run(self) -> None:
-        # Wire serial-log topics to the Serial tab now that the bus is alive.
-        self.bus.subscribe("serial/rx", lambda line: self._log_serial("rx", f"<- {line}", line))
-        self.bus.subscribe("serial/tx", lambda line: self._log_serial("tx", f"-> {line}", line))
-        self.bus.subscribe("serial/note", lambda line: self._log_serial("note", f"-- {line}", line))
+        # Fill the replay backlog now that the bus is alive. Displaying the
+        # traffic is each SerialConsole's own subscription, not this.
+        for kind in ("rx", "tx", "note"):
+            self.bus.subscribe(f"serial/{kind}", lambda line, kind=kind: self._log_serial(kind, line))
         self.root.mainloop()
 
-    def _log_serial(self, kind: str, tab_line: str, line: str) -> None:
-        """Fan one serial line out to the in-tab log and the replay backlog."""
+    def _log_serial(self, kind: str, line: str) -> None:
+        """Keep one serial line for a monitor window opened later."""
         self.serial_backlog.append((kind, time.time(), str(line)))
-        self.serial_tab.append_log(tab_line)
 
     def _on_close(self) -> None:
         try:

--- a/src/sorter/ui/serial_console.py
+++ b/src/sorter/ui/serial_console.py
@@ -28,9 +28,10 @@ from typing import Any
 
 from .theme import PALETTE, get_fonts
 
-# The Arduino IDE's ladder, and its default.
-BAUD_RATES = (300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 250000)
-DEFAULT_BAUD = 9600
+# What a 16 MHz AVR's U2X divisor can actually hit inside 8N1's ±2% tolerance:
+# 230400 misses by -3.55%, and 250000 (16 MHz / 64) is exact despite looking odd.
+BAUD_RATES = (9600, 19200, 38400, 57600, 115200, 250000)
+DEFAULT_BAUD = 9600  # the rate the firmware's Serial.begin() runs at
 
 # Label → what actually goes on the wire after the typed text.
 LINE_ENDINGS: dict[str, str] = {

--- a/src/sorter/ui/serial_console.py
+++ b/src/sorter/ui/serial_console.py
@@ -1,0 +1,477 @@
+"""The serial console — one widget, used both in the tab and in the monitor.
+
+The Serial Config tab's "Serial monitor / debug" panel and the detachable
+`SerialMonitorWindow` are the same tool reached two ways, so they are the same
+widget: everything below the connection header lives here, and both callers
+embed it. Anything added to one is therefore in the other by construction —
+the two had already drifted (the tab had no timestamps, no filter, no colours
+and its own 500-line cap) once the monitor arrived.
+
+Everything arrives over the EventBus (`serial/rx`, `serial/tx`, `serial/note`)
+and is therefore delivered on the Tk main thread — nothing here may be called
+from the reader thread. See CLAUDE.md §3.
+
+The log is deliberately never re-ordered. Serial traffic only means anything
+in the order it happened — a command and the reply it drew are one exchange —
+so the way to narrow it down is the filter box and the direction toggles,
+which hide lines without moving the ones that remain.
+"""
+
+from __future__ import annotations
+
+import time
+import tkinter as tk
+from collections import deque
+from collections.abc import Callable
+from tkinter import filedialog, ttk
+from typing import Any
+
+from .theme import PALETTE, get_fonts
+
+# The Arduino IDE's ladder, and its default.
+BAUD_RATES = (300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 250000)
+DEFAULT_BAUD = 9600
+
+# Label → what actually goes on the wire after the typed text.
+LINE_ENDINGS: dict[str, str] = {
+    "No line ending": "",
+    "New Line": "\n",
+    "Carriage Return": "\r",
+    "Both NL & CR": "\r\n",
+}
+DEFAULT_LINE_ENDING = "New Line"
+
+MAX_LINES = 4000  # scrollback cap; the oldest are dropped, not the newest
+MAX_HISTORY = 100
+# Typing in the filter box re-renders the whole scrollback, so coalesce
+# keystrokes instead of doing it per character.
+FILTER_DEBOUNCE_MS = 120
+
+# Line kinds → the palette role they print in and the prefix they carry.
+KIND_ROLE = {"rx": "text", "tx": "update", "note": "text_muted"}
+KIND_PREFIX = {"rx": "<- ", "tx": "-> ", "note": "-- "}
+
+
+class SerialConsole(ttk.Frame):
+    """Live serial traffic: filtered, timestamped, pausable, saveable.
+
+    `show_baud` adds the Arduino-style speed selector, which only the detached
+    window carries — the tab's Connection panel already owns baud, and two
+    controls writing one setting is how they disagree.
+    `detach_command`, where given, puts the "open the window" button on the
+    control row rather than costing the tab another row of height.
+    """
+
+    def __init__(
+        self,
+        parent: tk.Misc,
+        *,
+        app: Any,
+        height: int = 12,
+        show_baud: bool = False,
+        detach_command: Callable[[], None] | None = None,
+        on_baud_changed: Callable[[], None] | None = None,
+    ) -> None:
+        super().__init__(parent)
+        self.app = app
+        self.bus = app.bus
+        self._on_baud_changed = on_baud_changed
+        self._closed = False
+
+        self._fonts = getattr(app, "fonts", None) or get_fonts(self)
+        # (kind, epoch seconds, text) — the rendered scrollback, kept so a
+        # timestamp toggle can re-render and Save… can dump exactly what's on
+        # screen.
+        self._lines: deque[tuple[str, float, str]] = deque(maxlen=MAX_LINES)
+        self._held: deque[tuple[str, float, str]] = deque(maxlen=MAX_LINES)
+        self._history: list[str] = []
+        self._history_pos = 0
+        self._filter_job: str | None = None
+
+        self._build_controls(detach_command)
+        self._build_filter_row()
+        # The send row is packed against the bottom before the output claims
+        # the rest, or a window smaller than the Text's natural size clips it.
+        self._build_send_row(show_baud)
+        self._build_output(height)
+
+        self.bus.subscribe("serial/rx", self._on_rx)
+        self.bus.subscribe("serial/tx", self._on_tx)
+        self.bus.subscribe("serial/note", self._on_note)
+
+        self._replay_backlog()
+
+    # ----- construction -------------------------------------------------------
+
+    def _build_controls(self, detach_command: Callable[[], None] | None) -> None:
+        controls = ttk.Frame(self)
+        controls.pack(side=tk.TOP, fill=tk.X, pady=(0, 4))
+        self.autoscroll_var = tk.BooleanVar(value=True)
+        self.timestamps_var = tk.BooleanVar(value=False)
+        self.paused_var = tk.BooleanVar(value=False)
+        ttk.Checkbutton(controls, text="Autoscroll", variable=self.autoscroll_var).pack(side=tk.LEFT)
+        ttk.Checkbutton(
+            controls,
+            text="Timestamps",
+            variable=self.timestamps_var,
+            command=self._rerender,
+        ).pack(side=tk.LEFT, padx=(12, 0))
+        ttk.Checkbutton(
+            controls,
+            text="Pause",
+            variable=self.paused_var,
+            command=self._on_pause_toggled,
+        ).pack(side=tk.LEFT, padx=(12, 0))
+        if detach_command is not None:
+            ttk.Button(controls, text="Open monitor ↗", command=detach_command).pack(side=tk.RIGHT, padx=(12, 0))
+        ttk.Button(controls, text="Save…", command=self.save_to_file).pack(side=tk.RIGHT)
+        ttk.Button(controls, text="Clear", command=self.clear).pack(side=tk.RIGHT, padx=(0, 6))
+
+    def _build_filter_row(self) -> None:
+        """Substring filter + per-direction toggles, over the whole scrollback.
+
+        Filtering is a view, not a deletion: `_lines` keeps everything, so
+        clearing the box brings the hidden traffic straight back.
+        """
+        row = ttk.Frame(self)
+        row.pack(side=tk.TOP, fill=tk.X, pady=(0, 4))
+
+        ttk.Label(row, text="Filter").pack(side=tk.LEFT, padx=(0, 6))
+        self.filter_var = tk.StringVar()
+        self.filter_var.trace_add("write", lambda *_a: self._schedule_rerender())
+        entry = ttk.Entry(row, textvariable=self.filter_var, width=10)
+        entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        entry.bind("<Escape>", lambda _e: self.clear_filter())
+        ttk.Button(row, text="✕", width=3, command=self.clear_filter).pack(side=tk.LEFT, padx=(4, 0))
+
+        self.show_kind_vars: dict[str, tk.BooleanVar] = {}
+        for kind, label in (("rx", "RX"), ("tx", "TX"), ("note", "Notes")):
+            var = tk.BooleanVar(value=True)
+            self.show_kind_vars[kind] = var
+            ttk.Checkbutton(row, text=label, variable=var, command=self._rerender).pack(side=tk.LEFT, padx=(12, 0))
+
+        self._count_var = tk.StringVar(value="0 lines")
+        ttk.Label(row, textvariable=self._count_var, style="Muted.TLabel").pack(side=tk.LEFT, padx=(16, 0))
+
+    def _build_output(self, height: int) -> None:
+        box = ttk.Frame(self)
+        box.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
+        self.text = tk.Text(
+            box,
+            height=height,
+            wrap=tk.NONE,
+            state=tk.DISABLED,
+            font=self._fonts["mono"],
+            background=PALETTE["bg_input"],
+            foreground=PALETTE["text"],
+        )
+        scroll = ttk.Scrollbar(box, orient=tk.VERTICAL, command=self.text.yview)
+        self.text.configure(yscrollcommand=scroll.set)
+        scroll.pack(side=tk.RIGHT, fill=tk.Y)
+        self.text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
+        for kind, role in KIND_ROLE.items():
+            self.text.tag_configure(kind, foreground=PALETTE[role])
+        self.text.tag_configure("stamp", foreground=PALETTE["text_subtle"])
+
+    def _build_send_row(self, show_baud: bool) -> None:
+        row = ttk.Frame(self)
+        row.pack(side=tk.BOTTOM, fill=tk.X, pady=(6, 0))
+
+        # Right-hand controls claim their width first; the entry then absorbs
+        # whatever is left, so nothing falls off the edge on a narrow window.
+        self.baud_var = tk.StringVar(value=str(self.configured_baud()))
+        if show_baud:
+            baud = ttk.Combobox(
+                row,
+                textvariable=self.baud_var,
+                values=[str(b) for b in BAUD_RATES],
+                state="readonly",
+                width=8,
+            )
+            baud.pack(side=tk.RIGHT)
+            baud.bind("<<ComboboxSelected>>", self._on_baud_selected)
+            ttk.Label(row, text="Baud").pack(side=tk.RIGHT, padx=(16, 4))
+
+        ttk.Button(row, text="Send", style="Accent.TButton", command=self.send_command).pack(side=tk.RIGHT)
+        self.ending_var = tk.StringVar(value=DEFAULT_LINE_ENDING)
+        ttk.Combobox(
+            row,
+            textvariable=self.ending_var,
+            values=list(LINE_ENDINGS),
+            state="readonly",
+            width=15,
+        ).pack(side=tk.RIGHT, padx=6)
+
+        self.entry_var = tk.StringVar()
+        # A small request, not a small field: the entry takes the row's slack.
+        entry = ttk.Entry(row, textvariable=self.entry_var, width=10)
+        entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
+        entry.bind("<Return>", lambda _e: self.send_command())
+        entry.bind("<Up>", lambda _e: self._history_step(-1))
+        entry.bind("<Down>", lambda _e: self._history_step(1))
+        self.entry = entry
+
+    def apply_palette(self) -> None:
+        """Re-read the palette after a theme switch.
+
+        `retheme_widgets` translates the colours baked into widgets, but not
+        the ones baked into Text *tags* — those are ours to refresh.
+        """
+        self.text.configure(background=PALETTE["bg_input"], foreground=PALETTE["text"])
+        for kind, role in KIND_ROLE.items():
+            self.text.tag_configure(kind, foreground=PALETTE[role])
+        self.text.tag_configure("stamp", foreground=PALETTE["text_subtle"])
+
+    # ----- connection state ---------------------------------------------------
+
+    def configured_baud(self) -> int:
+        try:
+            return int(self.app.config.serial.get("baud", DEFAULT_BAUD))
+        except (AttributeError, TypeError, ValueError):
+            return DEFAULT_BAUD
+
+    def current_port(self) -> str:
+        broker = getattr(self.app, "broker", None)
+        port = getattr(broker, "port", "") if broker is not None else ""
+        if port:
+            return str(port)
+        try:
+            return str(self.app.config.serial.get("port", "") or "")
+        except AttributeError:
+            return ""
+
+    def _on_baud_selected(self, _event: Any = None) -> None:
+        """Persist the new speed and re-open the port at it, IDE-style."""
+        try:
+            baud = int(self.baud_var.get())
+        except (TypeError, ValueError):
+            return
+        if baud == self.configured_baud() and getattr(getattr(self.app, "broker", None), "baud", None) == baud:
+            return
+        try:
+            self.app.config.serial["baud"] = baud
+            self.app.config.save()
+        except Exception as exc:
+            self.note(f"could not save baud: {exc}")
+        port = self.current_port()
+        self.note(f"baud set to {baud}")
+        if port:
+            self.app.connect_serial(port=port)
+        if self._on_baud_changed is not None:
+            self._on_baud_changed()
+
+    # ----- inbound ------------------------------------------------------------
+
+    def _on_rx(self, line: Any) -> None:
+        self.append("rx", str(line))
+
+    def _on_tx(self, line: Any) -> None:
+        self.append("tx", str(line))
+
+    def _on_note(self, line: Any) -> None:
+        self.append("note", str(line))
+
+    def note(self, line: str) -> None:
+        """Record a console-local remark (not board traffic)."""
+        self.append("note", line)
+
+    def append(self, kind: str, line: str, *, stamp: float | None = None) -> None:
+        record = (kind, time.time() if stamp is None else stamp, line)
+        if self.paused_var.get():
+            self._held.append(record)
+            return
+        self._lines.append(record)
+        self._render(record)
+        self._update_count()
+
+    def _on_pause_toggled(self) -> None:
+        if self.paused_var.get():
+            return
+        held, self._held = list(self._held), deque(maxlen=MAX_LINES)
+        for record in held:
+            self._lines.append(record)
+            self._render(record)
+        self._update_count()
+
+    def _replay_backlog(self) -> None:
+        """Show what the app captured before this console existed.
+
+        Empty for the tab's console, which is built before the first probe;
+        it is the window opened after a failed auto-connect that needs it.
+        """
+        backlog = list(getattr(self.app, "serial_backlog", ()))
+        if not backlog:
+            return
+        for kind, stamp, line in backlog:
+            self._lines.append((kind, stamp, line))
+        self._rerender()
+        self._lines.append(("note", time.time(), f"end of replay ({len(backlog)} earlier line(s))"))
+        self._render(self._lines[-1])
+        self._update_count()
+
+    # ----- filtering ----------------------------------------------------------
+
+    def clear_filter(self) -> None:
+        self.filter_var.set("")
+
+    def _schedule_rerender(self) -> None:
+        if self._filter_job is not None:
+            self.after_cancel(self._filter_job)
+        self._filter_job = self.after(FILTER_DEBOUNCE_MS, self._run_scheduled_rerender)
+
+    def _run_scheduled_rerender(self) -> None:
+        self._filter_job = None
+        self._rerender()
+
+    def matches(self, record: tuple[str, float, str]) -> bool:
+        """Does this line survive the direction toggles and the filter box?
+
+        Case-insensitive substring, matched against the text as the board sent
+        it — not the rendered line, so a filter can't accidentally key off the
+        `<-`/`->` prefix or a timestamp that is only sometimes shown.
+        """
+        kind, _stamp, line = record
+        var = self.show_kind_vars.get(kind)
+        if var is not None and not var.get():
+            return False
+        needle = self.filter_var.get().strip().lower()
+        return not needle or needle in line.lower()
+
+    def _shown_line_count(self) -> int:
+        """How many lines the widget is actually displaying.
+
+        Every rendered record ends in a newline, so the insertion point sits at
+        the start of an empty trailing line that isn't output — hence the -1.
+        """
+        return max(0, int(self.text.index("end-1c").split(".")[0]) - 1)
+
+    def _update_count(self) -> None:
+        total = len(self._lines)
+        shown = self._shown_line_count()
+        self._count_var.set(f"{total} lines" if shown == total else f"{shown} of {total} lines")
+
+    # ----- rendering ----------------------------------------------------------
+
+    def _render(self, record: tuple[str, float, str]) -> None:
+        kind, stamp, line = record
+        if not self.matches(record):
+            return
+        self.text.configure(state=tk.NORMAL)
+        if self.timestamps_var.get():
+            self.text.insert(tk.END, f"{time.strftime('%H:%M:%S', time.localtime(stamp))} ", ("stamp",))
+        self.text.insert(tk.END, f"{KIND_PREFIX.get(kind, '')}{line}\n", (kind,))
+        self._trim()
+        if self.autoscroll_var.get():
+            self.text.see(tk.END)
+        self.text.configure(state=tk.DISABLED)
+
+    def _rerender(self) -> None:
+        self.text.configure(state=tk.NORMAL)
+        self.text.delete("1.0", tk.END)
+        self.text.configure(state=tk.DISABLED)
+        for record in list(self._lines):
+            self._render(record)
+        self._update_count()
+
+    def _trim(self) -> None:
+        """Keep the widget's line count in step with the deque's cap."""
+        shown = self._shown_line_count()
+        if shown > MAX_LINES:
+            self.text.delete("1.0", f"{shown - MAX_LINES + 1}.0")
+
+    def clear(self) -> None:
+        self._lines.clear()
+        self.text.configure(state=tk.NORMAL)
+        self.text.delete("1.0", tk.END)
+        self.text.configure(state=tk.DISABLED)
+        self._update_count()
+
+    def dump(self) -> str:
+        """The scrollback as plain text — what's on screen, filter included."""
+        stamps = self.timestamps_var.get()
+        out = []
+        for record in self._lines:
+            if not self.matches(record):
+                continue
+            kind, stamp, line = record
+            prefix = f"{time.strftime('%H:%M:%S', time.localtime(stamp))} " if stamps else ""
+            out.append(f"{prefix}{KIND_PREFIX.get(kind, '')}{line}")
+        return "\n".join(out) + ("\n" if out else "")
+
+    def save_to_file(self) -> None:
+        path = filedialog.asksaveasfilename(
+            parent=self,
+            title="Save serial log",
+            defaultextension=".txt",
+            filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
+        )
+        if not path:
+            return
+        try:
+            with open(path, "w", encoding="utf-8") as handle:
+                handle.write(self.dump())
+        except OSError as exc:
+            self.note(f"save failed: {exc}")
+            return
+        self.note(f"saved to {path}")
+
+    # ----- outbound -----------------------------------------------------------
+
+    def send_command(self) -> None:
+        text = self.entry_var.get()
+        if not text:
+            return
+        broker = getattr(self.app, "broker", None)
+        if broker is None or not getattr(broker, "is_connected", False):
+            self.note("not connected — nothing sent")
+            return
+        # The broker echoes the write through on_sent → serial/tx, so the line
+        # lands in the log the same way an auto-connect probe's does.
+        broker.send_raw(text + LINE_ENDINGS.get(self.ending_var.get(), "\n"))
+        if not self._history or self._history[-1] != text:
+            self._history.append(text)
+            del self._history[:-MAX_HISTORY]
+        self._history_pos = len(self._history)
+        self.entry_var.set("")
+
+    def _history_step(self, delta: int) -> str:
+        """Walk the command history; past the newest entry the field clears."""
+        if not self._history:
+            return "break"
+        self._history_pos = max(0, min(len(self._history), self._history_pos + delta))
+        value = "" if self._history_pos >= len(self._history) else self._history[self._history_pos]
+        self.entry_var.set(value)
+        self.entry.icursor(tk.END)
+        return "break"
+
+    # ----- lifecycle ----------------------------------------------------------
+
+    def close(self) -> None:
+        """Unsubscribe and cancel pending work. Idempotent.
+
+        Destroying a parent doesn't call an embedded widget's Python
+        `destroy()`, so the window calls this itself before tearing down.
+        """
+        if self._closed:
+            return
+        self._closed = True
+        # A debounced re-render still in flight would fire against a dead widget.
+        if self._filter_job is not None:
+            try:
+                self.after_cancel(self._filter_job)
+            except tk.TclError:
+                pass
+            self._filter_job = None
+        for topic, handler in (
+            ("serial/rx", self._on_rx),
+            ("serial/tx", self._on_tx),
+            ("serial/note", self._on_note),
+        ):
+            try:
+                self.bus.unsubscribe(topic, handler)
+            except Exception:
+                pass
+
+    def destroy(self) -> None:
+        self.close()
+        super().destroy()

--- a/src/sorter/ui/serial_console.py
+++ b/src/sorter/ui/serial_console.py
@@ -56,11 +56,14 @@ KIND_PREFIX = {"rx": "<- ", "tx": "-> ", "note": "-- "}
 class SerialConsole(ttk.Frame):
     """Live serial traffic: filtered, timestamped, pausable, saveable.
 
-    `show_baud` adds the Arduino-style speed selector, which only the detached
-    window carries — the tab's Connection panel already owns baud, and two
-    controls writing one setting is how they disagree.
+    Self-contained: the speed selector is part of the component, not something
+    a host bolts on, so embedding it anywhere gives a console that can talk to
+    the board on its own terms. A host that shows baud elsewhere too keeps the
+    two in step — `on_baud_changed` fires after a pick here, and a `serial/state`
+    from anyone else re-reads the setting (see `_sync_baud`).
+
     `detach_command`, where given, puts the "open the window" button on the
-    control row rather than costing the tab another row of height.
+    control row rather than costing the host another row of height.
     """
 
     def __init__(
@@ -69,7 +72,6 @@ class SerialConsole(ttk.Frame):
         *,
         app: Any,
         height: int = 12,
-        show_baud: bool = False,
         detach_command: Callable[[], None] | None = None,
         on_baud_changed: Callable[[], None] | None = None,
     ) -> None:
@@ -93,12 +95,13 @@ class SerialConsole(ttk.Frame):
         self._build_filter_row()
         # The send row is packed against the bottom before the output claims
         # the rest, or a window smaller than the Text's natural size clips it.
-        self._build_send_row(show_baud)
+        self._build_send_row()
         self._build_output(height)
 
         self.bus.subscribe("serial/rx", self._on_rx)
         self.bus.subscribe("serial/tx", self._on_tx)
         self.bus.subscribe("serial/note", self._on_note)
+        self.bus.subscribe("serial/state", self._sync_baud)
 
         self._replay_backlog()
 
@@ -174,24 +177,23 @@ class SerialConsole(ttk.Frame):
             self.text.tag_configure(kind, foreground=PALETTE[role])
         self.text.tag_configure("stamp", foreground=PALETTE["text_subtle"])
 
-    def _build_send_row(self, show_baud: bool) -> None:
+    def _build_send_row(self) -> None:
         row = ttk.Frame(self)
         row.pack(side=tk.BOTTOM, fill=tk.X, pady=(6, 0))
 
         # Right-hand controls claim their width first; the entry then absorbs
         # whatever is left, so nothing falls off the edge on a narrow window.
         self.baud_var = tk.StringVar(value=str(self.configured_baud()))
-        if show_baud:
-            baud = ttk.Combobox(
-                row,
-                textvariable=self.baud_var,
-                values=[str(b) for b in BAUD_RATES],
-                state="readonly",
-                width=8,
-            )
-            baud.pack(side=tk.RIGHT)
-            baud.bind("<<ComboboxSelected>>", self._on_baud_selected)
-            ttk.Label(row, text="Baud").pack(side=tk.RIGHT, padx=(16, 4))
+        baud = ttk.Combobox(
+            row,
+            textvariable=self.baud_var,
+            values=[str(b) for b in BAUD_RATES],
+            state="readonly",
+            width=8,
+        )
+        baud.pack(side=tk.RIGHT)
+        baud.bind("<<ComboboxSelected>>", self._on_baud_selected)
+        ttk.Label(row, text="Baud").pack(side=tk.RIGHT, padx=(16, 4))
 
         ttk.Button(row, text="Send", style="Accent.TButton", command=self.send_command).pack(side=tk.RIGHT)
         self.ending_var = tk.StringVar(value=DEFAULT_LINE_ENDING)
@@ -260,6 +262,15 @@ class SerialConsole(ttk.Frame):
             self.app.connect_serial(port=port)
         if self._on_baud_changed is not None:
             self._on_baud_changed()
+
+    def _sync_baud(self, _payload: Any = None) -> None:
+        """Follow a speed set somewhere else (the Serial tab, a reconnect).
+
+        Two controls for one setting only disagree if neither re-reads it.
+        """
+        current = str(self.configured_baud())
+        if self.baud_var.get() != current:
+            self.baud_var.set(current)
 
     # ----- inbound ------------------------------------------------------------
 
@@ -467,6 +478,7 @@ class SerialConsole(ttk.Frame):
             ("serial/rx", self._on_rx),
             ("serial/tx", self._on_tx),
             ("serial/note", self._on_note),
+            ("serial/state", self._sync_baud),
         ):
             try:
                 self.bus.unsubscribe(topic, handler)

--- a/src/sorter/ui/serial_monitor.py
+++ b/src/sorter/ui/serial_monitor.py
@@ -40,7 +40,6 @@ class SerialMonitorWindow(tk.Toplevel):
         self.console = SerialConsole(
             self,
             app=app,
-            show_baud=True,
             on_baud_changed=self.refresh_connection,
         )
         self.console.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=10, pady=(6, 10))

--- a/src/sorter/ui/serial_monitor.py
+++ b/src/sorter/ui/serial_monitor.py
@@ -5,52 +5,24 @@ so it is reachable exactly when the connection is the thing that's broken. It
 replays the app's rolling backlog on open, which is what makes a failed
 auto-connect diagnosable after the fact.
 
-Everything arrives over the EventBus (`serial/rx`, `serial/tx`, `serial/note`)
-and is therefore delivered on the Tk main thread — nothing here may be called
-from the reader thread. See CLAUDE.md §3.
-
-The log is deliberately never re-ordered. Serial traffic only means anything
-in the order it happened — a command and the reply it drew are one exchange —
-so the way to narrow it down is the filter box and the direction toggles,
-which hide lines without moving the ones that remain.
+The log, the filter and the send row are `SerialConsole` — the same widget the
+Serial Config tab embeds (see that module). What lives here is only what a
+detached window adds: a connection header, the baud selector, and the
+single-instance lifecycle.
 """
 
 from __future__ import annotations
 
-import time
 import tkinter as tk
-from collections import deque
-from tkinter import filedialog, ttk
+from tkinter import ttk
 from typing import Any
 
+from .serial_console import SerialConsole
 from .theme import PALETTE, get_fonts
-
-# The Arduino IDE's ladder, and its default.
-BAUD_RATES = (300, 1200, 2400, 4800, 9600, 19200, 38400, 57600, 74880, 115200, 230400, 250000)
-DEFAULT_BAUD = 9600
-
-# Label → what actually goes on the wire after the typed text.
-LINE_ENDINGS: dict[str, str] = {
-    "No line ending": "",
-    "New Line": "\n",
-    "Carriage Return": "\r",
-    "Both NL & CR": "\r\n",
-}
-DEFAULT_LINE_ENDING = "New Line"
-
-MAX_LINES = 4000  # scrollback cap; the oldest are dropped, not the newest
-MAX_HISTORY = 100
-# Typing in the filter box re-renders the whole scrollback, so coalesce
-# keystrokes instead of doing it per character.
-FILTER_DEBOUNCE_MS = 120
-
-# Line kinds → the palette role they print in and the prefix they carry.
-KIND_ROLE = {"rx": "text", "tx": "update", "note": "text_muted"}
-KIND_PREFIX = {"rx": "<- ", "tx": "-> ", "note": "-- "}
 
 
 class SerialMonitorWindow(tk.Toplevel):
-    """Live serial traffic: filtered, timestamped, pausable, saveable."""
+    """A `SerialConsole` in its own window, under a live connection header."""
 
     def __init__(self, parent: tk.Misc, *, app: Any) -> None:
         super().__init__(parent)
@@ -63,35 +35,25 @@ class SerialMonitorWindow(tk.Toplevel):
         self.configure(bg=PALETTE["bg_window"])
 
         self._fonts = getattr(app, "fonts", None) or get_fonts(self)
-        # (kind, epoch seconds, text) — the rendered scrollback, kept so a
-        # timestamp toggle can re-render and Save… can dump exactly what's on
-        # screen.
-        self._lines: deque[tuple[str, float, str]] = deque(maxlen=MAX_LINES)
-        self._held: deque[tuple[str, float, str]] = deque(maxlen=MAX_LINES)
-        self._history: list[str] = []
-        self._history_pos = 0
-        self._filter_job: str | None = None
 
         self._build_header()
-        self._build_filter_row()
-        # The send row is packed against the bottom before the output claims
-        # the rest, or a window smaller than the Text's natural size clips it.
-        self._build_send_row()
-        self._build_output()
+        self.console = SerialConsole(
+            self,
+            app=app,
+            show_baud=True,
+            on_baud_changed=self.refresh_connection,
+        )
+        self.console.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=10, pady=(6, 10))
 
-        self.bus.subscribe("serial/rx", self._on_rx)
-        self.bus.subscribe("serial/tx", self._on_tx)
-        self.bus.subscribe("serial/note", self._on_note)
         self.bus.subscribe("serial/state", self._on_state)
         self.protocol("WM_DELETE_WINDOW", self.close)
 
-        self._replay_backlog()
         self.refresh_connection()
 
     # ----- construction -------------------------------------------------------
 
     def _build_header(self) -> None:
-        header = ttk.Frame(self, padding=(10, 8))
+        header = ttk.Frame(self, padding=(10, 8, 10, 0))
         header.pack(side=tk.TOP, fill=tk.X)
 
         self._dot = tk.Label(
@@ -105,147 +67,20 @@ class SerialMonitorWindow(tk.Toplevel):
         self._header_var = tk.StringVar(value="disconnected")
         ttk.Label(header, textvariable=self._header_var).pack(side=tk.LEFT)
 
-        controls = ttk.Frame(self, padding=(10, 0))
-        controls.pack(side=tk.TOP, fill=tk.X)
-        self.autoscroll_var = tk.BooleanVar(value=True)
-        self.timestamps_var = tk.BooleanVar(value=False)
-        self.paused_var = tk.BooleanVar(value=False)
-        ttk.Checkbutton(controls, text="Autoscroll", variable=self.autoscroll_var).pack(side=tk.LEFT)
-        ttk.Checkbutton(
-            controls,
-            text="Timestamps",
-            variable=self.timestamps_var,
-            command=self._rerender,
-        ).pack(side=tk.LEFT, padx=(12, 0))
-        ttk.Checkbutton(
-            controls,
-            text="Pause",
-            variable=self.paused_var,
-            command=self._on_pause_toggled,
-        ).pack(side=tk.LEFT, padx=(12, 0))
-        ttk.Button(controls, text="Save…", command=self.save_to_file).pack(side=tk.RIGHT)
-        ttk.Button(controls, text="Clear", command=self.clear).pack(side=tk.RIGHT, padx=(0, 6))
-
-    def _build_filter_row(self) -> None:
-        """Substring filter + per-direction toggles, over the whole scrollback.
-
-        Filtering is a view, not a deletion: `_lines` keeps everything, so
-        clearing the box brings the hidden traffic straight back.
-        """
-        row = ttk.Frame(self, padding=(10, 6, 10, 0))
-        row.pack(side=tk.TOP, fill=tk.X)
-
-        ttk.Label(row, text="Filter").pack(side=tk.LEFT, padx=(0, 6))
-        self.filter_var = tk.StringVar()
-        self.filter_var.trace_add("write", lambda *_a: self._schedule_rerender())
-        entry = ttk.Entry(row, textvariable=self.filter_var, width=10)
-        entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
-        entry.bind("<Escape>", lambda _e: self.clear_filter())
-        ttk.Button(row, text="✕", width=3, command=self.clear_filter).pack(side=tk.LEFT, padx=(4, 0))
-
-        self.show_kind_vars: dict[str, tk.BooleanVar] = {}
-        for kind, label in (("rx", "RX"), ("tx", "TX"), ("note", "Notes")):
-            var = tk.BooleanVar(value=True)
-            self.show_kind_vars[kind] = var
-            ttk.Checkbutton(row, text=label, variable=var, command=self._rerender).pack(side=tk.LEFT, padx=(12, 0))
-
-        self._count_var = tk.StringVar(value="0 lines")
-        ttk.Label(row, textvariable=self._count_var, style="Muted.TLabel").pack(side=tk.LEFT, padx=(16, 0))
-
-    def _build_output(self) -> None:
-        box = ttk.Frame(self, padding=(10, 8))
-        box.pack(side=tk.TOP, fill=tk.BOTH, expand=True)
-        self.text = tk.Text(
-            box,
-            height=12,
-            wrap=tk.NONE,
-            state=tk.DISABLED,
-            font=self._fonts["mono"],
-            background=PALETTE["bg_input"],
-            foreground=PALETTE["text"],
-        )
-        scroll = ttk.Scrollbar(box, orient=tk.VERTICAL, command=self.text.yview)
-        self.text.configure(yscrollcommand=scroll.set)
-        scroll.pack(side=tk.RIGHT, fill=tk.Y)
-        self.text.pack(side=tk.LEFT, fill=tk.BOTH, expand=True)
-        for kind, role in KIND_ROLE.items():
-            self.text.tag_configure(kind, foreground=PALETTE[role])
-        self.text.tag_configure("stamp", foreground=PALETTE["text_subtle"])
-
     def apply_palette(self) -> None:
-        """Re-read the palette after a theme switch.
-
-        `retheme_widgets` translates the colours baked into widgets, but not
-        the ones baked into Text *tags* — those are ours to refresh.
-        """
+        """Re-read the palette after a theme switch (see `SerialConsole`)."""
         self.configure(bg=PALETTE["bg_window"])
-        self.text.configure(background=PALETTE["bg_input"], foreground=PALETTE["text"])
-        for kind, role in KIND_ROLE.items():
-            self.text.tag_configure(kind, foreground=PALETTE[role])
-        self.text.tag_configure("stamp", foreground=PALETTE["text_subtle"])
+        self.console.apply_palette()
         self.refresh_connection()
 
-    def _build_send_row(self) -> None:
-        row = ttk.Frame(self, padding=(10, 0, 10, 10))
-        row.pack(side=tk.BOTTOM, fill=tk.X)
-
-        # Right-hand controls claim their width first; the entry then absorbs
-        # whatever is left, so nothing falls off the edge on a narrow window.
-        self.baud_var = tk.StringVar(value=str(self._configured_baud()))
-        baud = ttk.Combobox(
-            row,
-            textvariable=self.baud_var,
-            values=[str(b) for b in BAUD_RATES],
-            state="readonly",
-            width=8,
-        )
-        baud.pack(side=tk.RIGHT)
-        baud.bind("<<ComboboxSelected>>", self._on_baud_selected)
-        ttk.Label(row, text="Baud").pack(side=tk.RIGHT, padx=(16, 4))
-
-        ttk.Button(row, text="Send", style="Accent.TButton", command=self.send_command).pack(side=tk.RIGHT)
-        self.ending_var = tk.StringVar(value=DEFAULT_LINE_ENDING)
-        ttk.Combobox(
-            row,
-            textvariable=self.ending_var,
-            values=list(LINE_ENDINGS),
-            state="readonly",
-            width=15,
-        ).pack(side=tk.RIGHT, padx=6)
-
-        self.entry_var = tk.StringVar()
-        # A small request, not a small field: the entry takes the row's slack.
-        entry = ttk.Entry(row, textvariable=self.entry_var, width=10)
-        entry.pack(side=tk.LEFT, fill=tk.X, expand=True)
-        entry.bind("<Return>", lambda _e: self.send_command())
-        entry.bind("<Up>", lambda _e: self._history_step(-1))
-        entry.bind("<Down>", lambda _e: self._history_step(1))
-        self.entry = entry
-
     # ----- connection state ---------------------------------------------------
-
-    def _configured_baud(self) -> int:
-        try:
-            return int(self.app.config.serial.get("baud", DEFAULT_BAUD))
-        except (AttributeError, TypeError, ValueError):
-            return DEFAULT_BAUD
-
-    def _current_port(self) -> str:
-        broker = getattr(self.app, "broker", None)
-        port = getattr(broker, "port", "") if broker is not None else ""
-        if port:
-            return str(port)
-        try:
-            return str(self.app.config.serial.get("port", "") or "")
-        except AttributeError:
-            return ""
 
     def refresh_connection(self) -> None:
         """Repaint the header from the app's live broker."""
         broker = getattr(self.app, "broker", None)
         connected = bool(broker is not None and getattr(broker, "is_connected", False))
-        port = self._current_port() or "no port"
-        baud = int(getattr(broker, "baud", 0) or self._configured_baud())
+        port = self.console.current_port() or "no port"
+        baud = int(getattr(broker, "baud", 0) or self.console.configured_baud())
         if connected:
             firmware = getattr(broker, "firmware_version", "") or "Unknown"
             self._header_var.set(f"{port} @ {baud} — {firmware}")
@@ -256,223 +91,12 @@ class SerialMonitorWindow(tk.Toplevel):
     def _on_state(self, _payload: Any = None) -> None:
         self.refresh_connection()
 
-    def _on_baud_selected(self, _event: Any = None) -> None:
-        """Persist the new speed and re-open the port at it, IDE-style."""
-        try:
-            baud = int(self.baud_var.get())
-        except (TypeError, ValueError):
-            return
-        if baud == self._configured_baud() and getattr(getattr(self.app, "broker", None), "baud", None) == baud:
-            return
-        try:
-            self.app.config.serial["baud"] = baud
-            self.app.config.save()
-        except Exception as exc:
-            self.note(f"could not save baud: {exc}")
-        port = self._current_port()
-        self.note(f"baud set to {baud}")
-        if port:
-            self.app.connect_serial(port=port)
-        self.refresh_connection()
-
-    # ----- inbound ------------------------------------------------------------
-
-    def _on_rx(self, line: Any) -> None:
-        self.append("rx", str(line))
-
-    def _on_tx(self, line: Any) -> None:
-        self.append("tx", str(line))
-
-    def _on_note(self, line: Any) -> None:
-        self.append("note", str(line))
-
-    def note(self, line: str) -> None:
-        """Record a monitor-local remark (not board traffic)."""
-        self.append("note", line)
-
-    def append(self, kind: str, line: str, *, stamp: float | None = None) -> None:
-        record = (kind, time.time() if stamp is None else stamp, line)
-        if self.paused_var.get():
-            self._held.append(record)
-            return
-        self._lines.append(record)
-        self._render(record)
-        self._update_count()
-
-    def _on_pause_toggled(self) -> None:
-        if self.paused_var.get():
-            return
-        held, self._held = list(self._held), deque(maxlen=MAX_LINES)
-        for record in held:
-            self._lines.append(record)
-            self._render(record)
-        self._update_count()
-
-    def _replay_backlog(self) -> None:
-        """Show what the app captured before this window existed."""
-        backlog = list(getattr(self.app, "serial_backlog", ()))
-        if not backlog:
-            return
-        for kind, stamp, line in backlog:
-            self._lines.append((kind, stamp, line))
-        self._rerender()
-        self._lines.append(("note", time.time(), f"end of replay ({len(backlog)} earlier line(s))"))
-        self._render(self._lines[-1])
-        self._update_count()
-
-    # ----- filtering ----------------------------------------------------------
-
-    def clear_filter(self) -> None:
-        self.filter_var.set("")
-
-    def _schedule_rerender(self) -> None:
-        if self._filter_job is not None:
-            self.after_cancel(self._filter_job)
-        self._filter_job = self.after(FILTER_DEBOUNCE_MS, self._run_scheduled_rerender)
-
-    def _run_scheduled_rerender(self) -> None:
-        self._filter_job = None
-        self._rerender()
-
-    def matches(self, record: tuple[str, float, str]) -> bool:
-        """Does this line survive the direction toggles and the filter box?
-
-        Case-insensitive substring, matched against the text as the board sent
-        it — not the rendered line, so a filter can't accidentally key off the
-        `<-`/`->` prefix or a timestamp that is only sometimes shown.
-        """
-        kind, _stamp, line = record
-        var = self.show_kind_vars.get(kind)
-        if var is not None and not var.get():
-            return False
-        needle = self.filter_var.get().strip().lower()
-        return not needle or needle in line.lower()
-
-    def _shown_line_count(self) -> int:
-        """How many lines the widget is actually displaying.
-
-        Every rendered record ends in a newline, so the insertion point sits at
-        the start of an empty trailing line that isn't output — hence the -1.
-        """
-        return max(0, int(self.text.index("end-1c").split(".")[0]) - 1)
-
-    def _update_count(self) -> None:
-        total = len(self._lines)
-        shown = self._shown_line_count()
-        self._count_var.set(f"{total} lines" if shown == total else f"{shown} of {total} lines")
-
-    # ----- rendering ----------------------------------------------------------
-
-    def _render(self, record: tuple[str, float, str]) -> None:
-        kind, stamp, line = record
-        if not self.matches(record):
-            return
-        self.text.configure(state=tk.NORMAL)
-        if self.timestamps_var.get():
-            self.text.insert(tk.END, f"{time.strftime('%H:%M:%S', time.localtime(stamp))} ", ("stamp",))
-        self.text.insert(tk.END, f"{KIND_PREFIX.get(kind, '')}{line}\n", (kind,))
-        self._trim()
-        if self.autoscroll_var.get():
-            self.text.see(tk.END)
-        self.text.configure(state=tk.DISABLED)
-
-    def _rerender(self) -> None:
-        self.text.configure(state=tk.NORMAL)
-        self.text.delete("1.0", tk.END)
-        self.text.configure(state=tk.DISABLED)
-        for record in list(self._lines):
-            self._render(record)
-        self._update_count()
-
-    def _trim(self) -> None:
-        """Keep the widget's line count in step with the deque's cap."""
-        shown = self._shown_line_count()
-        if shown > MAX_LINES:
-            self.text.delete("1.0", f"{shown - MAX_LINES + 1}.0")
-
-    def clear(self) -> None:
-        self._lines.clear()
-        self.text.configure(state=tk.NORMAL)
-        self.text.delete("1.0", tk.END)
-        self.text.configure(state=tk.DISABLED)
-        self._update_count()
-
-    def dump(self) -> str:
-        """The scrollback as plain text — what's on screen, filter included."""
-        stamps = self.timestamps_var.get()
-        out = []
-        for record in self._lines:
-            if not self.matches(record):
-                continue
-            kind, stamp, line = record
-            prefix = f"{time.strftime('%H:%M:%S', time.localtime(stamp))} " if stamps else ""
-            out.append(f"{prefix}{KIND_PREFIX.get(kind, '')}{line}")
-        return "\n".join(out) + ("\n" if out else "")
-
-    def save_to_file(self) -> None:
-        path = filedialog.asksaveasfilename(
-            parent=self,
-            title="Save serial log",
-            defaultextension=".txt",
-            filetypes=[("Text files", "*.txt"), ("All files", "*.*")],
-        )
-        if not path:
-            return
-        try:
-            with open(path, "w", encoding="utf-8") as handle:
-                handle.write(self.dump())
-        except OSError as exc:
-            self.note(f"save failed: {exc}")
-            return
-        self.note(f"saved to {path}")
-
-    # ----- outbound -----------------------------------------------------------
-
-    def send_command(self) -> None:
-        text = self.entry_var.get()
-        if not text:
-            return
-        broker = getattr(self.app, "broker", None)
-        if broker is None or not getattr(broker, "is_connected", False):
-            self.note("not connected — nothing sent")
-            return
-        # The broker echoes the write through on_sent → serial/tx, so the line
-        # lands in the log the same way an auto-connect probe's does.
-        broker.send_raw(text + LINE_ENDINGS.get(self.ending_var.get(), "\n"))
-        if not self._history or self._history[-1] != text:
-            self._history.append(text)
-            del self._history[:-MAX_HISTORY]
-        self._history_pos = len(self._history)
-        self.entry_var.set("")
-
-    def _history_step(self, delta: int) -> str:
-        """Walk the command history; past the newest entry the field clears."""
-        if not self._history:
-            return "break"
-        self._history_pos = max(0, min(len(self._history), self._history_pos + delta))
-        value = "" if self._history_pos >= len(self._history) else self._history[self._history_pos]
-        self.entry_var.set(value)
-        self.entry.icursor(tk.END)
-        return "break"
-
     # ----- lifecycle ----------------------------------------------------------
 
     def close(self) -> None:
-        # A debounced re-render still in flight would fire against a dead widget.
-        if self._filter_job is not None:
-            try:
-                self.after_cancel(self._filter_job)
-            except tk.TclError:
-                pass
-            self._filter_job = None
-        for topic, handler in (
-            ("serial/rx", self._on_rx),
-            ("serial/tx", self._on_tx),
-            ("serial/note", self._on_note),
-            ("serial/state", self._on_state),
-        ):
-            try:
-                self.bus.unsubscribe(topic, handler)
-            except Exception:
-                pass
+        self.console.close()
+        try:
+            self.bus.unsubscribe("serial/state", self._on_state)
+        except Exception:
+            pass
         self.destroy()

--- a/src/sorter/ui/tab_serial.py
+++ b/src/sorter/ui/tab_serial.py
@@ -12,6 +12,7 @@ from tkinter import messagebox, ttk
 from ..control.events import EventBus
 from ..hardware import serial_broker
 from ..hardware.serial_emulator import EMULATED_PORT
+from .serial_console import SerialConsole
 from .widgets import NumericField, build_button_row
 
 # (UI label, init-settings key, min, max, default). Defaults are the
@@ -168,23 +169,17 @@ class SerialTab(ttk.Frame):
             self.init_widgets[key] = field
 
         # ---- monitor & debug ----
+        # The same widget the detached window uses, minus its baud selector —
+        # the Connection panel above already owns that setting.
         monitor = ttk.LabelFrame(self, text="Serial monitor / debug")
         monitor.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=8, pady=8)
-
-        cmd_row = ttk.Frame(monitor)
-        cmd_row.pack(side=tk.TOP, fill=tk.X, padx=4, pady=4)
-        ttk.Label(cmd_row, text="Command").pack(side=tk.LEFT, padx=4)
-        self.cmd_var = tk.StringVar()
-        entry = ttk.Entry(cmd_row, textvariable=self.cmd_var, width=40)
-        entry.pack(side=tk.LEFT, padx=4)
-        entry.bind("<Return>", lambda _e: self.send_command())
-        ttk.Button(cmd_row, text="Send", command=self.send_command).pack(side=tk.LEFT)
-        ttk.Button(cmd_row, text="Open monitor ↗", command=self.app.open_serial_monitor).pack(
-            side=tk.LEFT, padx=(12, 0)
+        self.console = SerialConsole(
+            monitor,
+            app=self.app,
+            height=10,
+            detach_command=self.app.open_serial_monitor,
         )
-
-        self.log = tk.Text(monitor, height=10, wrap=tk.NONE, state=tk.DISABLED)
-        self.log.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=4, pady=4)
+        self.console.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=6, pady=6)
 
         self.refresh_ports()
 
@@ -298,26 +293,3 @@ class SerialTab(ttk.Frame):
                 except (TypeError, ValueError, tk.TclError):
                     pass
         self.app.set_status(f"Loaded {applied} value(s) from board.")
-
-    def send_command(self) -> None:
-        broker = self.app.broker
-        if broker is None:
-            messagebox.showerror("Not connected", "Connect to the board first.")
-            return
-        cmd = self.cmd_var.get().strip()
-        if not cmd:
-            return
-        broker.send_command(cmd)
-        self.cmd_var.set("")
-
-    # ----- log API used by the App --------------------------------------------
-
-    def append_log(self, line: str) -> None:
-        self.log.configure(state=tk.NORMAL)
-        self.log.insert(tk.END, line + "\n")
-        self.log.see(tk.END)
-        # Trim to last ~500 lines.
-        line_count = int(self.log.index("end-1c").split(".")[0])
-        if line_count > 600:
-            self.log.delete("1.0", f"{line_count - 500}.0")
-        self.log.configure(state=tk.DISABLED)

--- a/src/sorter/ui/tab_serial.py
+++ b/src/sorter/ui/tab_serial.py
@@ -12,7 +12,7 @@ from tkinter import messagebox, ttk
 from ..control.events import EventBus
 from ..hardware import serial_broker
 from ..hardware.serial_emulator import EMULATED_PORT
-from .serial_console import SerialConsole
+from .serial_console import BAUD_RATES, DEFAULT_BAUD, SerialConsole
 from .widgets import NumericField, build_button_row
 
 # (UI label, init-settings key, min, max, default). Defaults are the
@@ -63,10 +63,19 @@ class SerialTab(ttk.Frame):
         ttk.Button(connect, text="Refresh ports", command=self.refresh_ports).grid(row=0, column=2, padx=6)
 
         ttk.Label(connect, text="Baud").grid(row=0, column=3, padx=6, pady=4, sticky=tk.W)
-        self.baud_var = tk.IntVar(value=int(ser_cfg.get("baud", 9600)))
-        ttk.Spinbox(connect, from_=1200, to=2_000_000, increment=100, textvariable=self.baud_var, width=10).grid(
-            row=0, column=4, padx=6, sticky=tk.W
-        )
+        # The same list the console's picker offers, not free numeric entry: a
+        # rate outside it can't work (see BAUD_RATES). A value already saved by
+        # the old spinbox still displays; it just can't be re-selected. The
+        # console below carries its own picker — `_sync_baud` there and
+        # `_refresh_baud` here keep the two showing one setting.
+        self.baud_var = tk.IntVar(value=int(ser_cfg.get("baud", DEFAULT_BAUD)))
+        ttk.Combobox(
+            connect,
+            textvariable=self.baud_var,
+            values=[str(rate) for rate in BAUD_RATES],
+            state="readonly",
+            width=10,
+        ).grid(row=0, column=4, padx=6, sticky=tk.W)
 
         ttk.Label(connect, text="Probe timeout (s)").grid(row=0, column=5, padx=6, pady=4, sticky=tk.W)
         self.probe_timeout_var = tk.DoubleVar(value=float(ser_cfg.get("handshake_timeout_s", 4.0)))
@@ -178,6 +187,7 @@ class SerialTab(ttk.Frame):
             app=self.app,
             height=10,
             detach_command=self.app.open_serial_monitor,
+            on_baud_changed=self._refresh_baud,
         )
         self.console.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=6, pady=6)
 
@@ -194,6 +204,13 @@ class SerialTab(ttk.Frame):
             return
         self.save()
         self.app.connect_serial(port=port)
+
+    def _refresh_baud(self) -> None:
+        """Follow a speed picked in the console below."""
+        try:
+            self.baud_var.set(int(self.cfg.serial.get("baud", DEFAULT_BAUD)))
+        except (TypeError, ValueError, tk.TclError):
+            pass
 
     def refresh_ports(self) -> None:
         ports = serial_broker.list_serial_ports() + [EMULATED_PORT]

--- a/src/sorter/ui/tab_serial.py
+++ b/src/sorter/ui/tab_serial.py
@@ -12,7 +12,7 @@ from tkinter import messagebox, ttk
 from ..control.events import EventBus
 from ..hardware import serial_broker
 from ..hardware.serial_emulator import EMULATED_PORT
-from .serial_console import BAUD_RATES, DEFAULT_BAUD, SerialConsole
+from .serial_console import SerialConsole
 from .widgets import NumericField, build_button_row
 
 # (UI label, init-settings key, min, max, default). Defaults are the
@@ -62,21 +62,8 @@ class SerialTab(ttk.Frame):
         self.port_combo.grid(row=0, column=1, padx=6, pady=4, sticky=tk.W)
         ttk.Button(connect, text="Refresh ports", command=self.refresh_ports).grid(row=0, column=2, padx=6)
 
-        ttk.Label(connect, text="Baud").grid(row=0, column=3, padx=6, pady=4, sticky=tk.W)
-        # The same list the console's picker offers, not free numeric entry: a
-        # rate outside it can't work (see BAUD_RATES). A value already saved by
-        # the old spinbox still displays; it just can't be re-selected. The
-        # console below carries its own picker — `_sync_baud` there and
-        # `_refresh_baud` here keep the two showing one setting.
-        self.baud_var = tk.IntVar(value=int(ser_cfg.get("baud", DEFAULT_BAUD)))
-        ttk.Combobox(
-            connect,
-            textvariable=self.baud_var,
-            values=[str(rate) for rate in BAUD_RATES],
-            state="readonly",
-            width=10,
-        ).grid(row=0, column=4, padx=6, sticky=tk.W)
-
+        # No baud control here: the console below owns the setting, picker and
+        # all, so there is exactly one of them in this window.
         ttk.Label(connect, text="Probe timeout (s)").grid(row=0, column=5, padx=6, pady=4, sticky=tk.W)
         self.probe_timeout_var = tk.DoubleVar(value=float(ser_cfg.get("handshake_timeout_s", 4.0)))
         ttk.Spinbox(
@@ -178,8 +165,7 @@ class SerialTab(ttk.Frame):
             self.init_widgets[key] = field
 
         # ---- monitor & debug ----
-        # The same widget the detached window uses, minus its baud selector —
-        # the Connection panel above already owns that setting.
+        # The same widget the detached window uses, baud picker included.
         monitor = ttk.LabelFrame(self, text="Serial monitor / debug")
         monitor.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=8, pady=8)
         self.console = SerialConsole(
@@ -187,7 +173,6 @@ class SerialTab(ttk.Frame):
             app=self.app,
             height=10,
             detach_command=self.app.open_serial_monitor,
-            on_baud_changed=self._refresh_baud,
         )
         self.console.pack(side=tk.TOP, fill=tk.BOTH, expand=True, padx=6, pady=6)
 
@@ -205,13 +190,6 @@ class SerialTab(ttk.Frame):
         self.save()
         self.app.connect_serial(port=port)
 
-    def _refresh_baud(self) -> None:
-        """Follow a speed picked in the console below."""
-        try:
-            self.baud_var.set(int(self.cfg.serial.get("baud", DEFAULT_BAUD)))
-        except (TypeError, ValueError, tk.TclError):
-            pass
-
     def refresh_ports(self) -> None:
         ports = serial_broker.list_serial_ports() + [EMULATED_PORT]
         self.port_combo["values"] = ports
@@ -219,8 +197,8 @@ class SerialTab(ttk.Frame):
             self.port_var.set(ports[0])
 
     def save(self) -> None:
+        # Not baud — the console's picker persists that one as it is chosen.
         self.cfg.serial["port"] = self.port_var.get()
-        self.cfg.serial["baud"] = int(self.baud_var.get())
         self.cfg.serial["handshake_timeout_s"] = float(self.probe_timeout_var.get())
         self.cfg.serial["slot_quantity"] = int(self.slot_count_var.get())
         self.cfg.serial["init_on_startup"] = bool(self.init_on_startup_var.get())

--- a/tests/unit/ui/conftest.py
+++ b/tests/unit/ui/conftest.py
@@ -1,0 +1,75 @@
+"""Shared fakes for the serial console/monitor UI tests.
+
+The console is embedded twice (Serial Config tab, detached monitor), so both
+test modules drive it against the same stand-in app.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+pytest.importorskip("tkinter")
+
+
+class FakeBroker:
+    def __init__(self, *, connected: bool = True) -> None:
+        self.port = "/dev/ttyFAKE"
+        self.baud = 9600
+        self.firmware_version = "7.2.1"
+        self.is_connected = connected
+        self.raw: list[str] = []
+
+    def send_raw(self, text: str) -> None:
+        self.raw.append(text)
+
+
+class FakeConfig:
+    def __init__(self) -> None:
+        self.serial: dict[str, Any] = {"port": "/dev/ttyFAKE", "baud": 9600}
+        self.saved = 0
+
+    def save(self) -> None:
+        self.saved += 1
+
+
+class FakeApp:
+    def __init__(self, *, broker: Any = None, backlog: list | None = None) -> None:
+        from sorter.control.events import EventBus
+
+        self.bus = EventBus()
+        self.config = FakeConfig()
+        self.broker = broker
+        self.serial_backlog = backlog or []
+        self.reconnects: list[str] = []
+        self.disconnects = 0
+        self.monitors_opened = 0
+
+    def connect_serial(self, port: str | None = None) -> None:
+        self.reconnects.append(port or "")
+
+    def disconnect_serial(self) -> None:
+        self.disconnects += 1
+
+    def open_serial_monitor(self) -> None:
+        self.monitors_opened += 1
+
+    def set_status(self, message: str) -> None:
+        pass
+
+
+@pytest.fixture
+def root():
+    import tkinter as tk
+
+    from sorter.ui.theme import apply_theme
+
+    try:
+        r = tk.Tk()
+    except tk.TclError:
+        pytest.skip("no display")
+    r.withdraw()
+    apply_theme(r)
+    yield r
+    r.destroy()

--- a/tests/unit/ui/test_serial_console.py
+++ b/tests/unit/ui/test_serial_console.py
@@ -16,7 +16,7 @@ pytest.importorskip("tkinter")
 
 import tkinter as tk
 
-from sorter.ui.serial_console import LINE_ENDINGS, SerialConsole
+from sorter.ui.serial_console import BAUD_RATES, LINE_ENDINGS, SerialConsole
 
 from .conftest import FakeApp, FakeBroker
 
@@ -163,32 +163,47 @@ def test_up_and_down_walk_the_command_history(root) -> None:
 def test_changing_the_baud_persists_it_and_reconnects(root) -> None:
     app = FakeApp(broker=FakeBroker())
     repaints: list[int] = []
-    console = _console(root, app, show_baud=True, on_baud_changed=lambda: repaints.append(1))
+    console = _console(root, app, on_baud_changed=lambda: repaints.append(1))
     try:
         console.baud_var.set("115200")
         console._on_baud_selected()
         assert app.config.serial["baud"] == 115200
         assert app.config.saved == 1
         assert app.reconnects == ["/dev/ttyFAKE"]
-        assert repaints, "the owner is told to repaint its connection header"
+        assert repaints, "the host is told so its own baud control can follow"
     finally:
         console.close()
 
 
-def test_the_baud_selector_is_opt_in(root) -> None:
-    """The tab's Connection panel owns baud; two controls would disagree."""
+def test_the_baud_selector_is_part_of_the_component(root) -> None:
+    """Embedding the console anywhere gets the speed picker with it."""
     app = FakeApp(broker=FakeBroker())
     console = _console(root, app)
     try:
-        assert "Baud" not in _labels(console)
+        assert "Baud" in _labels(console)
+        assert console.baud_var.get() == "9600"
+        picker = next(
+            widget
+            for widget in _widgets(console)
+            if widget.winfo_class() == "TCombobox"
+            and tuple(str(value) for value in widget.cget("values")) == tuple(str(r) for r in BAUD_RATES)
+        )
+        assert str(picker.cget("state")) == "readonly", "a rate off the list can't work, so it can't be typed"
     finally:
         console.close()
 
-    with_baud = _console(root, FakeApp(broker=FakeBroker()), show_baud=True)
+
+def test_a_speed_set_elsewhere_is_followed(root) -> None:
+    """Two controls for one setting only disagree if neither re-reads it."""
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
     try:
-        assert "Baud" in _labels(with_baud)
+        app.config.serial["baud"] = 250000
+        app.bus.post("serial/state", {"connected": True, "message": "Serial: connected"})
+        app.bus.drain()
+        assert console.baud_var.get() == "250000"
     finally:
-        with_baud.close()
+        console.close()
 
 
 def test_detach_button_is_opt_in_and_calls_back(root) -> None:
@@ -236,7 +251,7 @@ def test_unsubscribes_on_close(root) -> None:
     console = _console(root, app)
     assert console._on_rx in app.bus._subs.get("serial/rx", [])
     console.close()
-    for topic in ("serial/rx", "serial/tx", "serial/note"):
+    for topic in ("serial/rx", "serial/tx", "serial/note", "serial/state"):
         assert not app.bus._subs.get(topic), f"{topic} still has a subscriber"
 
 

--- a/tests/unit/ui/test_serial_console.py
+++ b/tests/unit/ui/test_serial_console.py
@@ -1,0 +1,385 @@
+"""Serial console — rendering, filtering, pause/resume, history, send path.
+
+The same widget the Serial Config tab embeds and the monitor window wraps, so
+these cases cover both; `test_serial_monitor.py` only covers what the window
+adds on top. Needs a real Tk display (uses xvfb in CI); skipped where tkinter
+isn't importable, matching the other UI tests.
+"""
+
+from __future__ import annotations
+
+import time
+
+import pytest
+
+pytest.importorskip("tkinter")
+
+import tkinter as tk
+
+from sorter.ui.serial_console import LINE_ENDINGS, SerialConsole
+
+from .conftest import FakeApp, FakeBroker
+
+
+def _console(root, app: FakeApp, **kwargs) -> SerialConsole:
+    console = SerialConsole(root, app=app, **kwargs)
+    console.pack(fill=tk.BOTH, expand=True)
+    return console
+
+
+def _body(console: SerialConsole) -> str:
+    return console.text.get("1.0", tk.END)
+
+
+def test_bus_lines_land_in_the_log_with_direction_tags(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        app.bus.post("serial/rx", "done")
+        app.bus.post("serial/tx", "xf:0")
+        app.bus.drain()
+        body = _body(console)
+        assert "<- done" in body
+        assert "-> xf:0" in body
+        # RX and TX print in different palette roles, which is the whole point
+        # of tagging them.
+        assert console.text.tag_cget("rx", "foreground") != console.text.tag_cget("tx", "foreground")
+    finally:
+        console.close()
+
+
+def test_backlog_is_replayed_so_a_failed_probe_is_still_readable(root) -> None:
+    stamp = time.time()
+    backlog = [
+        ("note", stamp, "probing /dev/ttyUSB0 @ 9600…"),
+        ("rx", stamp, "\x00garbage"),
+        ("note", stamp, "/dev/ttyUSB0 did not handshake"),
+    ]
+    app = FakeApp(backlog=backlog)
+    console = _console(root, app)
+    try:
+        body = _body(console)
+        assert "probing /dev/ttyUSB0 @ 9600…" in body
+        assert "garbage" in body
+        assert "did not handshake" in body
+        assert "end of replay (3 earlier line(s))" in body
+    finally:
+        console.close()
+
+
+def test_pause_holds_lines_and_resume_flushes_them_in_order(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        console.paused_var.set(True)
+        app.bus.post("serial/rx", "first")
+        app.bus.post("serial/rx", "second")
+        app.bus.drain()
+        assert "first" not in _body(console)
+
+        console.paused_var.set(False)
+        console._on_pause_toggled()
+        body = _body(console)
+        assert body.index("first") < body.index("second"), "held lines flush in arrival order"
+    finally:
+        console.close()
+
+
+def test_timestamp_toggle_rerenders_what_is_already_there(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        console.append("rx", "done", stamp=time.mktime((2026, 8, 12, 13, 45, 7, 0, 0, -1)))
+        assert "13:45:07" not in _body(console)
+        console.timestamps_var.set(True)
+        console._rerender()
+        assert "13:45:07 <- done" in _body(console)
+    finally:
+        console.close()
+
+
+def test_clear_empties_both_the_widget_and_the_dump(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        console.append("rx", "done")
+        console.clear()
+        assert _body(console).strip() == ""
+        assert console.dump() == ""
+    finally:
+        console.close()
+
+
+@pytest.mark.parametrize(
+    ("label", "ending"),
+    [("No line ending", ""), ("New Line", "\n"), ("Carriage Return", "\r"), ("Both NL & CR", "\r\n")],
+)
+def test_send_applies_the_selected_line_ending(root, label: str, ending: str) -> None:
+    broker = FakeBroker()
+    app = FakeApp(broker=broker)
+    console = _console(root, app)
+    try:
+        assert LINE_ENDINGS[label] == ending
+        console.ending_var.set(label)
+        console.entry_var.set("getconfig")
+        console.send_command()
+        assert broker.raw == [f"getconfig{ending}"]
+        assert console.entry_var.get() == ""
+    finally:
+        console.close()
+
+
+def test_send_without_a_connection_says_so_instead_of_raising(root) -> None:
+    app = FakeApp(broker=FakeBroker(connected=False))
+    console = _console(root, app)
+    try:
+        console.entry_var.set("version")
+        console.send_command()
+        assert app.broker.raw == []
+        assert "not connected" in _body(console)
+    finally:
+        console.close()
+
+
+def test_up_and_down_walk_the_command_history(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        for cmd in ("version", "getconfig"):
+            console.entry_var.set(cmd)
+            console.send_command()
+        console._history_step(-1)
+        assert console.entry_var.get() == "getconfig"
+        console._history_step(-1)
+        assert console.entry_var.get() == "version"
+        console._history_step(1)
+        assert console.entry_var.get() == "getconfig"
+        console._history_step(1)
+        assert console.entry_var.get() == "", "past the newest entry the field clears"
+    finally:
+        console.close()
+
+
+def test_changing_the_baud_persists_it_and_reconnects(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    repaints: list[int] = []
+    console = _console(root, app, show_baud=True, on_baud_changed=lambda: repaints.append(1))
+    try:
+        console.baud_var.set("115200")
+        console._on_baud_selected()
+        assert app.config.serial["baud"] == 115200
+        assert app.config.saved == 1
+        assert app.reconnects == ["/dev/ttyFAKE"]
+        assert repaints, "the owner is told to repaint its connection header"
+    finally:
+        console.close()
+
+
+def test_the_baud_selector_is_opt_in(root) -> None:
+    """The tab's Connection panel owns baud; two controls would disagree."""
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        assert "Baud" not in _labels(console)
+    finally:
+        console.close()
+
+    with_baud = _console(root, FakeApp(broker=FakeBroker()), show_baud=True)
+    try:
+        assert "Baud" in _labels(with_baud)
+    finally:
+        with_baud.close()
+
+
+def test_detach_button_is_opt_in_and_calls_back(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    plain = _console(root, app)
+    try:
+        assert not _buttons(plain, "Open monitor ↗")
+    finally:
+        plain.close()
+
+    console = _console(root, app, detach_command=app.open_serial_monitor)
+    try:
+        button = _buttons(console, "Open monitor ↗")
+        assert button, "the tab's route to the detached window"
+        button[0].invoke()
+        assert app.monitors_opened == 1
+    finally:
+        console.close()
+
+
+def _widgets(parent):
+    for child in parent.winfo_children():
+        yield child
+        yield from _widgets(child)
+
+
+def _labels(console: SerialConsole) -> set[str]:
+    out = set()
+    for widget in _widgets(console):
+        try:
+            out.add(str(widget.cget("text")))
+        except tk.TclError:
+            pass
+    return out
+
+
+def _buttons(console: SerialConsole, text: str) -> list:
+    return [
+        widget for widget in _widgets(console) if widget.winfo_class() == "TButton" and str(widget.cget("text")) == text
+    ]
+
+
+def test_unsubscribes_on_close(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    assert console._on_rx in app.bus._subs.get("serial/rx", [])
+    console.close()
+    for topic in ("serial/rx", "serial/tx", "serial/note"):
+        assert not app.bus._subs.get(topic), f"{topic} still has a subscriber"
+
+
+def test_destroying_the_widget_unsubscribes_too(root) -> None:
+    """A console torn down with its parent must not keep receiving lines."""
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    console.destroy()
+    assert not app.bus._subs.get("serial/rx")
+
+
+def test_apply_palette_repaints_the_text_tags(root) -> None:
+    from sorter.ui.theme import apply_theme
+
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        before = console.text.tag_cget("rx", "foreground")
+        apply_theme(root, theme="Light")
+        console.apply_palette()
+        assert console.text.tag_cget("rx", "foreground") != before
+    finally:
+        apply_theme(root, theme="Dark")
+        console.close()
+
+
+def _flush_filter(console: SerialConsole) -> None:
+    """Run the debounced re-render now rather than waiting out the timer."""
+    if console._filter_job is not None:
+        console.after_cancel(console._filter_job)
+        console._filter_job = None
+    console._rerender()
+
+
+def _post(app: FakeApp, *pairs: tuple[str, str]) -> None:
+    for topic, line in pairs:
+        app.bus.post(topic, line)
+    app.bus.drain()
+
+
+def test_typing_a_filter_debounces_instead_of_rerendering_per_keystroke(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        console.filter_var.set("do")
+        assert console._filter_job is not None, "no re-render was scheduled"
+    finally:
+        console.close()
+
+
+def test_filter_hides_non_matching_lines_but_keeps_them_for_later(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        _post(app, ("serial/tx", "xf:0"), ("serial/rx", "done"), ("serial/rx", "waiting"))
+        console.filter_var.set("done")
+        _flush_filter(console)
+        body = _body(console)
+        assert "done" in body
+        assert "xf:0" not in body
+        assert "waiting" not in body
+
+        # Filtering is a view, not a deletion.
+        console.clear_filter()
+        _flush_filter(console)
+        body = _body(console)
+        assert "xf:0" in body and "waiting" in body
+    finally:
+        console.close()
+
+
+def test_filter_is_case_insensitive_and_matches_the_board_text_only(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        _post(app, ("serial/rx", "Done"))
+        console.filter_var.set("dOnE")
+        _flush_filter(console)
+        assert "Done" in _body(console)
+
+        # The `<-`/`->` prefixes are rendering, not content — a filter must not
+        # key off them or "->" would silently mean "everything I sent".
+        console.filter_var.set("<-")
+        _flush_filter(console)
+        assert "Done" not in _body(console)
+    finally:
+        console.close()
+
+
+def test_direction_toggles_hide_a_whole_kind(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        _post(app, ("serial/tx", "version"), ("serial/rx", "7.2.1"), ("serial/note", "probing"))
+        console.show_kind_vars["tx"].set(False)
+        console._rerender()
+        body = _body(console)
+        assert "version" not in body
+        assert "7.2.1" in body and "probing" in body
+    finally:
+        console.close()
+
+
+def test_lines_arriving_while_a_filter_is_active_respect_it(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        console.filter_var.set("done")
+        _flush_filter(console)
+        _post(app, ("serial/rx", "waiting"), ("serial/rx", "done"))
+        body = _body(console)
+        assert "done" in body
+        assert "waiting" not in body
+        # …and are still there once the filter goes away.
+        console.clear_filter()
+        _flush_filter(console)
+        assert "waiting" in _body(console)
+    finally:
+        console.close()
+
+
+def test_dump_follows_the_filter_so_save_writes_what_is_shown(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        _post(app, ("serial/rx", "done"), ("serial/rx", "waiting"))
+        console.filter_var.set("done")
+        _flush_filter(console)
+        dumped = console.dump()
+        assert "done" in dumped
+        assert "waiting" not in dumped
+    finally:
+        console.close()
+
+
+def test_count_reports_shown_against_total_only_while_filtering(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    console = _console(root, app)
+    try:
+        _post(app, ("serial/rx", "done"), ("serial/rx", "waiting"), ("serial/tx", "xf:0"))
+        assert console._count_var.get() == "3 lines"
+        console.filter_var.set("done")
+        _flush_filter(console)
+        assert console._count_var.get() == "1 of 3 lines"
+    finally:
+        console.close()

--- a/tests/unit/ui/test_serial_monitor.py
+++ b/tests/unit/ui/test_serial_monitor.py
@@ -30,7 +30,6 @@ def test_the_window_is_a_console_plus_a_header(root) -> None:
         app.bus.post("serial/rx", "done")
         app.bus.drain()
         assert "<- done" in win.console.text.get("1.0", "end")
-        # Only the detached window carries the speed selector.
         assert win.console.baud_var.get() == "9600"
     finally:
         win.close()

--- a/tests/unit/ui/test_serial_monitor.py
+++ b/tests/unit/ui/test_serial_monitor.py
@@ -1,225 +1,54 @@
-"""Serial monitor window — backlog replay, pause/resume, history, send path.
+"""Serial monitor window — the connection header and the lifecycle.
 
-Needs a real Tk display (uses xvfb in CI); skipped where tkinter isn't
-importable, matching the other UI tests.
+Everything below the header is `SerialConsole`, covered once in
+`test_serial_console.py` rather than twice here.
 """
 
 from __future__ import annotations
 
 import time
-from typing import Any
 
 import pytest
 
 pytest.importorskip("tkinter")
 
-import tkinter as tk
+from sorter.ui.serial_monitor import SerialMonitorWindow
 
-from sorter.control.events import EventBus
-from sorter.ui.serial_monitor import LINE_ENDINGS, SerialMonitorWindow
-from sorter.ui.theme import apply_theme
+from .conftest import FakeApp, FakeBroker
 
 
-class _FakeBroker:
-    def __init__(self, *, connected: bool = True) -> None:
-        self.port = "/dev/ttyFAKE"
-        self.baud = 9600
-        self.firmware_version = "7.2.1"
-        self.is_connected = connected
-        self.raw: list[str] = []
-
-    def send_raw(self, text: str) -> None:
-        self.raw.append(text)
-
-
-class _FakeConfig:
-    def __init__(self) -> None:
-        self.serial: dict[str, Any] = {"port": "/dev/ttyFAKE", "baud": 9600}
-        self.saved = 0
-
-    def save(self) -> None:
-        self.saved += 1
-
-
-class _FakeApp:
-    def __init__(self, *, broker: Any = None, backlog: list | None = None) -> None:
-        self.bus = EventBus()
-        self.config = _FakeConfig()
-        self.broker = broker
-        self.serial_backlog = backlog or []
-        self.reconnects: list[str] = []
-
-    def connect_serial(self, port: str | None = None) -> None:
-        self.reconnects.append(port or "")
-
-
-@pytest.fixture
-def root():
-    try:
-        r = tk.Tk()
-    except tk.TclError:
-        pytest.skip("no display")
-    r.withdraw()
-    apply_theme(r)
-    yield r
-    r.destroy()
-
-
-def _open(root, app: _FakeApp) -> SerialMonitorWindow:
+def _open(root, app: FakeApp) -> SerialMonitorWindow:
     win = SerialMonitorWindow(root, app=app)
     win.withdraw()
     return win
 
 
-def _body(win: SerialMonitorWindow) -> str:
-    return win.text.get("1.0", tk.END)
-
-
-def test_bus_lines_land_in_the_log_with_direction_tags(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
+def test_the_window_is_a_console_plus_a_header(root) -> None:
+    app = FakeApp(broker=FakeBroker())
     win = _open(root, app)
     try:
         app.bus.post("serial/rx", "done")
-        app.bus.post("serial/tx", "xf:0")
         app.bus.drain()
-        body = _body(win)
-        assert "<- done" in body
-        assert "-> xf:0" in body
-        # RX and TX print in different palette roles, which is the whole point
-        # of tagging them.
-        assert win.text.tag_cget("rx", "foreground") != win.text.tag_cget("tx", "foreground")
+        assert "<- done" in win.console.text.get("1.0", "end")
+        # Only the detached window carries the speed selector.
+        assert win.console.baud_var.get() == "9600"
     finally:
         win.close()
 
 
 def test_backlog_is_replayed_so_a_failed_probe_is_still_readable(root) -> None:
     stamp = time.time()
-    backlog = [
-        ("note", stamp, "probing /dev/ttyUSB0 @ 9600…"),
-        ("rx", stamp, "\x00garbage"),
-        ("note", stamp, "/dev/ttyUSB0 did not handshake"),
-    ]
-    app = _FakeApp(backlog=backlog)
+    app = FakeApp(backlog=[("note", stamp, "/dev/ttyUSB0 did not handshake")])
     win = _open(root, app)
     try:
-        body = _body(win)
-        assert "probing /dev/ttyUSB0 @ 9600…" in body
-        assert "garbage" in body
-        assert "did not handshake" in body
-        assert "end of replay (3 earlier line(s))" in body
-    finally:
-        win.close()
-
-
-def test_pause_holds_lines_and_resume_flushes_them_in_order(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        win.paused_var.set(True)
-        app.bus.post("serial/rx", "first")
-        app.bus.post("serial/rx", "second")
-        app.bus.drain()
-        assert "first" not in _body(win)
-
-        win.paused_var.set(False)
-        win._on_pause_toggled()
-        body = _body(win)
-        assert body.index("first") < body.index("second"), "held lines flush in arrival order"
-    finally:
-        win.close()
-
-
-def test_timestamp_toggle_rerenders_what_is_already_there(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        win.append("rx", "done", stamp=time.mktime((2026, 8, 12, 13, 45, 7, 0, 0, -1)))
-        assert "13:45:07" not in _body(win)
-        win.timestamps_var.set(True)
-        win._rerender()
-        assert "13:45:07 <- done" in _body(win)
-    finally:
-        win.close()
-
-
-def test_clear_empties_both_the_widget_and_the_dump(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        win.append("rx", "done")
-        win.clear()
-        assert _body(win).strip() == ""
-        assert win.dump() == ""
-    finally:
-        win.close()
-
-
-@pytest.mark.parametrize(
-    ("label", "ending"),
-    [("No line ending", ""), ("New Line", "\n"), ("Carriage Return", "\r"), ("Both NL & CR", "\r\n")],
-)
-def test_send_applies_the_selected_line_ending(root, label: str, ending: str) -> None:
-    broker = _FakeBroker()
-    app = _FakeApp(broker=broker)
-    win = _open(root, app)
-    try:
-        assert LINE_ENDINGS[label] == ending
-        win.ending_var.set(label)
-        win.entry_var.set("getconfig")
-        win.send_command()
-        assert broker.raw == [f"getconfig{ending}"]
-        assert win.entry_var.get() == ""
-    finally:
-        win.close()
-
-
-def test_send_without_a_connection_says_so_instead_of_raising(root) -> None:
-    app = _FakeApp(broker=_FakeBroker(connected=False))
-    win = _open(root, app)
-    try:
-        win.entry_var.set("version")
-        win.send_command()
-        assert app.broker.raw == []
-        assert "not connected" in _body(win)
-    finally:
-        win.close()
-
-
-def test_up_and_down_walk_the_command_history(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        for cmd in ("version", "getconfig"):
-            win.entry_var.set(cmd)
-            win.send_command()
-        win._history_step(-1)
-        assert win.entry_var.get() == "getconfig"
-        win._history_step(-1)
-        assert win.entry_var.get() == "version"
-        win._history_step(1)
-        assert win.entry_var.get() == "getconfig"
-        win._history_step(1)
-        assert win.entry_var.get() == "", "past the newest entry the field clears"
-    finally:
-        win.close()
-
-
-def test_changing_the_baud_persists_it_and_reconnects(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        win.baud_var.set("115200")
-        win._on_baud_selected()
-        assert app.config.serial["baud"] == 115200
-        assert app.config.saved == 1
-        assert app.reconnects == ["/dev/ttyFAKE"]
+        assert "did not handshake" in win.console.text.get("1.0", "end")
     finally:
         win.close()
 
 
 def test_header_tracks_the_connection_state(root) -> None:
-    broker = _FakeBroker()
-    app = _FakeApp(broker=broker)
+    broker = FakeBroker()
+    app = FakeApp(broker=broker)
     win = _open(root, app)
     try:
         assert win._header_var.get() == "/dev/ttyFAKE @ 9600 — 7.2.1"
@@ -231,147 +60,38 @@ def test_header_tracks_the_connection_state(root) -> None:
         win.close()
 
 
-def test_unsubscribes_on_close(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
+def test_changing_the_baud_repaints_the_header(root) -> None:
+    broker = FakeBroker()
+    app = FakeApp(broker=broker)
     win = _open(root, app)
-    assert win._on_rx in app.bus._subs.get("serial/rx", [])
+    try:
+        broker.baud = 115200
+        win.console.baud_var.set("115200")
+        win.console._on_baud_selected()
+        assert "@ 115200" in win._header_var.get()
+    finally:
+        win.close()
+
+
+def test_apply_palette_reaches_the_console(root) -> None:
+    from sorter.ui.theme import apply_theme
+
+    app = FakeApp(broker=FakeBroker())
+    win = _open(root, app)
+    try:
+        before = win.console.text.tag_cget("rx", "foreground")
+        apply_theme(root, theme="Light")
+        win.apply_palette()
+        assert win.console.text.tag_cget("rx", "foreground") != before
+    finally:
+        apply_theme(root, theme="Dark")
+        win.close()
+
+
+def test_unsubscribes_everything_on_close(root) -> None:
+    app = FakeApp(broker=FakeBroker())
+    win = _open(root, app)
+    assert win._on_state in app.bus._subs.get("serial/state", [])
     win.close()
     for topic in ("serial/rx", "serial/tx", "serial/note", "serial/state"):
         assert not app.bus._subs.get(topic), f"{topic} still has a subscriber"
-
-
-def test_apply_palette_repaints_the_text_tags(root) -> None:
-    from sorter.ui.theme import apply_theme as _apply
-
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        before = win.text.tag_cget("rx", "foreground")
-        _apply(root, theme="Light")
-        win.apply_palette()
-        assert win.text.tag_cget("rx", "foreground") != before
-    finally:
-        _apply(root, theme="Dark")
-        win.close()
-
-
-def _flush_filter(win: SerialMonitorWindow) -> None:
-    """Run the debounced re-render now rather than waiting out the timer."""
-    if win._filter_job is not None:
-        win.after_cancel(win._filter_job)
-        win._filter_job = None
-    win._rerender()
-
-
-def _post(app: _FakeApp, *pairs: tuple[str, str]) -> None:
-    for topic, line in pairs:
-        app.bus.post(topic, line)
-    app.bus.drain()
-
-
-def test_typing_a_filter_debounces_instead_of_rerendering_per_keystroke(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        win.filter_var.set("do")
-        assert win._filter_job is not None, "no re-render was scheduled"
-    finally:
-        win.close()
-
-
-def test_filter_hides_non_matching_lines_but_keeps_them_for_later(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        _post(app, ("serial/tx", "xf:0"), ("serial/rx", "done"), ("serial/rx", "waiting"))
-        win.filter_var.set("done")
-        _flush_filter(win)
-        body = _body(win)
-        assert "done" in body
-        assert "xf:0" not in body
-        assert "waiting" not in body
-
-        # Filtering is a view, not a deletion.
-        win.clear_filter()
-        _flush_filter(win)
-        body = _body(win)
-        assert "xf:0" in body and "waiting" in body
-    finally:
-        win.close()
-
-
-def test_filter_is_case_insensitive_and_matches_the_board_text_only(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        _post(app, ("serial/rx", "Done"))
-        win.filter_var.set("dOnE")
-        _flush_filter(win)
-        assert "Done" in _body(win)
-
-        # The `<-`/`->` prefixes are rendering, not content — a filter must not
-        # key off them or "->" would silently mean "everything I sent".
-        win.filter_var.set("<-")
-        _flush_filter(win)
-        assert "Done" not in _body(win)
-    finally:
-        win.close()
-
-
-def test_direction_toggles_hide_a_whole_kind(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        _post(app, ("serial/tx", "version"), ("serial/rx", "7.2.1"), ("serial/note", "probing"))
-        win.show_kind_vars["tx"].set(False)
-        win._rerender()
-        body = _body(win)
-        assert "version" not in body
-        assert "7.2.1" in body and "probing" in body
-    finally:
-        win.close()
-
-
-def test_lines_arriving_while_a_filter_is_active_respect_it(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        win.filter_var.set("done")
-        _flush_filter(win)
-        _post(app, ("serial/rx", "waiting"), ("serial/rx", "done"))
-        body = _body(win)
-        assert "done" in body
-        assert "waiting" not in body
-        # …and are still there once the filter goes away.
-        win.clear_filter()
-        _flush_filter(win)
-        assert "waiting" in _body(win)
-    finally:
-        win.close()
-
-
-def test_dump_follows_the_filter_so_save_writes_what_is_shown(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        _post(app, ("serial/rx", "done"), ("serial/rx", "waiting"))
-        win.filter_var.set("done")
-        _flush_filter(win)
-        dumped = win.dump()
-        assert "done" in dumped
-        assert "waiting" not in dumped
-    finally:
-        win.close()
-
-
-def test_count_reports_shown_against_total_only_while_filtering(root) -> None:
-    app = _FakeApp(broker=_FakeBroker())
-    win = _open(root, app)
-    try:
-        _post(app, ("serial/rx", "done"), ("serial/rx", "waiting"), ("serial/tx", "xf:0"))
-        assert win._count_var.get() == "3 lines"
-        win.filter_var.set("done")
-        _flush_filter(win)
-        assert win._count_var.get() == "1 of 3 lines"
-    finally:
-        win.close()

--- a/tests/unit/ui/test_tab_serial.py
+++ b/tests/unit/ui/test_tab_serial.py
@@ -1,0 +1,65 @@
+"""Serial Config tab — that its monitor panel is the shared console.
+
+The point of the panel is that it is not a second, lesser log: it is the same
+`SerialConsole` the detached window wraps, so the two can't drift apart again.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+pytest.importorskip("tkinter")
+
+import tkinter as tk
+
+from sorter.hardware import serial_broker
+from sorter.ui.serial_console import SerialConsole
+from sorter.ui.tab_serial import SerialTab
+
+from .conftest import FakeApp, FakeBroker
+
+
+@pytest.fixture
+def tab(root, monkeypatch):
+    monkeypatch.setattr(serial_broker, "list_serial_ports", lambda: ["/dev/ttyFAKE"])
+    app = FakeApp(broker=FakeBroker())
+    widget = SerialTab(root, config=app.config, bus=app.bus, app=app)
+    widget.pack(fill=tk.BOTH, expand=True)
+    yield widget, app
+    widget.console.close()
+    widget.destroy()
+
+
+def test_the_panel_is_the_shared_console_and_shows_live_traffic(tab) -> None:
+    widget, app = tab
+    assert isinstance(widget.console, SerialConsole)
+    app.bus.post("serial/rx", "done")
+    app.bus.post("serial/tx", "xf:0")
+    app.bus.drain()
+    body = widget.console.text.get("1.0", tk.END)
+    assert "<- done" in body and "-> xf:0" in body
+
+
+def test_the_panel_sends_through_the_console(tab) -> None:
+    widget, app = tab
+    widget.console.entry_var.set("getconfig")
+    widget.console.send_command()
+    assert app.broker.raw == ["getconfig\n"]
+
+
+def test_the_panel_offers_the_detached_window(tab) -> None:
+    widget, app = tab
+    buttons = [
+        child
+        for child in _descendants(widget.console)
+        if child.winfo_class() == "TButton" and str(child.cget("text")) == "Open monitor ↗"
+    ]
+    assert buttons
+    buttons[0].invoke()
+    assert app.monitors_opened == 1
+
+
+def _descendants(parent):
+    for child in parent.winfo_children():
+        yield child
+        yield from _descendants(child)

--- a/tests/unit/ui/test_theme.py
+++ b/tests/unit/ui/test_theme.py
@@ -382,7 +382,8 @@ def _stub_window(root, db=None):
             )
             self._camera_connected = False
             self._serial_connected = True
-            # set_theme repaints an open serial monitor's Text tags.
+            # set_theme repaints each serial console's Text tags.
+            self.serial_tab = None
             self._serial_monitor = None
             self.camera_dot = tk.Label(
                 root,


### PR DESCRIPTION
## What & Why

#78 gave the app a detachable serial monitor — autoscroll, timestamps, pause,
a case-insensitive filter with RX/TX/Notes toggles, RX/TX colouring, Clear,
Save…, command history and a line-ending selector — and left the Serial Config
tab's **Serial monitor / debug** panel exactly as it was: one colour, no
timestamps, no filter, a 500-line cap, and a `Command` box that wrote through
`send_command`. Two views of the same traffic, only one of them worth reading,
and nothing keeping them in step.

They are now literally the same widget.

**New `ui/serial_console.py`** — `SerialConsole(ttk.Frame)` is everything the
monitor had below its connection header, moved verbatim (the behaviour is #78's;
this PR changes where it lives, not what it does). Both hosts embed it, so a
feature added to one is in the other by construction.

The component is **self-contained, speed picker included** — embed it anywhere
and you get a console that can talk to the board on its own terms. That makes
it the only baud control in the app: the Serial Config tab's Connection panel
no longer has one, so a single widget owns `config.serial["baud"]`, persisting
and reconnecting as it is picked (and `SerialTab.save()` no longer writes that
key). Two consoles can still be live at once — the tab's and an open window's —
so `_sync_baud` re-reads the setting on `serial/state` and they can't drift
apart; `on_baud_changed` tells a host that wants to react, which is how the
window repaints its header.

The one host-specific option left is `detach_command`, the tab's
"Open monitor ↗", rendered on the control row rather than costing a row of its
own.

The console subscribes to `serial/rx` / `serial/tx` / `serial/note` itself and
replays `MainWindow.serial_backlog` on construction (empty for the tab, which
is built before the first probe; it is the window opened *after* a failed
auto-connect that needs it). `close()` unsubscribes and is idempotent, and
`destroy()` calls it — destroying a parent doesn't run an embedded widget's
Python `destroy`.

**`ui/serial_monitor.py`** — now just the connection header, the `serial/state`
subscription that repaints it, and the single-instance lifecycle: 478 lines to
102. `refresh_connection` is unchanged; `current_port()` / `configured_baud()`
became public on the console because the header reads them.

**`ui/tab_serial.py`** — the `Command` row and the `tk.Text` are gone, replaced
by the console. Sending now goes through `send_raw` + the line-ending selector,
the same path the window uses. `SerialTab.append_log` had one caller and is
deleted with it. Connection keeps port, probe timeout and the buttons; its
Baud control (a free-entry spinbox, 1200–2,000,000 in steps of 100) is gone,
since the console below owns that setting.

**`ui/app.py`** — `_log_serial` no longer fans out to the tab; it is the
backlog append it always was underneath. `set_theme` repaints **every** live
console's `Text` tags (they're outside `retheme_widgets`' reach), not only an
open window's.

**CLAUDE.md** updated in the same change: §5 shared-UI list (the new
`serial_console.py` entry carries the detail, `serial_monitor.py` shrinks to
what the window adds) and the tab table's Serial row.

### Second commit: trim the baud list to what the board can generate

The picker shipped with the Arduino IDE's ladder, which is long because the
IDE serves every board; this app serves one. Measured against the real rig:

- The **CH340 bridge** (`1a86:7523`) is not a constraint — read back via
  `termios2.c_ospeed`, it programs all 15 rates from 300 to 2,000,000 exactly.
- The **firmware** calls `Serial.begin(9600)` once, with no runtime baud
  command ([`CS72_Firmware_V1.7.ino`][fw] @ `cd2d01a`), so today only 9600
  works at all. The picker exists for reflashed boards.
- The **MCU** is a 16 MHz ATmega328P, where Arduino's U2X divisor
  (`UBRR = round(F_CPU / (8 × baud)) − 1`) decides what is reachable.

| requested | actual | error | |
|---|---|---|---|
| 9600 / 19200 / 38400 | 9615 / 19231 / 38462 | +0.16% | keep |
| 57600 | 57143 | −0.79% | keep |
| 74880 | 74074 | −1.08% | **drop** — an ESP8266 boot-ROM rate |
| 115200 | 117647 | +2.12% | keep — tolerance edge, but universal |
| 230400 | 222222 | **−3.55%** | **drop** — outside 8N1's ±2%; cannot work |
| 250000 | 250000 | **0.00%** | keep — `16 MHz / 64`, exact |

300 / 1200 / 2400 / 4800 go as unused legacy. `DEFAULT_BAUD` is unchanged —
9600 is what the firmware runs.

**A saved off-list value is left alone, not normalised.** It is only reachable
from a build that offered it; the readonly combobox then shows a rate it
cannot re-select, which is honest — that *is* what the port is configured at —
and rewriting a user's saved setting when they open a window would be a
surprise rather than a fix.

[fw]: https://github.com/sjseth/AI-Case-Sorter-CS7.2/blob/cd2d01ae3c6ef78a0eebcac13619e11fd5c7ca53/MicroController/CS72_Firmware_V1.7/CS72_Firmware_V1.7.ino

## Screenshots

Both columns are the real `MainWindow` at the same size, same theme, same
staged session: no real serial ports, a connection to the bundled
`SerialEmulator`, then six real protocol commands. Every log line is the
emulator's own reply.

| Before — the in-tab panel | After — the shared console |
|---|---|
| ![before final](https://github.com/user-attachments/assets/5d223636-42d6-4fbd-8e97-4bc27ed2bb41) | ![after final](https://github.com/user-attachments/assets/c2b8213b-bf9a-4375-a4b0-9e6a4357ccc8) |

The panel that was a plain grey dump now has the controls, the filter with its
`12 lines` count, the RX/TX colouring, and a send row with the line-ending
selector and the baud picker — because it is the window's widget, not a copy
of it. Note the trade in the top-left: `Baud` leaves the Connection panel,
because it now lives in the console for both hosts.

## Author Checklist

- [x] CLAUDE.md updated in the same change (§5)
- [x] No new `theme.PALETTE` roles; colours still read at call time
- [x] Threading rule respected — the console is fed by the bus, so every
      handler runs on the main thread
- [ ] Ran `/quality:full-pr-review` and addressed findings

## Test Plan

### Before Deployment

**Author**
- [x] `pytest -p no:randomly -m "not integration"
      --ignore=tests/unit/ui/test_theme_editor.py` — 778 passed
- [x] `ruff check`, `ruff format --check`, `ty check` — all clean
- [x] Tests follow the split: the behaviour cases move to
      `tests/unit/ui/test_serial_console.py` (+3 new: baud selector is opt-in,
      detach button is opt-in, destroy unsubscribes), `test_serial_monitor.py`
      keeps what the window adds, and a new `test_tab_serial.py` pins that the
      tab's panel really is a `SerialConsole`, shows live traffic, sends
      through it, and offers the detached window
- [x] Drove the real app end to end against the emulator (the screenshots
      above are that run): traffic appears in the tab log, the filter and
      count work there, and "Open monitor ↗" opens the window

**Reviewer**
- [ ] With real hardware: confirm the tab panel and the detached window show
      the same traffic, and that sending from either reaches the board
- [ ] Switch themes with both open and confirm RX/TX colours follow in both
- [ ] With the tab open *and* the monitor detached, change baud in one and
      confirm the other follows, that it persists, and that it reconnects
- [ ] Sanity-check the trimmed baud list against your own board — the MCU is
      inferred (no `avrdude` on hand for a signature read), so if it is not a
      16 MHz ATmega328P the divisor table above is the wrong one

### After Deployment

- [ ] First launch after the update shows the tab panel populated by the
      startup auto-connect probe (the backlog path is unchanged, but it is the
      one thing only a real launch exercises)
