### PR TITLE
fix(ml): upgrade PyTorch to 2.13.0 and close the weights_only CVE for existing installs

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -908,10 +908,12 @@ flowchart TD
   time — never re-declare them as a constant, which is how the runtime
   install once drifted from the lockfile and went invisible to dependency
   scanning (#67). The one coupling to keep by hand: the GPU build installs
-  from a fixed CUDA wheel index (`_CUDA_INDEX` in that dialog), and each
-  index only carries the torch versions built for it, so a torch bump must
-  check the index still serves the new pin —
-  `tests/integration/test_torch_wheel_index.py` verifies exactly that.
+  from a per-OS CUDA wheel index (`_CUDA_INDEX_BY_OS` in that dialog —
+  Linux and Windows differ because upstream never builds Windows cu129
+  wheels), and each index only carries the torch versions built for it, so
+  a torch bump must check every index still serves the new pin for its
+  platform — `tests/integration/test_torch_wheel_index.py` verifies
+  exactly that.
 - **DB access is shared across threads** via one connection + RLock. Wrap
   multi-statement work in `db.transaction()` (reentrant via SAVEPOINT).
 - **Headstamps are read fresh, not cached** — don't reintroduce a cached

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -97,9 +97,10 @@ one-for-one (`tests/unit/hardware/`, `tests/unit/data/`, …), plus a handful of
 modules that test something at the package's own top level (`test_paths.py`,
 `test_bootstrap.py`, `test_version.py`, `test_installer_scripts.py`) and stay
 directly under `tests/unit/`. Everything in `tests/unit/` uses synthetic
-fixtures only; `tests/integration/` stays flat — the two files that shell out
-to a real external tool (`uv build`, `git-cliff`) instead, each self-skipping
-if that tool is missing; `pytest -m "not integration"` skips them outright.
+fixtures only; `tests/integration/` stays flat — the files that exercise a
+real external tool or service (`uv build`, `git-cliff`, the PyTorch wheel
+index) instead, each self-skipping if that tool — or, for the wheel index,
+the network — is missing; `pytest -m "not integration"` skips them outright.
 CI (`.github/workflows/build.yml`) runs the full matrix on every push/PR —
 run `pytest` locally before pushing regardless, since CI turnaround is slower
 than your own machine. The suite is threading-fragile by design (see
@@ -526,8 +527,9 @@ modal), and never gate on `is_available()`.
 ### Dialogs (`dialog_*.py`)
 `dialog_training_progress` (live training console), `dialog_training_config`
 (hyperparameters), `dialog_model_editor` (create/edit model + feedback-loop
-opt-in), `dialog_install_torch` (installs torch/torchvision into the venv via
-uv, falling back to pip),
+opt-in), `dialog_install_torch` (installs the torch/torchvision pinned by
+pyproject.toml's `[ml]` extra — read at install time; the extra is the pins'
+single source of truth — into the venv via uv, falling back to pip),
 `dialog_login` (MSAL interactive sign-in), `dialog_model_evaluator` (run eval +
 HTML report + history), `dialog_model_images` + `dialog_image_preview` (training
 image browser/reclassify/delete), `dialog_share_model` (publish to community),
@@ -901,6 +903,15 @@ flowchart TD
   `[ml]` extra. Any **new** entry point that runs a model locally must go
   through `ui/torch_gate.ensure_torch` (§5) — a bare `LocalInferenceError`
   reaching the user is the bug that gate exists to prevent.
+- **The `[ml]` extra is the only place the torch version lives.**
+  `dialog_install_torch` reads the pins out of `pyproject.toml` at install
+  time — never re-declare them as a constant, which is how the runtime
+  install once drifted from the lockfile and went invisible to dependency
+  scanning (#67). The one coupling to keep by hand: the GPU build installs
+  from a fixed CUDA wheel index (`_CUDA_INDEX` in that dialog), and each
+  index only carries the torch versions built for it, so a torch bump must
+  check the index still serves the new pin —
+  `tests/integration/test_torch_wheel_index.py` verifies exactly that.
 - **DB access is shared across threads** via one connection + RLock. Wrap
   multi-statement work in `db.transaction()` (reentrant via SAVEPOINT).
 - **Headstamps are read fresh, not cached** — don't reintroduce a cached

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -505,6 +505,28 @@ if not ensure_torch(self, self._start, reason="Sorting needs PyTorch"):
     return
 ```
 
+**A second rule sits on top of presence, and it is a security floor.**
+`local_inference.MIN_TORCH_VERSION` (2.10.0) is the oldest torch allowed to
+load a checkpoint this app did not produce: CVE-2026-24747 lets a crafted
+`.pth` defeat the `weights_only=True` unpickler that `_load` relies on, and
+the Community tab and ZIP import are exactly that delivery path. So
+`ensure_torch` takes the `model` the action will load and picks the policy
+from `models.is_foreign_model`: a **foreign** model **blocks** until the user
+upgrades; the user's **own** model gets an **offer** that proceeds on decline,
+remembered for the session (their own checkpoint isn't an attack, and a
+multi-GB download shouldn't stand between them and sorting). Omitting `model`
+takes the blocking branch — unknown provenance is treated as foreign.
+The floor is deliberately **not** derived from the `[ml]` pin: the pin is
+"what a fresh install gets" and moves on every routine bump, while this is
+"below here the safety property is gone", moves only when an advisory says
+so, and records which one. It also bounds any future opt-into-an-older-build
+override (#67), and since it sits above the 2.3.0 floor where
+`torch.amp.GradScaler` first appears, honouring it cannot regress
+`train_convnext.py` onto the `AttributeError` older wheels produce.
+`meets_min_version()` **fails open** on unreadable metadata — a source build
+is likelier than an exploit, and bricking those installs would trade a real
+breakage for a speculative one.
+
 Gated: Run tab Start + Manual feed (only when `classifier.uses_local_inference`
 is True), the evaluator, and training. The Train tab's Feed *offers* rather
 than gates — capturing and labelling images is exactly the workflow that

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,6 +102,11 @@ Local training/inference additionally needs PyTorch (optional):
 ```bash
 uv sync --extra ml      # torch + torchvision
 ```
+Note this resolves from PyPI: on Linux that's the CUDA 13 build (needs an
+R580+ NVIDIA driver), on Windows it's CPU-only. The in-app Install-PyTorch
+dialog instead uses per-OS CUDA wheel indexes (12.9 on Linux — R525+
+drivers; 13.0 on Windows — R580+, GPU included) — see README's "Optional:
+PyTorch" for installing those builds by hand.
 
 ### No hardware? Use the emulator
 
@@ -114,10 +119,11 @@ and the UI without a physical sorter attached.
 uv run pytest
 ```
 
-Split into `tests/unit/` and `tests/integration/` — the latter is the two
-files that shell out to a real external tool (`uv build`, `git-cliff`)
-instead of a synthetic fixture, each carrying `@pytest.mark.integration` and
-skipping individually if that tool isn't installed. `pytest -m "not
+Split into `tests/unit/` and `tests/integration/` — the latter is the files
+that exercise a real external tool or service (`uv build`, `git-cliff`, the
+PyTorch wheel index) instead of a synthetic fixture, each carrying
+`@pytest.mark.integration` and skipping individually if that tool — or, for
+the wheel index, network access — isn't available. `pytest -m "not
 integration"` skips them outright for a faster inner loop; plain
 `pytest`/CI runs everything.
 

--- a/README.md
+++ b/README.md
@@ -166,6 +166,15 @@ uv sync --extra ml        # torch + torchvision
 - **GPU:** an NVIDIA card with **compute capability ≥ 8.0** (Ampere / RTX
   30-series and newer) is used automatically; older or absent GPUs fall back to
   **CPU**, which still works but is slower.
+- **The two install routes ship different CUDA builds.** The in-app dialog
+  installs CUDA 12.9 wheels on Linux (NVIDIA driver **R525+**) and CUDA 13.0
+  wheels on Windows (driver **R580+**). `uv sync --extra ml` instead resolves
+  from PyPI, whose Linux build is CUDA 13 (driver **R580+**) and whose
+  Windows build is **CPU-only**. For GPU use, prefer the in-app dialog — or
+  install the exact `torch==…` / `torchvision==…` pins from
+  `pyproject.toml`'s `[ml]` extra yourself from the matching index:
+  `uv pip install --index-url https://download.pytorch.org/whl/cu129` on
+  Linux, `…/whl/cu130` on Windows.
 - **AI Config mode needs no PyTorch on the client** — inference runs on the
   server instead.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -164,7 +164,7 @@ known-first-party = ["sorter"]
 testpaths = ["tests"]
 addopts = "-ra"
 markers = [
-    "integration: exercises a real external tool (uv build, git-cliff) instead of a synthetic fixture",
+    "integration: exercises a real external tool or service (uv build, git-cliff, the PyTorch wheel index) instead of a synthetic fixture",
 ]
 # The suite is threading-fragile by design (see tests/conftest.py): Tk widget
 # garbage collected on a worker thread calls into Tcl from the wrong thread

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -50,9 +50,15 @@ Issues = "https://github.com/sjseth/AI-Case-Sorter-Py/issues"
 
 [project.optional-dependencies]
 # Local PyTorch training/inference. Install with `pip install .[ml]`.
-# Must match _TARGETS in sorter/ui/dialog_install_torch.py, which is how
-# PyTorch actually gets installed at runtime. Bump both together.
-ml = ["torch==2.9.1", "torchvision==0.24.1"]
+# This is the single authoritative pin: sorter/ui/dialog_install_torch.py
+# reads it at runtime (that dialog is how PyTorch actually reaches a user's
+# venv), so bumping it here is the whole bump — and it keeps the versions
+# users really run visible to Renovate and vulnerability scanning, which a
+# constant in a .py file never was. One coupling to check when bumping: the
+# GPU build installs from a fixed CUDA index (_CUDA_INDEX in that dialog),
+# and each index only carries the torch versions built for it —
+# tests/integration/test_torch_wheel_index.py verifies the pair resolves.
+ml = ["torch==2.13.0", "torchvision==0.28.0"]
 
 [build-system]
 requires = ["hatchling==1.31.0", "hatch-vcs==0.5.0"]

--- a/src/sorter/ml/gpu_detect.py
+++ b/src/sorter/ml/gpu_detect.py
@@ -12,9 +12,14 @@ from __future__ import annotations
 import subprocess
 from dataclasses import dataclass
 
-# RTX 30-series (Ampere) is sm_80+ and is the first generation supported by
-# the cu128 wheel index. Older cards (Turing sm_75 and below) would need a
-# different wheel set and we don't support that flow.
+# Ampere (RTX 30-series, sm_80) and newer. This is a support floor, not a
+# wheel limitation: the cu129 wheels the install dialog uses bake in sm_75
+# (Turing) through sm_120 (Blackwell), so RTX 20-series cards *could* run
+# them — but Ampere+ is what gets validated on real hardware before a torch
+# bump lands (.github/renovate.json5's needs-hardware-test rule), and below
+# the floor the dialog offers the CPU build rather than an untested GPU one.
+# Lowering this for Turing is #67's call, made with hardware to test on —
+# not a comment edit.
 MIN_CUDA_COMPUTE = 8.0
 
 

--- a/src/sorter/ml/local_inference.py
+++ b/src/sorter/ml/local_inference.py
@@ -553,6 +553,66 @@ def is_installed() -> bool:
         return False
 
 
+# The oldest torch that may load a checkpoint this app did not produce.
+#
+# CVE-2026-24747 (GHSA-63cw-57p8-fm3p, fixed in torch 2.10.0): a crafted .pth
+# defeats the `weights_only=True` unpickler itself -- memory corruption, and
+# potentially code execution, from the very call `_load` relies on to make an
+# untrusted checkpoint safe (see the comment at that torch.load). Community
+# downloads and ZIP imports are exactly the delivery path, so a foreign model
+# on an older wheel is the one combination this app must refuse.
+#
+# Deliberately NOT derived from pyproject.toml's [ml] pin. The pin is "what a
+# fresh install gets" and moves on every routine bump; this is "below here the
+# safety property is gone", it moves only when a new advisory says so, and it
+# records which advisory. It also bounds any future opt-into-an-older-build
+# override (issue #67) -- and since it sits above the 2.3.0 floor where
+# torch.amp.GradScaler first appears, honouring it can't regress the trainer
+# onto the AttributeError that older wheels produce.
+MIN_TORCH_VERSION = "2.10.0"
+
+
+def installed_version() -> str | None:
+    """The installed torch's version string, *without* importing torch.
+
+    Reads distribution metadata, so it stays cheap enough for a button
+    handler -- same constraint as `is_installed()`. Returns None when torch
+    isn't installed, or is present with no metadata (a vendored or
+    source-built copy): callers must treat that as "unknown", not "old".
+    """
+    from importlib.metadata import PackageNotFoundError, version
+
+    try:
+        return version("torch")
+    except PackageNotFoundError:
+        return None
+    except Exception:
+        # Metadata can be malformed on a half-written install; unknown rather
+        # than a crash on the UI thread.
+        return None
+
+
+def meets_min_version(minimum: str = MIN_TORCH_VERSION) -> bool:
+    """Is the installed torch at or above `minimum`?
+
+    **Fails open** -- an unreadable or unparseable version returns True. A
+    version we cannot determine is far more likely to be a developer's source
+    build than an exploit attempt, and hard-blocking those installs would
+    break legitimate setups to guard against a case the metadata says nothing
+    about. The check is defence in depth over the pinned installer, not the
+    only thing standing between a user and CVE-2026-24747.
+    """
+    from packaging.version import InvalidVersion, Version
+
+    raw = installed_version()
+    if raw is None:
+        return True
+    try:
+        return Version(raw) >= Version(minimum)
+    except InvalidVersion:
+        return True
+
+
 def is_available() -> bool:
     """Does importing torch succeed?
 

--- a/src/sorter/ml/local_inference.py
+++ b/src/sorter/ml/local_inference.py
@@ -214,11 +214,19 @@ def _dump_environment(torch_mod: Any) -> None:
             except Exception as exc:
                 print(f"[env] matmul benchmark failed: {exc}", file=sys.stderr, flush=True)
 
-            # ConvNeXt-Tiny forward — same model class our classify uses.
-            # If this matches our 800+ ms classify time, the bottleneck is
-            # purely cuDNN / Blackwell conv kernels. If it's much faster,
-            # the issue is something in our pipeline (.to(device) walks,
-            # tensor strides, etc.).
+            # ConvNeXt-Tiny forward — same model class our classify uses, so
+            # comparing it against the [classify] forward time separates "the
+            # GPU/cuDNN path itself is slow" from "something in our pipeline
+            # is slow" (.to(device) walks, tensor strides, etc.).
+            #
+            # The reference number below is a real measurement, not a target:
+            # torch 2.13 + cu130 (cuDNN 9.20) on an RTX 5060 Ti (sm_120).
+            # It is quoted with its hardware and version because that is the
+            # only way it stays falsifiable — the previous note here predicted
+            # 30-80 ms/iter on sm_120, which was true of the torch 2.9.1 /
+            # earlier-cuDNN pin this app used to install and became wrong by
+            # more than an order of magnitude when that pin moved. Re-measure
+            # rather than trusting it after a torch bump.
             try:
                 # torchvision is the optional `[ml]` extra — genuinely absent
                 # from this dev/CI environment by design.
@@ -239,7 +247,8 @@ def _dump_environment(torch_mod: Any) -> None:
                 ms_per = (time.perf_counter() - t) * 1000.0 / iters
                 print(
                     f"[env] convnext_tiny_fp32_synthetic: {ms_per:.1f} ms/iter "
-                    f"(expected ~10-30 on sm_80+, 30-80 on sm_120 with cuDNN 9.x)",
+                    f"(~3 ms measured on sm_120 with torch 2.13 + cuDNN 9.20; "
+                    f"hundreds of ms means a PTX JIT fallback or a CPU device)",
                     file=sys.stderr,
                     flush=True,
                 )

--- a/src/sorter/ml/local_inference.py
+++ b/src/sorter/ml/local_inference.py
@@ -191,7 +191,8 @@ def _dump_environment(torch_mod: Any) -> None:
                 if not supported:
                     print(
                         f"[env] FIX: install a PyTorch build that bakes {sm_tag} "
-                        "in its arch list (e.g. the nightly cu128 build).",
+                        "in its arch list (a newer release, or a newer CUDA "
+                        "wheel index than the one it was installed from).",
                         file=sys.stderr,
                         flush=True,
                     )

--- a/src/sorter/ui/dialog_install_torch.py
+++ b/src/sorter/ui/dialog_install_torch.py
@@ -7,8 +7,9 @@ through `torch_gate.ensure_torch` rather than constructing it directly; pass
 wrong headline when the user just pressed Start on the Run tab.
 
 On open we detect a supported Nvidia GPU (compute capability ≥ 8.0). If one is
-present, the user gets to pick between the GPU build (CUDA 12.9 wheels) and the
-CPU build; otherwise only the CPU build is offered.
+present, the user gets to pick between the GPU build (CUDA 12.9 wheels on
+Linux, CUDA 13.0 on Windows) and the CPU build; otherwise only the CPU build
+is offered.
 
 `uv pip install --python <this interpreter>` runs in a subprocess and streams
 its output to the dialog's console. Prefers uv over `python -m pip` because a
@@ -45,18 +46,31 @@ from .theme import PALETTE
 # (`torch>=2.2`): the latest-at-install-time is a moving target and has been
 # observed to regress ConvNeXt inference on the RTX 50-series.
 #
-# Only the CUDA index for the GPU build is decided here. Why cu129 rather
-# than plain PyPI: each torch release ships on PyPI as a single build at that
+# Only the CUDA index for the GPU build is decided here, per OS. Why not
+# plain PyPI: each torch release ships there as a single build at that
 # release's default CUDA — for 2.13 that is CUDA 13, which needs an R580+
-# NVIDIA driver. The cu129 wheels cover the same cards (sm_75 Turing through
-# sm_120 Blackwell / RTX 50-series) but, being CUDA 12.x, run on any R525+
-# driver via CUDA 12 minor-version compatibility — a driver bar roughly three
-# years older. The index and the version are coupled: an index only carries
-# the torch versions actually built for it (cu129 carries 2.13; cu128 stopped
-# at 2.11), so a version bump in pyproject.toml must keep this index in
-# step — tests/integration/test_torch_wheel_index.py checks the pair
-# resolves before a user's install ever has to.
-_CUDA_INDEX = "https://download.pytorch.org/whl/cu129"
+# NVIDIA driver — and on Windows the PyPI wheel is CPU-only. Why two
+# indexes: upstream builds no Windows wheels at all for CUDA 12.9 (it is
+# Linux-only in pytorch's binary build matrix), so each OS gets the
+# lowest-driver-bar index that still covers every supported card:
+#
+#   linux — cu129: sm_75 (Turing) through sm_120 (Blackwell / RTX
+#     50-series), and CUDA 12.x minor-version compatibility means any R525+
+#     driver works — a driver bar roughly three years older than CUDA 13's.
+#   win32 — cu130: the only Windows index for current torch that bakes in
+#     sm_120; needs an R580+ driver. (Windows' CUDA-12.x alternative,
+#     cu126, stops at sm_90 and would drop the RTX 50-series.)
+#
+# The index and the version are coupled: an index only carries the torch
+# versions actually built for it (cu128 stopped at 2.11), so a version bump
+# in pyproject.toml must keep this table in step —
+# tests/integration/test_torch_wheel_index.py resolves every (pin, index,
+# platform) combination before a user's install ever has to.
+_CUDA_INDEX_BY_OS = {
+    "linux": "https://download.pytorch.org/whl/cu129",
+    "win32": "https://download.pytorch.org/whl/cu130",
+}
+_CUDA_INDEX = _CUDA_INDEX_BY_OS.get(sys.platform, _CUDA_INDEX_BY_OS["linux"])
 
 
 def ml_pin_targets() -> tuple[str, ...] | None:
@@ -76,7 +90,11 @@ def ml_pin_targets() -> tuple[str, ...] | None:
         if data["project"]["name"] != "ai-case-sorter":
             return None
         targets = data["project"]["optional-dependencies"]["ml"]
-    except (OSError, tomllib.TOMLDecodeError, KeyError, TypeError):
+    except (OSError, tomllib.TOMLDecodeError, UnicodeDecodeError, KeyError, TypeError):
+        # UnicodeDecodeError is spelled out because it is a sibling of
+        # TOMLDecodeError (both subclass ValueError), not covered by it:
+        # tomllib decodes the raw bytes itself, so a pyproject.toml re-saved
+        # in a non-UTF-8 editor raises it before parsing even starts.
         return None
     if not isinstance(targets, list) or not targets or not all(isinstance(t, str) for t in targets):
         return None

--- a/src/sorter/ui/dialog_install_torch.py
+++ b/src/sorter/ui/dialog_install_torch.py
@@ -7,7 +7,7 @@ through `torch_gate.ensure_torch` rather than constructing it directly; pass
 wrong headline when the user just pressed Start on the Run tab.
 
 On open we detect a supported Nvidia GPU (compute capability ≥ 8.0). If one is
-present, the user gets to pick between the GPU build (CUDA 12.8 wheels) and the
+present, the user gets to pick between the GPU build (CUDA 12.9 wheels) and the
 CPU build; otherwise only the CPU build is offered.
 
 `uv pip install --python <this interpreter>` runs in a subprocess and streams
@@ -27,20 +27,61 @@ import subprocess
 import sys
 import threading
 import tkinter as tk
+import tomllib
 from collections.abc import Callable
+from pathlib import Path
 from tkinter import ttk
 
 from ..ml.gpu_detect import GpuInfo, detect_supported_nvidia_gpu
 from ..paths import find_uv
 from .theme import PALETTE
 
-# Pin exactly the versions the legacy project validates against. Floating
-# versions (`torch>=2.2`) let pip pull the
-# latest — which is a moving target and has been observed to regress
-# ConvNeXt inference on the RTX 50-series.
-_TARGETS = ("torch==2.9.1", "torchvision==0.24.1")
-_CPU_TARGETS = _TARGETS
-_CUDA_INDEX = "https://download.pytorch.org/whl/cu128"
+# The torch/torchvision versions come from pyproject.toml's [ml] extra —
+# read at install time by ml_pin_targets() below, never duplicated here as a
+# constant. One declaration means Renovate and vulnerability scanners see the
+# pins users actually install, and a bump in pyproject.toml is the whole bump
+# (#67: the two copies had drifted apart, and the .py copy was invisible to
+# every scanner). The pins themselves stay exact rather than floating
+# (`torch>=2.2`): the latest-at-install-time is a moving target and has been
+# observed to regress ConvNeXt inference on the RTX 50-series.
+#
+# Only the CUDA index for the GPU build is decided here. Why cu129 rather
+# than plain PyPI: each torch release ships on PyPI as a single build at that
+# release's default CUDA — for 2.13 that is CUDA 13, which needs an R580+
+# NVIDIA driver. The cu129 wheels cover the same cards (sm_75 Turing through
+# sm_120 Blackwell / RTX 50-series) but, being CUDA 12.x, run on any R525+
+# driver via CUDA 12 minor-version compatibility — a driver bar roughly three
+# years older. The index and the version are coupled: an index only carries
+# the torch versions actually built for it (cu129 carries 2.13; cu128 stopped
+# at 2.11), so a version bump in pyproject.toml must keep this index in
+# step — tests/integration/test_torch_wheel_index.py checks the pair
+# resolves before a user's install ever has to.
+_CUDA_INDEX = "https://download.pytorch.org/whl/cu129"
+
+
+def ml_pin_targets() -> tuple[str, ...] | None:
+    """The exact requirement strings pyproject.toml's [ml] extra pins.
+
+    Resolved relative to this source tree — the app always runs from one
+    (see CLAUDE.md §2), so the versions installed at runtime can never
+    drift from the ones declared to dependency scanners. Returns None when
+    the file is missing or doesn't parse; that's a tree the launcher
+    couldn't have synced either, so the caller reports it instead of
+    guessing at a version.
+    """
+    path = Path(__file__).resolve().parents[3] / "pyproject.toml"
+    try:
+        with path.open("rb") as fh:
+            data = tomllib.load(fh)
+        if data["project"]["name"] != "ai-case-sorter":
+            return None
+        targets = data["project"]["optional-dependencies"]["ml"]
+    except (OSError, tomllib.TOMLDecodeError, KeyError, TypeError):
+        return None
+    if not isinstance(targets, list) or not targets or not all(isinstance(t, str) for t in targets):
+        return None
+    return tuple(targets)
+
 
 # Shown when the caller doesn't name the action. Deliberately generic: this
 # dialog now fronts inference as well as training.
@@ -196,6 +237,18 @@ class TorchInstallDialog(tk.Toplevel):
         active_btn = self.gpu_btn if (use_gpu and self._gpu is not None) else self.cpu_btn
         active_btn.config(text="Installing…")
 
+        targets = ml_pin_targets()
+        if targets is None:
+            self._append(
+                "Could not read the pinned PyTorch version from pyproject.toml "
+                "(expected next to bootstrap.py, at the top of the app folder). "
+                "The install can't proceed without it — restart via "
+                "start.sh/start.bat, or reinstall the app if the file is "
+                "really gone.\n"
+            )
+            self._finish(success=False)
+            return
+
         # uv first, because a uv-managed venv (the launcher's default) has no
         # pip in it at all. But a plain `python -m venv` + `pip install -e .`
         # checkout is a documented way to run this app, and there uv may
@@ -203,10 +256,10 @@ class TorchInstallDialog(tk.Toplevel):
         # rather than refusing to install. Only give up if neither exists.
         uv = find_uv()
         if uv is not None:
-            cmd: list[str] = [uv, "pip", "install", "--python", sys.executable, *list(_CPU_TARGETS)]
+            cmd: list[str] = [uv, "pip", "install", "--python", sys.executable, *targets]
         elif importlib.util.find_spec("pip") is not None:
             self._append("uv not found; falling back to pip in the running interpreter.\n")
-            cmd = [sys.executable, "-u", "-m", "pip", "install", *list(_CPU_TARGETS)]
+            cmd = [sys.executable, "-u", "-m", "pip", "install", *targets]
         else:
             self._append(
                 "Could not find uv or pip. uv should have been installed by "

--- a/src/sorter/ui/dialog_model_evaluator.py
+++ b/src/sorter/ui/dialog_model_evaluator.py
@@ -417,6 +417,7 @@ class ModelEvaluatorDialog(tk.Toplevel):
             self,
             self._run,
             reason="Evaluating needs PyTorch",
+            model=self.model,
         ):
             return
 

--- a/src/sorter/ui/tab_run.py
+++ b/src/sorter/ui/tab_run.py
@@ -1657,6 +1657,7 @@ class RunTab(ttk.Frame):
             self,
             self._toggle_run,
             reason="Sorting needs PyTorch",
+            model=classifier.active_model(self.app.db),
         ):
             return
         self._begin_wish_list_fetch(controller)
@@ -1686,6 +1687,7 @@ class RunTab(ttk.Frame):
             self,
             self._manual_feed,
             reason="Sorting needs PyTorch",
+            model=classifier.active_model(self.app.db),
         ):
             return
         self.app.run_worker(controller.cycle_once)

--- a/src/sorter/ui/tab_train.py
+++ b/src/sorter/ui/tab_train.py
@@ -321,7 +321,7 @@ class TrainTab(ttk.Frame):
         # normal path here, not an error.
         if not classifier.has_local_checkpoint(active):
             return True
-        if local_inference.is_installed():
+        if local_inference.is_installed() and local_inference.meets_min_version():
             return True
         self._torch_prompt_shown = True
         resume = lambda: self._feed(sort_label=sort_label)  # noqa: E731
@@ -330,6 +330,7 @@ class TrainTab(ttk.Frame):
             resume,
             reason="Predicting labels needs PyTorch",
             on_cancel=resume,
+            model=active,
         )
 
     def _feed(self, sort_label: str | None = None) -> None:
@@ -560,6 +561,7 @@ class TrainTab(ttk.Frame):
             self,
             self._start_training,
             reason="Training needs PyTorch",
+            model=m,
         ):
             return
 

--- a/src/sorter/ui/torch_gate.py
+++ b/src/sorter/ui/torch_gate.py
@@ -24,6 +24,19 @@ Passing the caller itself as `proceed` is the point: the gate re-runs on the
 second pass, finds torch present, and falls through to the work. Nothing has
 to be factored out into a continuation.
 
+A second rule sits on top of presence, and it is a security floor rather than
+a capability one: **a model that came from somewhere else may not be loaded by
+a torch below `local_inference.MIN_TORCH_VERSION`.** CVE-2026-24747 lets a
+crafted `.pth` defeat the `weights_only=True` unpickler that `_load` relies on
+to make an untrusted checkpoint safe, so for a community download or a ZIP
+import the gate blocks until the user upgrades. For a model the user trained
+here the upgrade is *offered* and declining is remembered for the session —
+their own checkpoint is not an attack, and a multi-GB download should not
+stand between them and sorting their own brass.
+
+That asymmetry is why callers pass `model`: the gate decides block-vs-offer
+from `models.is_foreign_model`, so no call site has to encode the policy.
+
 Must be called on the Tk main thread (it may open a modal) — so from button
 handlers and event callbacks, never from inside `run_worker`.
 """
@@ -33,8 +46,20 @@ from __future__ import annotations
 import tkinter as tk
 from collections.abc import Callable
 
+from ..data.models import Model, is_foreign_model
 from ..ml import local_inference
 from .dialog_install_torch import TorchInstallDialog
+
+# Set when the user declines the *optional* upgrade offer, so their own-model
+# workflow is interrupted once per session rather than on every Start. Never
+# consulted for a foreign model -- that path has no "not now".
+_upgrade_declined = False
+
+
+def reset_upgrade_prompt() -> None:
+    """Forget a declined upgrade offer (test seam; also correct after an install)."""
+    global _upgrade_declined
+    _upgrade_declined = False
 
 
 def ensure_torch(
@@ -43,25 +68,81 @@ def ensure_torch(
     *,
     reason: str | None = None,
     on_cancel: Callable[[], None] | None = None,
+    model: Model | None = None,
 ) -> bool:
-    """Gate a local-model action on PyTorch being installed.
+    """Gate a local-model action on PyTorch being installed and safe to use.
 
-    Returns True when torch is already there and the caller should carry
-    straight on.
+    Returns True when the caller should carry straight on.
 
-    Returns False when it isn't: the install dialog is now open, and `proceed`
-    will be called if and only if the install succeeds. The caller must return
-    immediately and do nothing else — the user may still cancel.
+    Returns False when it should not: the install dialog is now open, and
+    `proceed` will be called if and only if the install succeeds. The caller
+    must return immediately and do nothing else — the user may still cancel.
 
-    Uses `is_installed()` (a `find_spec` probe), not `is_available()`, so this
-    never imports torch on the UI thread.
+    `model` is the model the action will load, and it selects the policy for
+    an installed-but-outdated torch (see the module docstring): foreign models
+    block, own models get a once-per-session offer that proceeds on decline.
+    Omitting it is the conservative choice — an unknown provenance is treated
+    as foreign.
+
+    Uses `is_installed()` (a `find_spec` probe) and distribution metadata, not
+    `is_available()`, so this never imports torch on the UI thread.
     """
-    if local_inference.is_installed():
+    global _upgrade_declined
+
+    def _upgraded() -> None:
+        # Any completed install clears the decline: whatever the user was
+        # putting off, they have now done it. Leaving the flag set would
+        # outlive the condition it describes.
+        reset_upgrade_prompt()
+        proceed()
+
+    if not local_inference.is_installed():
+        TorchInstallDialog(
+            parent,
+            on_success=_upgraded,
+            on_cancel=on_cancel,
+            reason=reason,
+        )
+        return False
+
+    if local_inference.meets_min_version():
         return True
+
+    have = local_inference.installed_version() or "an older version"
+    if model is None or is_foreign_model(model):
+        # Blocking: this checkpoint is someone else's, and on this torch
+        # weights_only=True is not the protection the loader assumes it is.
+        TorchInstallDialog(
+            parent,
+            on_success=_upgraded,
+            on_cancel=on_cancel,
+            reason=(
+                f"Update PyTorch to use this model — you have {have}, and "
+                f"loading a downloaded or imported model needs "
+                f"{local_inference.MIN_TORCH_VERSION} or newer (security fix)"
+            ),
+        )
+        return False
+
+    if _upgrade_declined:
+        return True
+
+    def _decline() -> None:
+        global _upgrade_declined
+        _upgrade_declined = True
+        if on_cancel is not None:
+            on_cancel()
+        else:
+            proceed()
+
     TorchInstallDialog(
         parent,
-        on_success=proceed,
-        on_cancel=on_cancel,
-        reason=reason,
+        on_success=_upgraded,
+        on_cancel=_decline,
+        reason=(
+            f"A PyTorch update is available — you have {have}. "
+            f"{local_inference.MIN_TORCH_VERSION} or newer is required before "
+            f"loading models from the community, and fixes a security issue"
+        ),
     )
     return False

--- a/tests/integration/test_torch_wheel_index.py
+++ b/tests/integration/test_torch_wheel_index.py
@@ -1,0 +1,60 @@
+"""The (torch version, CUDA index) pair the install dialog uses must resolve.
+
+The GPU build installs pyproject.toml's [ml] pins from a fixed CUDA wheel
+index (dialog_install_torch._CUDA_INDEX), and an index only carries the
+torch versions actually built for it — cu128 stopped at torch 2.11, so
+bumping the pin without moving the index would produce a 404 at install
+time, on the user's machine, with nothing catching it earlier (#67). This
+resolves each pinned version against the pinned index so that class of bump
+fails in CI instead.
+
+Needs the network: skips when download.pytorch.org can't be reached, the
+same way the other integration tests skip when their external tool is
+missing. A reachable index that lacks the pinned version is a hard fail —
+that's the bug this file exists to catch.
+"""
+
+from __future__ import annotations
+
+from urllib.parse import unquote
+
+import pytest
+import requests
+
+pytest.importorskip("tkinter")  # dialog_install_torch imports tkinter at module level
+
+from sorter.ui.dialog_install_torch import _CUDA_INDEX, ml_pin_targets
+
+pytestmark = [
+    pytest.mark.integration,
+]
+
+
+def _fetch_project_page(name: str) -> str:
+    """The PEP 503 listing for one package on the pinned index, unquoted so
+    wheel names read as `torch-2.13.0+cu129-...` rather than `%2B`-escaped."""
+    url = f"{_CUDA_INDEX}/{name}/"
+    try:
+        resp = requests.get(url, timeout=30)
+    except requests.RequestException as exc:
+        pytest.skip(f"no network access to {url}: {exc}")
+    if resp.status_code >= 500:
+        pytest.skip(f"{url} answered {resp.status_code} — index unavailable, not a pin problem")
+    assert resp.status_code == 200, f"{url} answered {resp.status_code} — wrong index URL or package path"
+    return unquote(resp.text)
+
+
+def test_pinned_versions_exist_on_the_cuda_index() -> None:
+    targets = ml_pin_targets()
+    assert targets is not None, "pyproject.toml's [ml] extra did not resolve"
+    for target in targets:
+        name, _, version = target.partition("==")
+        page = _fetch_project_page(name)
+        # A wheel name continues with either `+<local build tag>` or the
+        # `-<python tag>` separator, so match both; a bare substring check
+        # would also accept e.g. 2.13.0.post1 standing in for 2.13.0.
+        assert f"{name}-{version}+" in page or f"{name}-{version}-" in page, (
+            f"{name}=={version} has no build on {_CUDA_INDEX} — the [ml] pin in "
+            f"pyproject.toml and _CUDA_INDEX in dialog_install_torch.py have "
+            f"moved out of step"
+        )

--- a/tests/integration/test_torch_wheel_index.py
+++ b/tests/integration/test_torch_wheel_index.py
@@ -1,21 +1,23 @@
-"""The (torch version, CUDA index) pair the install dialog uses must resolve.
+"""Every (torch pin, CUDA index, platform) the install dialog can use must resolve.
 
-The GPU build installs pyproject.toml's [ml] pins from a fixed CUDA wheel
-index (dialog_install_torch._CUDA_INDEX), and an index only carries the
-torch versions actually built for it — cu128 stopped at torch 2.11, so
-bumping the pin without moving the index would produce a 404 at install
-time, on the user's machine, with nothing catching it earlier (#67). This
-resolves each pinned version against the pinned index so that class of bump
-fails in CI instead.
+The GPU build installs pyproject.toml's [ml] pins from a per-OS CUDA wheel
+index (dialog_install_torch._CUDA_INDEX_BY_OS), and an index only carries
+the torch versions actually built for it — cu128 stopped at torch 2.11, and
+CUDA 12.9 wheels were never built for Windows at all — so bumping the pin
+without checking the indexes would produce "no matching distribution" at
+install time, on the user's machine, with nothing catching it earlier (#67).
+This resolves each pinned version against each index and requires a wheel
+for that index's platform, so that class of bump fails in CI instead.
 
-Needs the network: skips when download.pytorch.org can't be reached, the
-same way the other integration tests skip when their external tool is
-missing. A reachable index that lacks the pinned version is a hard fail —
-that's the bug this file exists to catch.
+Needs the network: skips when download.pytorch.org can't be reached or is
+rate-limiting, the same way the other integration tests skip when their
+external tool is missing. A reachable index that lacks the pinned version
+for its platform is a hard fail — that's the bug this file exists to catch.
 """
 
 from __future__ import annotations
 
+import re
 from urllib.parse import unquote
 
 import pytest
@@ -23,38 +25,50 @@ import requests
 
 pytest.importorskip("tkinter")  # dialog_install_torch imports tkinter at module level
 
-from sorter.ui.dialog_install_torch import _CUDA_INDEX, ml_pin_targets
+from sorter.ui.dialog_install_torch import _CUDA_INDEX_BY_OS, ml_pin_targets
 
 pytestmark = [
     pytest.mark.integration,
 ]
 
+# The wheel platform tag that proves "this OS can install from its index".
+# The GPU flow only ever runs where nvidia-smi exists, i.e. these two.
+_PLATFORM_TAG = {"linux": "linux", "win32": "win_amd64"}
 
-def _fetch_project_page(name: str) -> str:
-    """The PEP 503 listing for one package on the pinned index, unquoted so
-    wheel names read as `torch-2.13.0+cu129-...` rather than `%2B`-escaped."""
-    url = f"{_CUDA_INDEX}/{name}/"
+
+def _fetch_project_page(index: str, name: str) -> str:
+    """The PEP 503 listing for one package on one index, unquoted so wheel
+    names read as `torch-2.13.0+cu129-...` rather than `%2B`-escaped."""
+    url = f"{index}/{name}/"
     try:
         resp = requests.get(url, timeout=30)
     except requests.RequestException as exc:
         pytest.skip(f"no network access to {url}: {exc}")
-    if resp.status_code >= 500:
+    if resp.status_code in (403, 429) or resp.status_code >= 500:
+        # CloudFront rate limits and interception proxies answer with these;
+        # neither says anything about the pins. A 404 stays a hard fail
+        # below — that IS the wrong-index / wrong-package signal.
         pytest.skip(f"{url} answered {resp.status_code} — index unavailable, not a pin problem")
     assert resp.status_code == 200, f"{url} answered {resp.status_code} — wrong index URL or package path"
     return unquote(resp.text)
 
 
-def test_pinned_versions_exist_on_the_cuda_index() -> None:
+@pytest.mark.parametrize("os_key", sorted(_CUDA_INDEX_BY_OS))
+def test_pinned_versions_exist_on_each_cuda_index(os_key: str) -> None:
     targets = ml_pin_targets()
     assert targets is not None, "pyproject.toml's [ml] extra did not resolve"
+    index = _CUDA_INDEX_BY_OS[os_key]
+    tag = _PLATFORM_TAG[os_key]
     for target in targets:
         name, _, version = target.partition("==")
-        page = _fetch_project_page(name)
-        # A wheel name continues with either `+<local build tag>` or the
-        # `-<python tag>` separator, so match both; a bare substring check
-        # would also accept e.g. 2.13.0.post1 standing in for 2.13.0.
-        assert f"{name}-{version}+" in page or f"{name}-{version}-" in page, (
-            f"{name}=={version} has no build on {_CUDA_INDEX} — the [ml] pin in "
-            f"pyproject.toml and _CUDA_INDEX in dialog_install_torch.py have "
-            f"moved out of step"
+        page = _fetch_project_page(index, name)
+        # Wheel filenames for the pinned version, whatever local build tag
+        # they carry. Presence of *a* build isn't enough — an index can list
+        # Linux wheels for a version it never built on Windows (cu129 does
+        # exactly that), so the platform this index serves must have one.
+        wheels = re.findall(rf"{re.escape(name)}-{re.escape(version)}[+-][^\s\"'<>]*?\.whl", page)
+        assert any(tag in wheel for wheel in wheels), (
+            f"{name}=={version} has no {tag} build on {index} — the [ml] pin in "
+            f"pyproject.toml and _CUDA_INDEX_BY_OS in dialog_install_torch.py "
+            f"have moved out of step"
         )

--- a/tests/unit/ui/test_dialog_install_torch.py
+++ b/tests/unit/ui/test_dialog_install_torch.py
@@ -115,6 +115,14 @@ def test_pin_targets_none_when_pyproject_missing_or_foreign(tmp_path, monkeypatc
     (tmp_path / "pyproject.toml").write_text('[project]\nname = "someone-elses-app"\n', encoding="utf-8")
     assert dialog_install_torch.ml_pin_targets() is None
 
+    # A pyproject.toml re-saved in a non-UTF-8 encoding. tomllib decodes the
+    # raw bytes itself and raises UnicodeDecodeError — a ValueError sibling
+    # of TOMLDecodeError, not a subclass — and the real file's comments are
+    # full of em dashes (0x97 in cp1252), so a hand-edit in a legacy-encoding
+    # editor produces exactly this. Must be None, not an escaping exception.
+    (tmp_path / "pyproject.toml").write_bytes('[project]\nname = "ai-case-sorter"  # em — dash\n'.encode("cp1252"))
+    assert dialog_install_torch.ml_pin_targets() is None
+
     # The real shape resolves.
     (tmp_path / "pyproject.toml").write_text(
         '[project]\nname = "ai-case-sorter"\n'
@@ -122,6 +130,15 @@ def test_pin_targets_none_when_pyproject_missing_or_foreign(tmp_path, monkeypatc
         encoding="utf-8",
     )
     assert dialog_install_torch.ml_pin_targets() == ("torch==9.9.9", "torchvision==9.9.9")
+
+
+def test_cuda_index_covers_both_gpu_platforms() -> None:
+    """The GPU flow only runs where nvidia-smi exists — Linux and Windows —
+    and each needs its own index: upstream builds no Windows wheels for CUDA
+    12.9, so a single shared index would strand one platform or the other.
+    The active index must come from that table, never a third value."""
+    assert set(dialog_install_torch._CUDA_INDEX_BY_OS) == {"linux", "win32"}
+    assert dialog_install_torch._CUDA_INDEX in dialog_install_torch._CUDA_INDEX_BY_OS.values()
 
 
 def test_install_without_pins_fails_without_spawning_a_process(root, monkeypatch) -> None:

--- a/tests/unit/ui/test_dialog_install_torch.py
+++ b/tests/unit/ui/test_dialog_install_torch.py
@@ -5,8 +5,11 @@ display; skips cleanly without one."""
 from __future__ import annotations
 
 import importlib.util
+import re
 import subprocess
 import threading
+import tomllib
+from pathlib import Path
 
 import pytest
 
@@ -16,6 +19,12 @@ import tkinter as tk
 
 from sorter.ui import dialog_install_torch
 from sorter.ui.dialog_install_torch import TorchInstallDialog
+
+# Derived from this test file's own location, deliberately NOT from
+# dialog_install_torch.__file__ — an independent path to the same
+# pyproject.toml is what lets these tests catch a wrong-depth resolve
+# in ml_pin_targets() instead of repeating it.
+REPO_ROOT = Path(__file__).resolve().parents[3]
 
 
 @pytest.fixture
@@ -71,6 +80,63 @@ def test_install_uses_uv_pip_not_bare_pip(root, monkeypatch) -> None:
     assert cmd[1:3] == ["pip", "install"]
     assert "--python" in cmd
     assert "-m" not in cmd
+    dlg.destroy()
+
+
+def test_pin_targets_resolve_from_pyproject() -> None:
+    """The runtime install targets ARE pyproject.toml's [ml] extra — one
+    source of truth (#67). A wrong-depth path resolve or a parse regression
+    in ml_pin_targets() shows up here as a mismatch against the real file."""
+    with (REPO_ROOT / "pyproject.toml").open("rb") as fh:
+        expected = tuple(tomllib.load(fh)["project"]["optional-dependencies"]["ml"])
+    assert dialog_install_torch.ml_pin_targets() == expected
+
+
+def test_ml_extra_is_exact_torch_pins() -> None:
+    """The [ml] entries go verbatim onto a pip/uv command line, so they must
+    stay exact `==` pins: a floating spec would reintroduce the
+    latest-at-install-time moving target the pins exist to prevent."""
+    targets = dialog_install_torch.ml_pin_targets()
+    assert targets is not None
+    assert [t.partition("==")[0] for t in targets] == ["torch", "torchvision"]
+    for target in targets:
+        assert re.fullmatch(r"[A-Za-z0-9_.-]+==[0-9][0-9A-Za-z.]*", target), target
+
+
+def test_pin_targets_none_when_pyproject_missing_or_foreign(tmp_path, monkeypatch) -> None:
+    fake_module = tmp_path / "src" / "sorter" / "ui" / "dialog_install_torch.py"
+    fake_module.parent.mkdir(parents=True)
+    monkeypatch.setattr(dialog_install_torch, "__file__", str(fake_module))
+
+    # No pyproject.toml at the tree root at all.
+    assert dialog_install_torch.ml_pin_targets() is None
+
+    # A pyproject.toml belonging to some other project entirely.
+    (tmp_path / "pyproject.toml").write_text('[project]\nname = "someone-elses-app"\n', encoding="utf-8")
+    assert dialog_install_torch.ml_pin_targets() is None
+
+    # The real shape resolves.
+    (tmp_path / "pyproject.toml").write_text(
+        '[project]\nname = "ai-case-sorter"\n'
+        '[project.optional-dependencies]\nml = ["torch==9.9.9", "torchvision==9.9.9"]\n',
+        encoding="utf-8",
+    )
+    assert dialog_install_torch.ml_pin_targets() == ("torch==9.9.9", "torchvision==9.9.9")
+
+
+def test_install_without_pins_fails_without_spawning_a_process(root, monkeypatch) -> None:
+    """An unreadable pyproject.toml must surface as a console message, not as
+    an install of some guessed version."""
+    monkeypatch.setattr(dialog_install_torch, "ml_pin_targets", lambda: None)
+    spawn_attempted = []
+    monkeypatch.setattr(subprocess, "Popen", lambda *_a, **_k: spawn_attempted.append(1))
+
+    dlg = TorchInstallDialog(root)
+    dlg._start_install(use_gpu=False)
+
+    assert not spawn_attempted
+    assert dlg._installing is False
+    assert "pyproject.toml" in dlg.console.get("1.0", tk.END)
     dlg.destroy()
 
 

--- a/tests/unit/ui/test_torch_gate.py
+++ b/tests/unit/ui/test_torch_gate.py
@@ -229,3 +229,123 @@ def test_cancelling_the_install_does_not_run_the_action(
     if dialog.on_cancel is not None:
         dialog.on_cancel()
     assert ran == []
+
+
+# ----- the security floor ---------------------------------------------------
+# CVE-2026-24747: on torch < 2.10.0 a crafted .pth defeats the
+# weights_only=True unpickler that _load relies on, so a checkpoint from
+# someone else must not be loaded on an older wheel.
+
+
+@pytest.fixture(autouse=True)
+def _forget_declined_upgrade():
+    """The declined-offer memory is module state; isolate every test from it."""
+    torch_gate.reset_upgrade_prompt()
+    yield
+    torch_gate.reset_upgrade_prompt()
+
+
+@pytest.mark.parametrize(
+    ("installed", "expected"),
+    [
+        ("2.9.1", False),  # the version this repo shipped before the bump
+        ("2.2.0", False),
+        ("2.10.0", True),  # exactly the floor
+        ("2.13.0", True),
+        ("2.13.0+cu129", True),  # a wheel-index build carries a local version
+    ],
+)
+def test_meets_min_version(monkeypatch, installed: str, expected: bool) -> None:
+    monkeypatch.setattr(local_inference, "installed_version", lambda: installed)
+    assert local_inference.meets_min_version() is expected
+
+
+def test_min_version_fails_open_when_the_version_is_unknowable(monkeypatch) -> None:
+    """A torch with no readable metadata is a source build far more often than
+    an attack, and hard-blocking it would break legitimate setups."""
+    monkeypatch.setattr(local_inference, "installed_version", lambda: None)
+    assert local_inference.meets_min_version() is True
+    monkeypatch.setattr(local_inference, "installed_version", lambda: "not-a-version")
+    assert local_inference.meets_min_version() is True
+
+
+def _foreign() -> Model:
+    return Model(name="Community", model_type="CommunityManaged")
+
+
+def _own() -> Model:
+    return Model(name="Mine", model_type="Standard")
+
+
+@pytest.fixture
+def _outdated_torch(monkeypatch):
+    monkeypatch.setattr(torch_gate.local_inference, "is_installed", lambda: True)
+    monkeypatch.setattr(torch_gate.local_inference, "meets_min_version", lambda: False)
+    monkeypatch.setattr(torch_gate.local_inference, "installed_version", lambda: "2.9.1")
+
+
+def test_foreign_model_on_an_outdated_torch_is_blocked(_outdated_torch, fake_dialog) -> None:
+    ran = []
+    assert torch_gate.ensure_torch(_NO_PARENT, lambda: ran.append("proceed"), model=_foreign()) is False
+    assert ran == []
+    assert len(fake_dialog.instances) == 1
+    # And declining does NOT let it through -- there is no "not now" here.
+    dialog = fake_dialog.instances[0]
+    if dialog.on_cancel is not None:
+        dialog.on_cancel()
+    assert ran == []
+    assert torch_gate.ensure_torch(_NO_PARENT, lambda: ran.append("proceed"), model=_foreign()) is False
+    assert ran == []
+
+
+def test_unknown_provenance_is_treated_as_foreign(_outdated_torch, fake_dialog) -> None:
+    """Omitting `model` must take the conservative branch, not the lenient one."""
+    ran = []
+    assert torch_gate.ensure_torch(_NO_PARENT, lambda: ran.append("proceed")) is False
+    assert ran == []
+
+
+def test_own_model_on_an_outdated_torch_is_offered_not_blocked(_outdated_torch, fake_dialog) -> None:
+    """The user's own checkpoint is not an attack: offer the upgrade, but let
+    them decline and carry on sorting."""
+    ran = []
+    assert torch_gate.ensure_torch(_NO_PARENT, lambda: ran.append("proceed"), model=_own()) is False
+    assert ran == []
+    fake_dialog.instances[0].on_cancel()
+    assert ran == ["proceed"]
+
+
+def test_a_declined_upgrade_is_remembered_for_the_session(_outdated_torch, fake_dialog) -> None:
+    ran = []
+    torch_gate.ensure_torch(_NO_PARENT, lambda: ran.append("first"), model=_own())
+    fake_dialog.instances[0].on_cancel()
+    # Second action: straight through, no second prompt.
+    assert torch_gate.ensure_torch(_NO_PARENT, lambda: ran.append("second"), model=_own()) is True
+    assert len(fake_dialog.instances) == 1
+
+
+def test_declining_for_an_own_model_still_blocks_a_foreign_one(_outdated_torch, fake_dialog) -> None:
+    """The session-level 'not now' must not become a way to load community
+    models on a vulnerable torch."""
+    torch_gate.ensure_torch(_NO_PARENT, lambda: None, model=_own())
+    fake_dialog.instances[0].on_cancel()
+    ran = []
+    assert torch_gate.ensure_torch(_NO_PARENT, lambda: ran.append("proceed"), model=_foreign()) is False
+    assert ran == []
+
+
+def test_a_completed_upgrade_clears_the_declined_memory(_outdated_torch, fake_dialog) -> None:
+    ran = []
+    torch_gate.ensure_torch(_NO_PARENT, lambda: ran.append("proceed"), model=_own())
+    fake_dialog.instances[0].on_cancel()
+    assert torch_gate._upgrade_declined is True
+    torch_gate.ensure_torch(_NO_PARENT, lambda: None, model=_foreign())
+    fake_dialog.instances[-1].on_success()  # the install finished
+    assert torch_gate._upgrade_declined is False
+
+
+def test_a_current_torch_never_prompts(monkeypatch, fake_dialog) -> None:
+    monkeypatch.setattr(torch_gate.local_inference, "is_installed", lambda: True)
+    monkeypatch.setattr(torch_gate.local_inference, "meets_min_version", lambda: True)
+    assert torch_gate.ensure_torch(_NO_PARENT, lambda: None, model=_foreign()) is True
+    assert fake_dialog.instances == []

--- a/uv.lock
+++ b/uv.lock
@@ -43,8 +43,8 @@ requires-dist = [
     { name = "pyserial", specifier = "==3.5" },
     { name = "requests", specifier = "==2.34.2" },
     { name = "sqlite-utils", specifier = "==4.1.1" },
-    { name = "torch", marker = "extra == 'ml'", specifier = "==2.9.1" },
-    { name = "torchvision", marker = "extra == 'ml'", specifier = "==0.24.1" },
+    { name = "torch", marker = "extra == 'ml'", specifier = "==2.13.0" },
+    { name = "torchvision", marker = "extra == 'ml'", specifier = "==0.28.0" },
 ]
 provides-extras = ["ml"]
 
@@ -303,6 +303,81 @@ wheels = [
 ]
 
 [[package]]
+name = "cuda-bindings"
+version = "13.3.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "cuda-pathfinder" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/67/5e7dba1ba576dd73da5dee894ca076ca5e959450dfff66d6d510a255d1f7/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c7855c4868aabc0cfae28abbe83d56734bdfbd08f08fc234ac1912a12858bf49", size = 6025351, upload-time = "2026-05-29T23:11:49.685Z" },
+    { url = "https://files.pythonhosted.org/packages/39/2a/6d2e9047d1fb243dbaa364b01e0297534b9ed7fd27dba1c9f361519cf69b/cuda_bindings-13.3.1-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:e32d08f71ebcdf00f0f41eab2eb37e8da94c8ed411cc9f7f7a019ce6b34abe3a", size = 6657965, upload-time = "2026-05-29T23:11:52.227Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6e/2394f8163360f8391f8f1b7e72d300a82724edb81a7b7084c799fbd4c91f/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9efb21c1ee64981e184b9e0ba5eb3179e5ba3d4b51665a6cb52b8ef3d01a7cbf", size = 5920504, upload-time = "2026-05-29T23:11:56.883Z" },
+    { url = "https://files.pythonhosted.org/packages/34/c2/ef9b6a63f7dc432712a462c816662e662e00d38caa9b861c8c2588195d03/cuda_bindings-13.3.1-cp313-cp313-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2732904099e0a4d4db774a5fc6d91ee95fae065b4d2ecabb4968c5fe2406c9d7", size = 6476660, upload-time = "2026-05-29T23:11:59.188Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/81/bff68ce829999c1e4209c761bbf903b1c06ec570416ddb25020864ad5907/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:1ab2f74ed65bfef4163ba07a8db16f1085e0729291db12a2423aff84ee8278b8", size = 6013639, upload-time = "2026-05-29T23:12:03.509Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/e0/c8a1f0c8f9ffdea4f5fe6dbab89b326cef4d85caf489dad39e209da89416/cuda_bindings-13.3.1-cp314-cp314-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:efd4c814d311ec08c981f6dded1dbe7d4b371067ee4f6c14cccec4bde9590f80", size = 6534419, upload-time = "2026-05-29T23:12:05.633Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b8/83b1f563925b290f2d11a01a77a84013ba56052fe3653a5bef3ccfbb43d6/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c3c772dfff49681541d59630c90f858e173ac926b9c593a2b7123f2a1043cc76", size = 5809771, upload-time = "2026-05-29T23:12:10.422Z" },
+    { url = "https://files.pythonhosted.org/packages/12/20/e79b4bfe98f075195afb6343d41c498f9dbd2d161d7021d4d28bceb83581/cuda_bindings-13.3.1-cp314-cp314t-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:36febb7c1079d68a981dbbd8d5a67235b399802b82075c9388624719607e52b9", size = 6358584, upload-time = "2026-05-29T23:12:12.767Z" },
+]
+
+[[package]]
+name = "cuda-pathfinder"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fc/b4/d088047afe39827556df21118cac9ffd20cc3f968c99a7681494d1eb333c/cuda_pathfinder-1.6.0-py3-none-any.whl", hash = "sha256:1503af579d8379c24bdd65528379bc57039b0455be9f5f9686cf8e473a1fce51", size = 54591, upload-time = "2026-07-21T15:03:56.224Z" },
+]
+
+[[package]]
+name = "cuda-toolkit"
+version = "13.0.3.0"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/c7/a79086a62c98befcdb8349656c6f114e2db3b8b2422f6e25c97a7f2a9a3c/cuda_toolkit-13.0.3.0-py2.py3-none-any.whl", hash = "sha256:d693caaa261214ddd7dbb60d68e71cbed884e68c2be7509778f3051da0b91c3f", size = 2512, upload-time = "2026-04-14T00:50:08.173Z" },
+]
+
+[package.optional-dependencies]
+cublas = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cudart = [
+    { name = "nvidia-cuda-runtime", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cufft = [
+    { name = "nvidia-cufft", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cufile = [
+    { name = "nvidia-cufile", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux')" },
+]
+cupti = [
+    { name = "nvidia-cuda-cupti", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+curand = [
+    { name = "nvidia-curand", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cusolver = [
+    { name = "nvidia-cublas", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusolver", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+cusparse = [
+    { name = "nvidia-cusparse", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvjitlink = [
+    { name = "nvidia-nvjitlink", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvrtc = [
+    { name = "nvidia-cuda-nvrtc", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+nvtx = [
+    { name = "nvidia-nvtx", marker = "(platform_machine == 'aarch64' and sys_platform == 'linux') or (platform_machine == 'x86_64' and sys_platform == 'linux') or (platform_machine == 'AMD64' and sys_platform == 'win32')" },
+]
+
+[[package]]
 name = "filelock"
 version = "3.32.2"
 source = { registry = "https://pypi.org/simple" }
@@ -519,137 +594,155 @@ wheels = [
 ]
 
 [[package]]
-name = "nvidia-cublas-cu12"
-version = "12.8.4.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/61/e24b560ab2e2eaeb3c839129175fb330dfcfc29e5203196e5541a4c44682/nvidia_cublas_cu12-12.8.4.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:8ac4e771d5a348c551b2a426eda6193c19aa630236b418086020df5ba9667142", size = 594346921, upload-time = "2025-03-07T01:44:31.254Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-cupti-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/02/2adcaa145158bf1a8295d83591d22e4103dbfd821bcaf6f3f53151ca4ffa/nvidia_cuda_cupti_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ea0cb07ebda26bb9b29ba82cda34849e73c166c18162d3913575b0c9db9a6182", size = 10248621, upload-time = "2025-03-07T01:40:21.213Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-nvrtc-cu12"
-version = "12.8.93"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/05/6b/32f747947df2da6994e999492ab306a903659555dddc0fbdeb9d71f75e52/nvidia_cuda_nvrtc_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:a7756528852ef889772a84c6cd89d41dfa74667e24cca16bb31f8f061e3e9994", size = 88040029, upload-time = "2025-03-07T01:42:13.562Z" },
-]
-
-[[package]]
-name = "nvidia-cuda-runtime-cu12"
-version = "12.8.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/0d/9b/a997b638fcd068ad6e4d53b8551a7d30fe8b404d6f1804abf1df69838932/nvidia_cuda_runtime_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:adade8dcbd0edf427b7204d480d6066d33902cab2a4707dcfc48a2d0fd44ab90", size = 954765, upload-time = "2025-03-07T01:40:01.615Z" },
-]
-
-[[package]]
-name = "nvidia-cudnn-cu12"
-version = "9.10.2.21"
+name = "nvidia-cublas"
+version = "13.1.1.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
+    { name = "nvidia-cuda-nvrtc" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/ba/51/e123d997aa098c61d029f76663dedbfb9bc8dcf8c60cbd6adbe42f76d049/nvidia_cudnn_cu12-9.10.2.21-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:949452be657fa16687d0930933f032835951ef0892b37d2d53824d1a84dc97a8", size = 706758467, upload-time = "2025-06-06T21:54:08.597Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/a1/0bd24ee8c8d03adac032fd2909426a00c88f8c57961b1277ded97f91119f/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:b7a210458267ac818974c53038fbec2e969d5c99f305ab15c72522fa9f001dd5", size = 542848918, upload-time = "2026-04-08T18:46:22.985Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/cd/154ca20c38269e05eff77c1464e6c1da89f50a6390b565e9d82e06bc11e1/nvidia_cublas-13.1.1.3-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:37936a16db8fe4ac1f065c2139360608a543a09275cb1a1af612e08cfa065436", size = 423138758, upload-time = "2026-04-08T18:46:58.655Z" },
 ]
 
 [[package]]
-name = "nvidia-cufft-cu12"
-version = "11.3.3.83"
+name = "nvidia-cuda-cupti"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/2a/80353b103fc20ce05ef51e928daed4b6015db4aaa9162ed0997090fe2250/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_aarch64.whl", hash = "sha256:796bd679890ee55fb14a94629b698b6db54bcfd833d391d5e94017dd9d7d3151", size = 10310827, upload-time = "2025-09-04T08:26:42.012Z" },
+    { url = "https://files.pythonhosted.org/packages/33/6d/737d164b4837a9bbd202f5ae3078975f0525a55730fe871d8ed4e3b952b0/nvidia_cuda_cupti-13.0.85-py3-none-manylinux_2_25_x86_64.whl", hash = "sha256:4eb01c08e859bf924d222250d2e8f8b8ff6d3db4721288cf35d14252a4d933c8", size = 10715597, upload-time = "2025-09-04T08:26:51.312Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-nvrtc"
+version = "13.0.88"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c3/68/483a78f5e8f31b08fb1bb671559968c0ca3a065ac7acabfc7cee55214fd6/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:ad9b6d2ead2435f11cbb6868809d2adeeee302e9bb94bcf0539c7a40d80e8575", size = 90215200, upload-time = "2025-09-04T08:28:44.204Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/dc/6bb80850e0b7edd6588d560758f17e0550893a1feaf436807d64d2da040f/nvidia_cuda_nvrtc-13.0.88-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:d27f20a0ca67a4bb34268a5e951033496c5b74870b868bacd046b1b8e0c3267b", size = 43015449, upload-time = "2025-09-04T08:28:20.239Z" },
+]
+
+[[package]]
+name = "nvidia-cuda-runtime"
+version = "13.0.96"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/87/4f/17d7b9b8e285199c58ce28e31b5c5bbaa4d8271af06a89b6405258245de2/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ef9bcbe90493a2b9d810e43d249adb3d02e98dd30200d86607d8d02687c43f55", size = 2261060, upload-time = "2025-10-09T08:55:15.78Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/24/d1558f3b68b1d26e706813b1d10aa1d785e4698c425af8db8edc3dced472/nvidia_cuda_runtime-13.0.96-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:7f82250d7782aa23b6cfe765ecc7db554bd3c2870c43f3d1821f1d18aebf0548", size = 2243632, upload-time = "2025-10-09T08:55:36.117Z" },
+]
+
+[[package]]
+name = "nvidia-cudnn-cu13"
+version = "9.20.0.48"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1f/13/ee4e00f30e676b66ae65b4f08cb5bcbb8392c03f54f2d5413ea99a5d1c80/nvidia_cufft_cu12-11.3.3.83-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:4d2dd21ec0b88cf61b62e6b43564355e5222e4a3fb394cac0db101f2dd0d4f74", size = 193118695, upload-time = "2025-03-07T01:45:27.821Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c5/83384d846b2fd17c44bd499b36c75a45ed4f095fbbb2252294e89cea5c5c/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:e31454ae00094b0c55319d9d15b6fa2fc50a9e1c0f5c8c80fb75258234e731e1", size = 444574296, upload-time = "2026-03-09T19:28:27.751Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/5e/edb9c0ae051602c3ccaffe424256463636d639e27d7f302dde9975ef9e7a/nvidia_cudnn_cu13-9.20.0.48-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0c45dd8eeb50b603f07995b1b300c62ffe6a1980482b82b3bcf94a4ca9d49304", size = 366173588, upload-time = "2026-03-09T19:29:34.474Z" },
 ]
 
 [[package]]
-name = "nvidia-cufile-cu12"
-version = "1.13.1.3"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/bb/fe/1bcba1dfbfb8d01be8d93f07bfc502c93fa23afa6fd5ab3fc7c1df71038a/nvidia_cufile_cu12-1.13.1.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1d069003be650e131b21c932ec3d8969c1715379251f8d23a1860554b1cb24fc", size = 1197834, upload-time = "2025-03-07T01:45:50.723Z" },
-]
-
-[[package]]
-name = "nvidia-curand-cu12"
-version = "10.3.9.90"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/fb/aa/6584b56dc84ebe9cf93226a5cde4d99080c8e90ab40f0c27bda7a0f29aa1/nvidia_curand_cu12-10.3.9.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:b32331d4f4df5d6eefa0554c565b626c7216f87a06a4f56fab27c3b68a830ec9", size = 63619976, upload-time = "2025-03-07T01:46:23.323Z" },
-]
-
-[[package]]
-name = "nvidia-cusolver-cu12"
-version = "11.7.3.90"
+name = "nvidia-cufft"
+version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas-cu12" },
-    { name = "nvidia-cusparse-cu12" },
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/85/48/9a13d2975803e8cf2777d5ed57b87a0b6ca2cc795f9a4f59796a910bfb80/nvidia_cusolver_cu12-11.7.3.90-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:4376c11ad263152bd50ea295c05370360776f8c3427b30991df774f9fb26c450", size = 267506905, upload-time = "2025-03-07T01:47:16.273Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/2f/7b57e29836ea8714f81e9898409196f47d772d5ddedddf1592eadb8ab743/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6c44f692dce8fd5ffd3e3df134b6cdb9c2f72d99cf40b62c32dde45eea9ddad3", size = 214085489, upload-time = "2025-09-04T08:31:56.044Z" },
 ]
 
 [[package]]
-name = "nvidia-cusparse-cu12"
-version = "12.5.8.93"
+name = "nvidia-cufile"
+version = "1.15.1.6"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/3f/70/4f193de89a48b71714e74602ee14d04e4019ad36a5a9f20c425776e72cd6/nvidia_cufile-1.15.1.6-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:08a3ecefae5a01c7f5117351c64f17c7c62efa5fffdbe24fc7d298da19cd0b44", size = 1223672, upload-time = "2025-09-04T08:32:22.779Z" },
+    { url = "https://files.pythonhosted.org/packages/ab/73/cc4a14c9813a8a0d509417cf5f4bdaba76e924d58beb9864f5a7baceefbf/nvidia_cufile-1.15.1.6-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:bdc0deedc61f548bddf7733bdc216456c2fdb101d020e1ab4b88d232d5e2f6d1", size = 1136992, upload-time = "2025-09-04T08:32:14.119Z" },
+]
+
+[[package]]
+name = "nvidia-curand"
+version = "10.4.0.35"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1e/72/7c2ae24fb6b63a32e6ae5d241cc65263ea18d08802aaae087d9f013335a2/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:133df5a7509c3e292aaa2b477afd0194f06ce4ea24d714d616ff36439cee349a", size = 61962106, upload-time = "2025-08-04T10:21:41.128Z" },
+    { url = "https://files.pythonhosted.org/packages/a5/9f/be0a41ca4a4917abf5cb9ae0daff1a6060cc5de950aec0396de9f3b52bc5/nvidia_curand-10.4.0.35-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:1aee33a5da6e1db083fe2b90082def8915f30f3248d5896bcec36a579d941bfc", size = 59544258, upload-time = "2025-08-04T10:22:03.992Z" },
+]
+
+[[package]]
+name = "nvidia-cusolver"
+version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink-cu12" },
+    { name = "nvidia-cublas" },
+    { name = "nvidia-cusparse" },
+    { name = "nvidia-nvjitlink" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/c2/f5/e1854cb2f2bcd4280c44736c93550cc300ff4b8c95ebe370d0aa7d2b473d/nvidia_cusparse_cu12-12.5.8.93-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:1ec05d76bbbd8b61b06a80e1eaf8cf4959c3d4ce8e711b65ebd0443bb0ebb13b", size = 288216466, upload-time = "2025-03-07T01:48:13.779Z" },
-]
-
-[[package]]
-name = "nvidia-cusparselt-cu12"
-version = "0.7.1"
-source = { registry = "https://pypi.org/simple" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/56/79/12978b96bd44274fe38b5dde5cfb660b1d114f70a65ef962bcbbed99b549/nvidia_cusparselt_cu12-0.7.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:f1bb701d6b930d5a7cea44c19ceb973311500847f81b634d802b7b539dc55623", size = 287193691, upload-time = "2025-02-26T00:15:44.104Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/67/cba3777620cdacb99102da4042883709c41c709f4b6323c10781a9c3aa34/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:0a759da5dea5c0ea10fd307de75cdeb59e7ea4fcb8add0924859b944babf1112", size = 200941980, upload-time = "2025-09-04T08:33:22.767Z" },
 ]
 
 [[package]]
-name = "nvidia-nccl-cu12"
-version = "2.27.5"
+name = "nvidia-cusparse"
+version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "nvidia-nvjitlink" },
+]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6e/89/f7a07dc961b60645dbbf42e80f2bc85ade7feb9a491b11a1e973aa00071f/nvidia_nccl_cu12-2.27.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:ad730cf15cb5d25fe849c6e6ca9eb5b76db16a80f13f425ac68d8e2e55624457", size = 322348229, upload-time = "2025-06-26T04:11:28.385Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/18/623c77619c31d62efd55302939756966f3ecc8d724a14dab2b75f1508850/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:2b3c89c88d01ee0e477cb7f82ef60a11a4bcd57b6b87c33f789350b59759360b", size = 145942937, upload-time = "2025-09-04T08:33:58.029Z" },
 ]
 
 [[package]]
-name = "nvidia-nvjitlink-cu12"
-version = "12.8.93"
+name = "nvidia-cusparselt-cu13"
+version = "0.8.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f6/74/86a07f1d0f42998ca31312f998bd3b9a7eff7f52378f4f270c8679c77fb9/nvidia_nvjitlink_cu12-12.8.93-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:81ff63371a7ebd6e6451970684f916be2eab07321b73c9d244dc2b4da7f73b88", size = 39254836, upload-time = "2025-03-07T01:49:55.661Z" },
+    { url = "https://files.pythonhosted.org/packages/46/e1/cdc1797eadf82d3a9a575a19b33fdc871a97edbec42c00b5b5e914f4aff4/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_aarch64.whl", hash = "sha256:4dca476c50bf4780d46cd0bfbd82e2bc10a08e4fef7950917ce8d7578d22a23f", size = 221051344, upload-time = "2025-09-05T18:49:51.289Z" },
+    { url = "https://files.pythonhosted.org/packages/34/7d/2661f2fb3ac4302f3a246f5fc030213ac60c1fe0bce84f9783dbd831dbb7/nvidia_cusparselt_cu13-0.8.1-py3-none-manylinux2014_x86_64.whl", hash = "sha256:786ce87568c303fadb5afcc7102d454cd3040d75f6f8626f5db460d1871f4dd0", size = 170148586, upload-time = "2025-09-05T18:50:50.248Z" },
 ]
 
 [[package]]
-name = "nvidia-nvshmem-cu12"
-version = "3.3.20"
+name = "nvidia-nccl-cu13"
+version = "2.29.7"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3b/6c/99acb2f9eb85c29fc6f3a7ac4dccfd992e22666dd08a642b303311326a97/nvidia_nvshmem_cu12-3.3.20-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:d00f26d3f9b2e3c3065be895e3059d6479ea5c638a3f38c9fec49b1b9dd7c1e5", size = 124657145, upload-time = "2025-08-04T20:25:19.995Z" },
+    { url = "https://files.pythonhosted.org/packages/72/0d/daf50d44177ee0cbc7ff0a0c91eb5ff676c82be42f9a970bc7597f440c3a/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_aarch64.whl", hash = "sha256:674a12383e3c38a1bcccae7d4f3633b37852230b6047883cb2f4c2d1b36d9bf5", size = 206014712, upload-time = "2026-03-03T05:34:20.843Z" },
+    { url = "https://files.pythonhosted.org/packages/67/f4/58e4e91b6919367c7aafb8e36fce9aad1a3047e536bf7e2fd560927d3a4c/nvidia_nccl_cu13-2.29.7-py3-none-manylinux_2_18_x86_64.whl", hash = "sha256:edd81538446786ec3b73972543e53bb43bcaf0bfc8ef76cb679fcc390ffe136d", size = 205976000, upload-time = "2026-03-03T05:36:24.472Z" },
 ]
 
 [[package]]
-name = "nvidia-nvtx-cu12"
-version = "12.8.90"
+name = "nvidia-nvjitlink"
+version = "13.3.33"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a2/eb/86626c1bbc2edb86323022371c39aa48df6fd8b0a1647bc274577f72e90b/nvidia_nvtx_cu12-12.8.90-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:5b17e2001cc0d751a5bc2c6ec6d26ad95913324a4adb86788c944f8ce9ba441f", size = 89954, upload-time = "2025-03-07T01:42:44.131Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ee/580ca6f29dcab0221db8706badca1bbbb084f1975c4d4e83329c3a7e31f0/nvidia_nvjitlink-13.3.33-py3-none-manylinux2010_x86_64.manylinux_2_12_x86_64.whl", hash = "sha256:26a6de7fb4c8fdaa7703d3dad720d6d427ddfea5c48a528fd97c11733ad830e5", size = 40742423, upload-time = "2026-05-26T16:54:51.613Z" },
+    { url = "https://files.pythonhosted.org/packages/69/30/45414e35ff2eee7db3da037e5707037ccf9d2b5218ffbdb055ea4d5aa98a/nvidia_nvjitlink-13.3.33-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:ce48b37dfeb3cb1eae4cf85adacb47d7a6539ea2272870c9a3628ce275c2037e", size = 39168635, upload-time = "2026-05-26T16:54:13.906Z" },
+]
+
+[[package]]
+name = "nvidia-nvshmem-cu13"
+version = "3.4.5"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/0f/05cc9c720236dcd2db9c1ab97fff629e96821be2e63103569da0c9b72f19/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:6dc2a197f38e5d0376ad52cd1a2a3617d3cdc150fd5966f4aee9bcebb1d68fe9", size = 60215947, upload-time = "2025-09-06T00:32:20.022Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/35/a9bf80a609e74e3b000fef598933235c908fcefcef9026042b8e6dfde2a9/nvidia_nvshmem_cu13-3.4.5-py3-none-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:290f0a2ee94c9f3687a02502f3b9299a9f9fe826e6d0287ee18482e78d495b80", size = 60412546, upload-time = "2025-09-06T00:32:41.564Z" },
+]
+
+[[package]]
+name = "nvidia-nvtx"
+version = "13.0.85"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c2/f3/d86c845465a2723ad7e1e5c36dcd75ddb82898b3f53be47ebd429fb2fa5d/nvidia_nvtx-13.0.85-py3-none-manylinux1_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:4936d1d6780fbe68db454f5e72a42ff64d1fd6397df9f363ae786930fd5c1cd4", size = 148047, upload-time = "2025-09-04T08:29:01.761Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/64/3708a90d1ebe202ffdeb7185f878a3c84d15c2b2c31858da2ce0583e2def/nvidia_nvtx-13.0.85-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:cb7780edb6b14107373c835bf8b72e7a178bac7367e23da7acb108f973f157a6", size = 148878, upload-time = "2025-09-04T08:28:53.627Z" },
 ]
 
 [[package]]
@@ -968,59 +1061,46 @@ wheels = [
 
 [[package]]
 name = "torch"
-version = "2.9.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "cuda-bindings", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
+    { name = "cuda-toolkit", extra = ["cublas", "cudart", "cufft", "cufile", "cupti", "curand", "cusolver", "cusparse", "nvjitlink", "nvrtc", "nvtx"], marker = "sys_platform == 'linux'" },
     { name = "filelock" },
     { name = "fsspec" },
     { name = "jinja2" },
     { name = "networkx" },
-    { name = "nvidia-cublas-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-cupti-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-nvrtc-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cuda-runtime-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cudnn-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufft-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cufile-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-curand-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusolver-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparse-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-cusparselt-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nccl-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvjitlink-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvshmem-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
-    { name = "nvidia-nvtx-cu12", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "nvidia-cudnn-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-cusparselt-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nccl-cu13", marker = "sys_platform == 'linux'" },
+    { name = "nvidia-nvshmem-cu13", marker = "sys_platform == 'linux'" },
     { name = "setuptools" },
     { name = "sympy" },
-    { name = "triton", marker = "platform_machine == 'x86_64' and sys_platform == 'linux'" },
+    { name = "triton", marker = "python_full_version < '3.15' and sys_platform == 'linux'" },
     { name = "typing-extensions" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0f/27/07c645c7673e73e53ded71705045d6cb5bae94c4b021b03aa8d03eee90ab/torch-2.9.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:da5f6f4d7f4940a173e5572791af238cb0b9e21b1aab592bd8b26da4c99f1cd6", size = 104126592, upload-time = "2025-11-12T15:20:41.62Z" },
-    { url = "https://files.pythonhosted.org/packages/19/17/e377a460603132b00760511299fceba4102bd95db1a0ee788da21298ccff/torch-2.9.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:27331cd902fb4322252657f3902adf1c4f6acad9dcad81d8df3ae14c7c4f07c4", size = 899742281, upload-time = "2025-11-12T15:22:17.602Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/1a/64f5769025db846a82567fa5b7d21dba4558a7234ee631712ee4771c436c/torch-2.9.1-cp312-cp312-win_amd64.whl", hash = "sha256:81a285002d7b8cfd3fdf1b98aa8df138d41f1a8334fd9ea37511517cedf43083", size = 110940568, upload-time = "2025-11-12T15:21:18.689Z" },
-    { url = "https://files.pythonhosted.org/packages/6e/ab/07739fd776618e5882661d04c43f5b5586323e2f6a2d7d84aac20d8f20bd/torch-2.9.1-cp312-none-macosx_11_0_arm64.whl", hash = "sha256:c0d25d1d8e531b8343bea0ed811d5d528958f1dcbd37e7245bc686273177ad7e", size = 74479191, upload-time = "2025-11-12T15:21:25.816Z" },
-    { url = "https://files.pythonhosted.org/packages/20/60/8fc5e828d050bddfab469b3fe78e5ab9a7e53dda9c3bdc6a43d17ce99e63/torch-2.9.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:c29455d2b910b98738131990394da3e50eea8291dfeb4b12de71ecf1fdeb21cb", size = 104135743, upload-time = "2025-11-12T15:21:34.936Z" },
-    { url = "https://files.pythonhosted.org/packages/f2/b7/6d3f80e6918213babddb2a37b46dbb14c15b14c5f473e347869a51f40e1f/torch-2.9.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:524de44cd13931208ba2c4bde9ec7741fd4ae6bfd06409a604fc32f6520c2bc9", size = 899749493, upload-time = "2025-11-12T15:24:36.356Z" },
-    { url = "https://files.pythonhosted.org/packages/a6/47/c7843d69d6de8938c1cbb1eba426b1d48ddf375f101473d3e31a5fc52b74/torch-2.9.1-cp313-cp313-win_amd64.whl", hash = "sha256:545844cc16b3f91e08ce3b40e9c2d77012dd33a48d505aed34b7740ed627a1b2", size = 110944162, upload-time = "2025-11-12T15:21:53.151Z" },
-    { url = "https://files.pythonhosted.org/packages/28/0e/2a37247957e72c12151b33a01e4df651d9d155dd74d8cfcbfad15a79b44a/torch-2.9.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:5be4bf7496f1e3ffb1dd44b672adb1ac3f081f204c5ca81eba6442f5f634df8e", size = 74830751, upload-time = "2025-11-12T15:21:43.792Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/f7/7a18745edcd7b9ca2381aa03353647bca8aace91683c4975f19ac233809d/torch-2.9.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:30a3e170a84894f3652434b56d59a64a2c11366b0ed5776fab33c2439396bf9a", size = 104142929, upload-time = "2025-11-12T15:21:48.319Z" },
-    { url = "https://files.pythonhosted.org/packages/f4/dd/f1c0d879f2863ef209e18823a988dc7a1bf40470750e3ebe927efdb9407f/torch-2.9.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:8301a7b431e51764629208d0edaa4f9e4c33e6df0f2f90b90e261d623df6a4e2", size = 899748978, upload-time = "2025-11-12T15:23:04.568Z" },
-    { url = "https://files.pythonhosted.org/packages/1f/9f/6986b83a53b4d043e36f3f898b798ab51f7f20fdf1a9b01a2720f445043d/torch-2.9.1-cp313-cp313t-win_amd64.whl", hash = "sha256:2e1c42c0ae92bf803a4b2409fdfed85e30f9027a66887f5e7dcdbc014c7531db", size = 111176995, upload-time = "2025-11-12T15:22:01.618Z" },
-    { url = "https://files.pythonhosted.org/packages/40/60/71c698b466dd01e65d0e9514b5405faae200c52a76901baf6906856f17e4/torch-2.9.1-cp313-none-macosx_11_0_arm64.whl", hash = "sha256:2c14b3da5df416cf9cb5efab83aa3056f5b8cd8620b8fde81b4987ecab730587", size = 74480347, upload-time = "2025-11-12T15:21:57.648Z" },
-    { url = "https://files.pythonhosted.org/packages/48/50/c4b5112546d0d13cc9eaa1c732b823d676a9f49ae8b6f97772f795874a03/torch-2.9.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1edee27a7c9897f4e0b7c14cfc2f3008c571921134522d5b9b5ec4ebbc69041a", size = 74433245, upload-time = "2025-11-12T15:22:39.027Z" },
-    { url = "https://files.pythonhosted.org/packages/81/c9/2628f408f0518b3bae49c95f5af3728b6ab498c8624ab1e03a43dd53d650/torch-2.9.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:19d144d6b3e29921f1fc70503e9f2fc572cde6a5115c0c0de2f7ca8b1483e8b6", size = 104134804, upload-time = "2025-11-12T15:22:35.222Z" },
-    { url = "https://files.pythonhosted.org/packages/28/fc/5bc91d6d831ae41bf6e9e6da6468f25330522e92347c9156eb3f1cb95956/torch-2.9.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:c432d04376f6d9767a9852ea0def7b47a7bbc8e7af3b16ac9cf9ce02b12851c9", size = 899747132, upload-time = "2025-11-12T15:23:36.068Z" },
-    { url = "https://files.pythonhosted.org/packages/63/5d/e8d4e009e52b6b2cf1684bde2a6be157b96fb873732542fb2a9a99e85a83/torch-2.9.1-cp314-cp314-win_amd64.whl", hash = "sha256:d187566a2cdc726fc80138c3cdb260970fab1c27e99f85452721f7759bbd554d", size = 110934845, upload-time = "2025-11-12T15:22:48.367Z" },
-    { url = "https://files.pythonhosted.org/packages/bd/b2/2d15a52516b2ea3f414643b8de68fa4cb220d3877ac8b1028c83dc8ca1c4/torch-2.9.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:cb10896a1f7fedaddbccc2017ce6ca9ecaaf990f0973bdfcf405439750118d2c", size = 74823558, upload-time = "2025-11-12T15:22:43.392Z" },
-    { url = "https://files.pythonhosted.org/packages/86/5c/5b2e5d84f5b9850cd1e71af07524d8cbb74cba19379800f1f9f7c997fc70/torch-2.9.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:0a2bd769944991c74acf0c4ef23603b9c777fdf7637f115605a4b2d8023110c7", size = 104145788, upload-time = "2025-11-12T15:23:52.109Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/8c/3da60787bcf70add986c4ad485993026ac0ca74f2fc21410bc4eb1bb7695/torch-2.9.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:07c8a9660bc9414c39cac530ac83b1fb1b679d7155824144a40a54f4a47bfa73", size = 899735500, upload-time = "2025-11-12T15:24:08.788Z" },
-    { url = "https://files.pythonhosted.org/packages/db/2b/f7818f6ec88758dfd21da46b6cd46af9d1b3433e53ddbb19ad1e0da17f9b/torch-2.9.1-cp314-cp314t-win_amd64.whl", hash = "sha256:c88d3299ddeb2b35dcc31753305612db485ab6f1823e37fb29451c8b2732b87e", size = 111163659, upload-time = "2025-11-12T15:23:20.009Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/3a/ed0f4d4d1dcde03bced7aac9a28e800abcdc0cbd06b6775044c9fbd877b7/torch-2.13.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:2fe228aba290d14b9f31b049be550dbd469c3fd3013d7a19705b30454da97027", size = 111213045, upload-time = "2026-07-08T16:05:22.997Z" },
+    { url = "https://files.pythonhosted.org/packages/df/a9/f6a2a4d763ff1df02e9a64c477029db614295bc9367f4131223791ccc243/torch-2.13.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:572df8be8ffb4599c88cbd6a0726f1f854f4da65d2e3c09f0e2c2283333cd6d4", size = 427210998, upload-time = "2026-07-08T16:04:37.708Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/82/fea946351658e6534db52d2cc12bc53087cbf87f9440c5f180f367c1950b/torch-2.13.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:796633c4cdf0fe2cdced72d8f88f22e73dbcfce83132763162f6d4bff13b820b", size = 526605292, upload-time = "2026-07-08T16:04:22.81Z" },
+    { url = "https://files.pythonhosted.org/packages/21/d6/e8f3c6f7e01f626f77259de9860d2a78bc84c40539e28e79b7e98b0bb659/torch-2.13.0-cp312-cp312-win_amd64.whl", hash = "sha256:024c6cc0c1b085f2f91f20a3dc27b0471d021c31ce84b81be3afdc39f791fd9d", size = 122057313, upload-time = "2026-07-08T16:03:53.43Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/fa/c1c10b7aff4a9a3e8956d4f0a5f468fa6db7abc3208805719076772b4833/torch-2.13.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:33449899ce5496c1b84b4853179d94fd102028ae1407314d9fb956bb79e70d09", size = 111213743, upload-time = "2026-07-08T16:03:28.579Z" },
+    { url = "https://files.pythonhosted.org/packages/11/18/9ecb37b56293a0be8d80f810bf672a72fe7e02f8b475d5ef1b9bf8a0d748/torch-2.13.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:1e09d6a722504957c694faceca843acde562786df1144ebcc5a74075ec7f6005", size = 427213008, upload-time = "2026-07-08T16:03:44.106Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/5a/7c50ba1b7b713d71d34669c6d13dab0a11531a3eceb0307a5162dbfec0f7/torch-2.13.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:a3a9a21312872af8a26950b2c15680335a386a1f56ed03e780653d78b9607e9e", size = 526602329, upload-time = "2026-07-08T16:03:12.649Z" },
+    { url = "https://files.pythonhosted.org/packages/91/3d/e7adcc6aaf36961cd18f56cf8ad0f3058c3a5c84ccf391762176c94581b8/torch-2.13.0-cp313-cp313-win_amd64.whl", hash = "sha256:49b58f1e2c52440abb6f17c28f0335fe6c6d01ad1a7f55b0183b81e4b34d64e6", size = 122057920, upload-time = "2026-07-08T16:03:01.808Z" },
+    { url = "https://files.pythonhosted.org/packages/36/76/6dcc7f0c07052102dd36f83cbc5800842a909c8c3fbf1a7f8a5844954de9/torch-2.13.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:d849b390e07d8d333ce8ecaf91b273c656c598379a19c9acf1318a883f6b391c", size = 111227066, upload-time = "2026-07-08T16:03:33.6Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/09/2c10e8cd0e00fa5d23c052df6ce467eaa7182399f5e0f824f1e4ff42ccae/torch-2.13.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:a3893dc2da0a972a8ca5d698c85a9f967559ac5f8ee1797b77408aa8734d073c", size = 427226309, upload-time = "2026-07-08T16:02:53.127Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c6/22c2102bbef14ca6a6cb4c20e42f088e49c5f812be4e160ae57502e325f9/torch-2.13.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:49f1ea385c754e54919408a9bb3b5a72b0b755bbe2c916c1d6f70afbec4908a2", size = 526614507, upload-time = "2026-07-08T16:02:16.441Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/0c/7d1deb6bce5bc3e6042caf39100ac768eba3b9a098e1dddd16f75bd6489b/torch-2.13.0-cp314-cp314-win_amd64.whl", hash = "sha256:4f8573e3ce9ebcd53fe922f01077a6085ccdfbe5f12fd215883a9d87d7a744fd", size = 122051871, upload-time = "2026-07-08T16:03:23.521Z" },
+    { url = "https://files.pythonhosted.org/packages/f4/ce/aa8b7f9949d32e0f2f624f342bc3b48112c1b8a130288465938bc83bcbf9/torch-2.13.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:c28def70706c2f9ecc752574766e8ae4da9b810ab6676b611166761a78a9f1e1", size = 111537025, upload-time = "2026-07-08T16:02:44.28Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d1/491e3a0389430946145888b0203f2b6a759ce2a61481b96a85c2da4f2ced/torch-2.13.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:31061ff56ed8fbf26c749806905aeb749ebeb819810fd5d52508aa5afd90dddc", size = 427219769, upload-time = "2026-07-08T16:02:31.18Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/1d/38006e045bf0a1fc28ef01e757c554e59e59a8770c284bc4f47b14e60441/torch-2.13.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:cc26eead4cf51d0b544e31e364dcf000846549c273bd148936fe9d24d29acb92", size = 526571320, upload-time = "2026-07-08T16:01:59.348Z" },
+    { url = "https://files.pythonhosted.org/packages/56/94/655c91992a882bd5071aa0b5d22a07dbb130d801e872be97c0b627a7c693/torch-2.13.0-cp314-cp314t-win_amd64.whl", hash = "sha256:a7de8a313090dc5c7d7ba4bfe5c3be222528f9a4dba1acc83bddb1157360c4b8", size = 122306773, upload-time = "2026-07-08T16:02:39.832Z" },
 ]
 
 [[package]]
 name = "torchvision"
-version = "0.24.1"
+version = "0.28.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "numpy" },
@@ -1028,38 +1108,37 @@ dependencies = [
     { name = "torch" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f0/af/18e2c6b9538a045f60718a0c5a058908ccb24f88fde8e6f0fc12d5ff7bd3/torchvision-0.24.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e48bf6a8ec95872eb45763f06499f87bd2fb246b9b96cb00aae260fda2f96193", size = 1891433, upload-time = "2025-11-12T15:25:03.232Z" },
-    { url = "https://files.pythonhosted.org/packages/9d/43/600e5cfb0643d10d633124f5982d7abc2170dfd7ce985584ff16edab3e76/torchvision-0.24.1-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:7fb7590c737ebe3e1c077ad60c0e5e2e56bb26e7bccc3b9d04dbfc34fd09f050", size = 2386737, upload-time = "2025-11-12T15:25:08.288Z" },
-    { url = "https://files.pythonhosted.org/packages/93/b1/db2941526ecddd84884132e2742a55c9311296a6a38627f9e2627f5ac889/torchvision-0.24.1-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:66a98471fc18cad9064123106d810a75f57f0838eee20edc56233fd8484b0cc7", size = 8049868, upload-time = "2025-11-12T15:25:13.058Z" },
-    { url = "https://files.pythonhosted.org/packages/69/98/16e583f59f86cd59949f59d52bfa8fc286f86341a229a9d15cbe7a694f0c/torchvision-0.24.1-cp312-cp312-win_amd64.whl", hash = "sha256:4aa6cb806eb8541e92c9b313e96192c6b826e9eb0042720e2fa250d021079952", size = 4302006, upload-time = "2025-11-12T15:25:16.184Z" },
-    { url = "https://files.pythonhosted.org/packages/e4/97/ab40550f482577f2788304c27220e8ba02c63313bd74cf2f8920526aac20/torchvision-0.24.1-cp313-cp313-macosx_12_0_arm64.whl", hash = "sha256:8a6696db7fb71eadb2c6a48602106e136c785642e598eb1533e0b27744f2cce6", size = 1891435, upload-time = "2025-11-12T15:25:28.642Z" },
-    { url = "https://files.pythonhosted.org/packages/30/65/ac0a3f9be6abdbe4e1d82c915d7e20de97e7fd0e9a277970508b015309f3/torchvision-0.24.1-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:db2125c46f9cb25dc740be831ce3ce99303cfe60439249a41b04fd9f373be671", size = 2338718, upload-time = "2025-11-12T15:25:26.19Z" },
-    { url = "https://files.pythonhosted.org/packages/10/b5/5bba24ff9d325181508501ed7f0c3de8ed3dd2edca0784d48b144b6c5252/torchvision-0.24.1-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:f035f0cacd1f44a8ff6cb7ca3627d84c54d685055961d73a1a9fb9827a5414c8", size = 8049661, upload-time = "2025-11-12T15:25:22.558Z" },
-    { url = "https://files.pythonhosted.org/packages/5c/ec/54a96ae9ab6a0dd66d4bba27771f892e36478a9c3489fa56e51c70abcc4d/torchvision-0.24.1-cp313-cp313-win_amd64.whl", hash = "sha256:16274823b93048e0a29d83415166a2e9e0bf4e1b432668357b657612a4802864", size = 4319808, upload-time = "2025-11-12T15:25:17.318Z" },
-    { url = "https://files.pythonhosted.org/packages/d5/f3/a90a389a7e547f3eb8821b13f96ea7c0563cdefbbbb60a10e08dda9720ff/torchvision-0.24.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e3f96208b4bef54cd60e415545f5200346a65024e04f29a26cd0006dbf9e8e66", size = 2005342, upload-time = "2025-11-12T15:25:11.871Z" },
-    { url = "https://files.pythonhosted.org/packages/a9/fe/ff27d2ed1b524078164bea1062f23d2618a5fc3208e247d6153c18c91a76/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:f231f6a4f2aa6522713326d0d2563538fa72d613741ae364f9913027fa52ea35", size = 2341708, upload-time = "2025-11-12T15:25:25.08Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/b9/d6c903495cbdfd2533b3ef6f7b5643ff589ea062f8feb5c206ee79b9d9e5/torchvision-0.24.1-cp313-cp313t-manylinux_2_28_x86_64.whl", hash = "sha256:1540a9e7f8cf55fe17554482f5a125a7e426347b71de07327d5de6bfd8d17caa", size = 8177239, upload-time = "2025-11-12T15:25:18.554Z" },
-    { url = "https://files.pythonhosted.org/packages/4f/2b/ba02e4261369c3798310483028495cf507e6cb3f394f42e4796981ecf3a7/torchvision-0.24.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d83e16d70ea85d2f196d678bfb702c36be7a655b003abed84e465988b6128938", size = 4251604, upload-time = "2025-11-12T15:25:34.069Z" },
-    { url = "https://files.pythonhosted.org/packages/42/84/577b2cef8f32094add5f52887867da4c2a3e6b4261538447e9b48eb25812/torchvision-0.24.1-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:cccf4b4fec7fdfcd3431b9ea75d1588c0a8596d0333245dafebee0462abe3388", size = 2005319, upload-time = "2025-11-12T15:25:23.827Z" },
-    { url = "https://files.pythonhosted.org/packages/5f/34/ecb786bffe0159a3b49941a61caaae089853132f3cd1e8f555e3621f7e6f/torchvision-0.24.1-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:1b495edd3a8f9911292424117544f0b4ab780452e998649425d1f4b2bed6695f", size = 2338844, upload-time = "2025-11-12T15:25:32.625Z" },
-    { url = "https://files.pythonhosted.org/packages/51/99/a84623786a6969504c87f2dc3892200f586ee13503f519d282faab0bb4f0/torchvision-0.24.1-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:ab211e1807dc3e53acf8f6638df9a7444c80c0ad050466e8d652b3e83776987b", size = 8175144, upload-time = "2025-11-12T15:25:31.355Z" },
-    { url = "https://files.pythonhosted.org/packages/6d/ba/8fae3525b233e109317ce6a9c1de922ab2881737b029a7e88021f81e068f/torchvision-0.24.1-cp314-cp314-win_amd64.whl", hash = "sha256:18f9cb60e64b37b551cd605a3d62c15730c086362b40682d23e24b616a697d41", size = 4234459, upload-time = "2025-11-12T15:25:19.859Z" },
-    { url = "https://files.pythonhosted.org/packages/50/33/481602c1c72d0485d4b3a6b48c9534b71c2957c9d83bf860eb837bf5a620/torchvision-0.24.1-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:ec9d7379c519428395e4ffda4dbb99ec56be64b0a75b95989e00f9ec7ae0b2d7", size = 2005336, upload-time = "2025-11-12T15:25:27.225Z" },
-    { url = "https://files.pythonhosted.org/packages/d0/7f/372de60bf3dd8f5593bd0d03f4aecf0d1fd58f5bc6943618d9d913f5e6d5/torchvision-0.24.1-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:af9201184c2712d808bd4eb656899011afdfce1e83721c7cb08000034df353fe", size = 2341704, upload-time = "2025-11-12T15:25:29.857Z" },
-    { url = "https://files.pythonhosted.org/packages/36/9b/0f3b9ff3d0225ee2324ec663de0e7fb3eb855615ca958ac1875f22f1f8e5/torchvision-0.24.1-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:9ef95d819fd6df81bc7cc97b8f21a15d2c0d3ac5dbfaab5cbc2d2ce57114b19e", size = 8177422, upload-time = "2025-11-12T15:25:37.357Z" },
-    { url = "https://files.pythonhosted.org/packages/d6/ab/e2bcc7c2f13d882a58f8b30ff86f794210b075736587ea50f8c545834f8a/torchvision-0.24.1-cp314-cp314t-win_amd64.whl", hash = "sha256:480b271d6edff83ac2e8d69bbb4cf2073f93366516a50d48f140ccfceedb002e", size = 4335190, upload-time = "2025-11-12T15:25:35.745Z" },
+    { url = "https://files.pythonhosted.org/packages/15/49/c1cab1ecbb3ff1a380a3f99283db1dee61b8afe354f6352c643b65937130/torchvision-0.28.0-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:e9f54c30cd52e3ef7fd034cc69b7bb7e0964e1c8f8743e018ab92e95b40f9eee", size = 1856020, upload-time = "2026-07-08T16:07:52.182Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/4c/95233776e2def960e5abb7a07931230a545f43717a56a1e1140162033598/torchvision-0.28.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:5cf78ebc401ce64ae19b8c55de866bb836797d559a4de9c25ccbe74cfa642d3a", size = 7842127, upload-time = "2026-07-08T16:07:53.446Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e4/e9b2495d0d57b9f60d63c57d0a910410a81b4b073bf70917bef815291119/torchvision-0.28.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:028a3d481b37d785605620d7cdad897064c5a55bae2aa1f2658766333e291940", size = 7675040, upload-time = "2026-07-08T16:07:58.017Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/9c/55ed9cb6dfe3ee9c837df5cd0e758372e5829aa38b8dd71343aa632cc4e2/torchvision-0.28.0-cp312-cp312-win_amd64.whl", hash = "sha256:87dc16b2df427c1318ad335f1e2be2b3b15b2cf20f7934c83b0505a48425ee5d", size = 4085785, upload-time = "2026-07-08T16:07:50.928Z" },
+    { url = "https://files.pythonhosted.org/packages/20/55/08a726c14c67b37c8aca04b077766909f1c7ed23f76116884fe63b9bd033/torchvision-0.28.0-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:d483b4aa3f5237569053f749cd1a2b5bb548ca456e40461a5dd087f21149d123", size = 1856021, upload-time = "2026-07-08T16:07:45.386Z" },
+    { url = "https://files.pythonhosted.org/packages/db/8f/40beacd53809194f5259e590d1afaeaa8ad57da15f77c646e6560bcc4616/torchvision-0.28.0-cp313-cp313-manylinux_2_28_aarch64.whl", hash = "sha256:bb6dd6918460ed89cc7644adcc2402991474d6933cf1ce92b390641cb233fddf", size = 7797014, upload-time = "2026-07-08T16:07:43.04Z" },
+    { url = "https://files.pythonhosted.org/packages/32/db/062cdb5a84380a60439775311fff34d89229760d2a50680393dc18699956/torchvision-0.28.0-cp313-cp313-manylinux_2_28_x86_64.whl", hash = "sha256:ad7b3a439265cc3739a4ab5b4c998c0e38ea99c0ee7ca4dea35c5d0b099ec237", size = 7674669, upload-time = "2026-07-08T16:07:38.91Z" },
+    { url = "https://files.pythonhosted.org/packages/f3/a6/b4081e2d04e1541abf82785ac9e5178a494c19330391f551356c8c18b7b3/torchvision-0.28.0-cp313-cp313-win_amd64.whl", hash = "sha256:7e9dd6f60d6e15f8dc27d4f877fdb6002fc70d70272412135f1c2ff9cfa08d3b", size = 4157380, upload-time = "2026-07-08T16:07:40.22Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/b9/da40eca5bbe9596c12ae9899ab7abaf887f5e20f29d08b924b4633714821/torchvision-0.28.0-cp314-cp314-macosx_14_0_arm64.whl", hash = "sha256:3bd9dba55224a9db4a2d77f6feaa5651770d8c8e86d3d0ddb0fa6bec54c8712b", size = 1856014, upload-time = "2026-07-08T16:07:44.282Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d6/313aafd3df4eaf5f330211bd4e75b7598bddbfee4f55580d3b58536e1b20/torchvision-0.28.0-cp314-cp314-manylinux_2_28_aarch64.whl", hash = "sha256:89f90e29b0966352811b12589f3a3c61943bf2bb9487b9d7bbec10efb1096bb5", size = 7796873, upload-time = "2026-07-08T16:07:30.907Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/41/31f8e959ab8f942600b6357f8999c21d779d5fd3304b0fd204ff4b518239/torchvision-0.28.0-cp314-cp314-manylinux_2_28_x86_64.whl", hash = "sha256:36beb0782976906069ca03d4c9aacaf4b6b838b06ed6c20960ea9c51cce7acdd", size = 7674634, upload-time = "2026-07-08T16:07:29.657Z" },
+    { url = "https://files.pythonhosted.org/packages/15/15/4c5115253fd470672cdac0a1cf139e06b4f3e29d041238a2b255937f63be/torchvision-0.28.0-cp314-cp314-win_amd64.whl", hash = "sha256:3557cc7b539f46dabcda2b6f2b14017ccbeef024de466d4fc5835fc3f287f769", size = 4184005, upload-time = "2026-07-08T16:07:35.805Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/80/822a6163da716f8a78141cf6678d74e26a572285d4ea866ef8aa657bb307/torchvision-0.28.0-cp314-cp314t-macosx_14_0_arm64.whl", hash = "sha256:09ce8f56e81f19b9c378ae7bb109f83f6659fd8bc3cd14241a48e4af46e9ed49", size = 1856011, upload-time = "2026-07-08T16:07:33.404Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/d1/cd3f9463b39a790ec8c0c2f6e6c8061edb1562114d04fcdfa786ed889345/torchvision-0.28.0-cp314-cp314t-manylinux_2_28_aarch64.whl", hash = "sha256:62c7d110f86a039245b587e4fae60278c649f3bd42ff79cfbc1178eca4e72542", size = 7796742, upload-time = "2026-07-08T16:07:28.339Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/82/3e0a7ad18e99831e2d7f4713d3be717b7159ff5a920862dd5c23c454aa71/torchvision-0.28.0-cp314-cp314t-manylinux_2_28_x86_64.whl", hash = "sha256:904cf89af220f8c6b2ed0296bb5065b474ce43b77558e48b2bf9de8b0ba17204", size = 7675526, upload-time = "2026-07-08T16:07:34.572Z" },
+    { url = "https://files.pythonhosted.org/packages/18/d4/23aea03b28297bc66a4461f55ae4296368a9d85fa9a454bafcb2a5348bd7/torchvision-0.28.0-cp314-cp314t-win_amd64.whl", hash = "sha256:46f581979c010ad6da6bd85ee602aa707e1ff44312670223b7a0ee517ad06d47", size = 4291452, upload-time = "2026-07-08T16:07:32.236Z" },
 ]
 
 [[package]]
 name = "triton"
-version = "3.5.1"
+version = "3.7.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f2/50/9a8358d3ef58162c0a415d173cfb45b67de60176e1024f71fbc4d24c0b6d/triton-3.5.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d2c6b915a03888ab931a9fd3e55ba36785e1fe70cbea0b40c6ef93b20fc85232", size = 170470207, upload-time = "2025-11-11T17:41:00.253Z" },
-    { url = "https://files.pythonhosted.org/packages/27/46/8c3bbb5b0a19313f50edcaa363b599e5a1a5ac9683ead82b9b80fe497c8d/triton-3.5.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:f3f4346b6ebbd4fad18773f5ba839114f4826037c9f2f34e0148894cd5dd3dba", size = 170470410, upload-time = "2025-11-11T17:41:06.319Z" },
-    { url = "https://files.pythonhosted.org/packages/37/92/e97fcc6b2c27cdb87ce5ee063d77f8f26f19f06916aa680464c8104ef0f6/triton-3.5.1-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:0b4d2c70127fca6a23e247f9348b8adde979d2e7a20391bfbabaac6aebc7e6a8", size = 170579924, upload-time = "2025-11-11T17:41:12.455Z" },
-    { url = "https://files.pythonhosted.org/packages/a4/e6/c595c35e5c50c4bc56a7bac96493dad321e9e29b953b526bbbe20f9911d0/triton-3.5.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d0637b1efb1db599a8e9dc960d53ab6e4637db7d4ab6630a0974705d77b14b60", size = 170480488, upload-time = "2025-11-11T17:41:18.222Z" },
-    { url = "https://files.pythonhosted.org/packages/16/b5/b0d3d8b901b6a04ca38df5e24c27e53afb15b93624d7fd7d658c7cd9352a/triton-3.5.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:bac7f7d959ad0f48c0e97d6643a1cc0fd5786fe61cb1f83b537c6b2d54776478", size = 170582192, upload-time = "2025-11-11T17:41:23.963Z" },
+    { url = "https://files.pythonhosted.org/packages/94/fa/f856e24deb462d5f18bd4b5a746957862ab9b6ee5834bda60605ec348366/triton-3.7.1-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:9497f2e696ee368862a181a90b2dcc03ca978cc4f602abd67c7d81022a6988e1", size = 184692359, upload-time = "2026-06-17T20:03:48.288Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/6f/fb96d15db6f36d6eae4cafb998c2e0353bf59d7c4ea1662d7497f269134a/triton-3.7.1-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:7e40869937a68206ec70d7f25bb7ec6433cb083f9135e1f36dbd318dc449a728", size = 197719725, upload-time = "2026-06-17T19:53:20.419Z" },
+    { url = "https://files.pythonhosted.org/packages/00/42/c5089d4d9327fcd1e862c599cc2927f39418f84dd11a84cb2ccff9d4787a/triton-3.7.1-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:cdbfc09d9ec58bc5e68321525653220de7515c199e7a8097a97c85e62b52cd0a", size = 184694629, upload-time = "2026-06-17T20:03:53.444Z" },
+    { url = "https://files.pythonhosted.org/packages/07/42/2c3ac59253ae8892b6f307875263dd23dc875cdf732d3aea40d6d41fb7cb/triton-3.7.1-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:58c0e131da05134a2a4788ccbcc0c1105cf0f54c8e98f19e34cd465396dc15eb", size = 197729241, upload-time = "2026-06-17T19:53:27.801Z" },
+    { url = "https://files.pythonhosted.org/packages/40/71/e01aa7ad573883ed9456f130226babdec70b005e098c4d6226a6238e761b/triton-3.7.1-cp314-cp314-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fe4ea396a06171f1f1f58cbd39c70b09294398f7dd7c620939bab54ad6f934fa", size = 184705764, upload-time = "2026-06-17T20:03:59.064Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/09/5683146fda6a2b569deb78ccfd8fbfea8bfe55f726b081c0a6bb18dd6f28/triton-3.7.1-cp314-cp314-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:2020153b08280415ec0da6607834e79166442147e78e144df06b508c75b186d2", size = 197729537, upload-time = "2026-06-17T19:53:35.516Z" },
+    { url = "https://files.pythonhosted.org/packages/e9/f8/448220c3092019f9fdfab39ec47985968181d67da34b44f6a7f6280a5cbb/triton-3.7.1-cp314-cp314t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:c58e4c61f0c73b5dba3b5d19b4a7093c32f90dc18b2a7f121a7c16ccd31107b7", size = 184814760, upload-time = "2026-06-17T20:04:04.984Z" },
+    { url = "https://files.pythonhosted.org/packages/f0/ac/229b7d4589d2e5937310e72c6d46e89599d16a4a12b479ffa1499fee8eb8/triton-3.7.1-cp314-cp314t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:10ba85fa2cca4a2fbdeb36bf1cb082f2c252bda55bf9fccd74f65ec5bc647e68", size = 197824404, upload-time = "2026-06-17T19:53:42.772Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Description

Upgrades PyTorch **2.9.1 → 2.13.0** and torchvision **0.24.1 → 0.28.0**, makes `pyproject.toml`'s `[ml]` extra the only pin, and — the part that turned out to matter most — makes the upgrade actually *reach* users who already have PyTorch.

### Why this is a security fix, not a routine bump

Per PyPI's advisory data, **torch 2.9.1 has 4 known vulnerabilities; 2.13.0 has 0.** The one in this app's threat model:

> **CVE-2026-24747 / GHSA-63cw-57p8-fm3p** (fixed in 2.10.0) — "a vulnerability in PyTorch's `weights_only` unpickler allows an attacker to craft a malicious checkpoint file (`.pth`) that, when loaded with `torch.load(..., weights_only=True)`, can corrupt memory and potentially lead to arbitrary code execution."

`local_inference._load` calls exactly that, and the comment above it states the flag is what stops "a malicious .pth (community download or imported ZIP)" executing code. On torch ≤ 2.9.x that protection does not hold, and the Community tab and ZIP import are the delivery path.

Also worth noting: **CVE-2025-3000 (`torch.jit.script`, memory corruption) is fixed only in 2.13.0** — 2.10 through 2.12 don't clear it. Going to the latest is what clears all four. torchvision has no advisories in either version.

### The pin bump alone would not have mitigated it

`torch_gate.ensure_torch` checked **presence only** (`find_spec`), and `bootstrap.py` syncs `--inexact` specifically so torch survives launches. An install on 2.9.1 stays on 2.9.1 after taking this update — and that is precisely the population that has had time to accumulate community models. So this adds a version floor:

- `local_inference.MIN_TORCH_VERSION = "2.10.0"`, documented with the advisory, plus `installed_version()` (distribution metadata — no torch import, so it stays safe on the UI thread) and `meets_min_version()`.
- `ensure_torch` now takes the model the action will load and picks a policy from `models.is_foreign_model`: a **community download or ZIP import blocks** until upgraded; the user's **own model gets an offer** that proceeds on decline, remembered for the session. Omitting the model blocks — unknown provenance is treated as foreign, and declining for an own model never opens the foreign path.
- `meets_min_version()` **fails open** on unreadable metadata: a developer's source build is likelier there than an exploit, and hard-blocking it would trade a real breakage for a speculative one.
- The floor is deliberately **not** derived from the `[ml]` pin. The pin is "what a fresh install gets" and moves on every routine bump; the floor is "below here the safety property is gone", moves only when an advisory says so, and records which one.

### The CUDA index had to move, and split per OS

cu128 tops out at torch 2.11, so the pin bump alone would have 404'd at install time (#67's trap). PyTorch's v2.13.0 build matrix also shows **no Windows wheels for CUDA 12.9** (`# CUDA 12.9 is only built for Linux`), so `_CUDA_INDEX_BY_OS` picks the lowest-driver-bar index that still covers every supported card:

| OS | Index | Cards | Driver floor |
|---|---|---|---|
| Linux | cu129 | sm_75 (Turing) – sm_120 (Blackwell) | R525+ (CUDA 12 minor-version compat) |
| Windows | cu130 | sm_75 – sm_120 | R580+ |

Windows has no CUDA-12.x option that keeps the RTX 50-series (cu126 stops at sm_90), so the higher floor there is the cost of not dropping those cards. **This is the trade-off most worth a second opinion.**

### Validation

- **CI exercised the wheel indexes for real.** `test_torch_wheel_index.py` ran (not skipped) on the Windows runner and confirmed cu129 and cu130 both carry torch 2.13.0 / torchvision 0.28.0 with the right platform tags.
- **Verified end to end on real hardware** (RTX 5060 Ti, Windows): installs as `2.13.0+cu130`, `cuda_available=True`, `arch_list=['sm_75','sm_80','sm_86','sm_90','sm_100','sm_120']`, card reports `sm_120` with **no PTX-JIT-fallback warning** — i.e. the cu130 choice is what keeps RTX 50-series on real kernels. Two models load and classify on CUDA with per-model `image_size` resolving correctly.
- **Not exercised in the UI:** the block/offer gate paths (unit-tested only — the test machine went straight to 2.13.0), and the raised Windows driver floor (the test machine is on R580+).

### Also in here

- `ml_pin_targets()` catches `UnicodeDecodeError` (a `ValueError` sibling of `TOMLDecodeError`, not a subclass): a `pyproject.toml` re-saved in a legacy encoding otherwise escaped the handler and wedged the install dialog with every button disabled. Regression-tested with a cp1252 em dash.
- `gpu_detect.MIN_CUDA_COMPUTE`'s comment claimed the wheels start at sm_80. They don't — cu129/cu130 bake in sm_75. The 8.0 floor stays, now honestly described as a hardware-validation floor.
- The startup benchmark hint predicted "30–80 ms/iter on sm_120"; that was true of the 2.9.1 pin's older cuDNN and is now wrong by more than an order of magnitude (2.8 ms measured on cuDNN 9.20). Re-anchored to a measured number quoted with its hardware and torch version, so a healthy GPU is no longer reported as suspect.
- README/CONTRIBUTING record that `uv sync --extra ml` and the in-app dialog ship **different CUDA builds** (PyPI's Linux build is CUDA 13 / R580+; its Windows build is CPU-only).
- `uv.lock` regenerated — the diff is purely the torch closure.

### Cross-checked against the WinForms build

`SJSeth.CaseSorter`'s `setup_torch.py` (the post-fix version) pins **one** modern torch for everyone and routes weak/old GPUs to the CPU *wheel of that same version* — it never installs an older torch. This PR has the same shape, so it does not reopen the `torch.amp.GradScaler` AttributeError (needs ≥ 2.3.0) or the numpy 1.x/2.x ABI mismatch that build hit. Usefully, the two constraints collapse: the security floor (≥ 2.10.0) is stricter than the API floor (≥ 2.3.0), so anything honouring the CVE cannot regress into that traceback.

Refs #67 — delivers the single source of truth, the version/index coupling, and the resolution test. Not closing it: the index is still a per-OS constant rather than derived from the detected driver, and there's no user-facing version override yet (when that lands, `MIN_TORCH_VERSION` is what must bound it).
Refs #77 — partially delivers item 4 (the gate grows from presence to a floor, with an upgrade route for users who already have torch). Checkpoint provenance stamping, the manifest carry, and translating the load failure remain open.

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [ ] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#contributions--licensing-dco) — **left for you.** Commits are authored as `Claude <noreply@anthropic.com>` and the DCO app did not skip them, so this check is red. `git rebase --signoff origin/main && git push --force-with-lease` clears it; that attestation is yours to make, not mine.
- [x] Tests pass locally — `xvfb-run -a uv run --no-sync pytest`: 825 passed, 24 skipped; `ruff` and `ty` clean
- [x] I have updated `CLAUDE.md` if this changes architecture, a module boundary, or a subsystem described there
- [ ] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01KQEiiV9jYVdcSShGiFtAP4