### PR TITLE
chore(renovate): stop pinning requires-python and workflow tool versions

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -51,6 +51,36 @@
   packageRules: [
 
     // =====================================================
+    // Things rangeStrategy: "pin" must not touch
+    //
+    // The global "pin" above is a backstop for *dependencies*. Two places it
+    // reaches are not dependency pins and must keep their ranges:
+    //
+    // - requires-python is a support floor (>=3.12), not a version choice.
+    //   Pinning it to one exact interpreter breaks the 3.12/3.13 CI legs,
+    //   contradicts the installer's $PythonMin, and time-bombs every end-user
+    //   install: .python-version says "3.14", so uv provisions the *latest*
+    //   3.14.x -- the day a new patch ships, an exact ==3.14.x pin fails
+    //   every launch at `uv sync`. (.python-version itself is the deliberate
+    //   place where the app's actual interpreter is chosen.)
+    //
+    // - Workflow python-version / node-version inputs stay at the same
+    //   granularity as .python-version on purpose: they should track a minor
+    //   line, picking up patch releases for free, not drift stale on an
+    //   exact patch nobody bumps.
+    // =====================================================
+
+    {
+      matchDepTypes: ["requires-python"],
+      enabled: false,
+    },
+    {
+      matchManagers: ["github-actions"],
+      matchDepTypes: ["uses-with"],
+      rangeStrategy: "preserve",
+    },
+
+    // =====================================================
     // Version classification labels
     //
     // minimumReleaseAge is a supply-chain-attack mitigation, not just noise


### PR DESCRIPTION
## Description

The global `rangeStrategy: "pin"` backstop in `.github/renovate.json5` was reaching two places that are not dependency pins, producing the immortal "pin dependencies" PR (#88, recreated as #89):

- **`requires-python`** is a support floor (`>=3.12`), not a version choice. Pinning it to `==3.14.7` breaks the 3.12/3.13 CI matrix legs, contradicts the installer's `$PythonMin`, and time-bombs every end-user install: `.python-version` says `3.14`, so uv provisions the *latest* 3.14.x — the day a new patch ships, the exact pin fails every launch at `uv sync`.
- **Workflow `python-version` / `node-version` inputs** deliberately track a minor line (matching `.python-version`'s granularity) so they pick up patch releases for free instead of drifting stale on an exact patch.

This adds two `packageRules` entries: one disabling Renovate for `requires-python`, one preserving ranges for the `github-actions` manager's `uses-with` deps. Config validated with `renovate-config-validator` (renovate@44, same as `validate-renovate.yml`).

Once this lands on `main`, Renovate's next run should close #89 on its own — it should not be closed by hand before then, since closing an immortal PR just recreates it.

Fixes #89

## Checklist

- [x] I have read [CONTRIBUTING.md](../CONTRIBUTING.md)
- [x] Every commit is signed off (`git commit -s`) per the [DCO](../CONTRIBUTING.md#contributions--licensing-dco)
- [x] Tests pass locally (config-only change; validated with `renovate-config-validator`)
- [x] I have updated `CLAUDE.md` if this changes architecture, a module boundary, or a subsystem described there (not needed — no architecture change)
- [x] I have read the [Code of Conduct](../CODE_OF_CONDUCT.md)

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ThCuyspEqraWaBUcZQoTjP